### PR TITLE
Integrate with Travis in order to build with node 7 and 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "6"
+  - "7"
+cache:
+  directories:
+    - node_modules

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "vscode-base-languageclient": "^0.0.1-alpha.2"
   },
   "scripts": {
-    "prepublish": "npm run clean && npm run compile",
+    "prepare": "npm run clean && npm run compile",
     "compile": "tsc",
     "watch": "tsc -w",
     "clean": "rimraf lib"


### PR DESCRIPTION
There should be a CI system for building this package that tests it with Node.js 8 and NPM 5 since it seems so fail (see issue https://github.com/TypeFox/monaco-languageclient/issues/8).

I like Travis so I created a .travis.yml (after merging this it would need to be enabled at https://travis-ci.org. This could also be used for an automated release process as a next step.
You can see how it looks like here: https://travis-ci.org/franzbecker/monaco-languageclient/