### PR TITLE
Convert Diagnostic's code to a string for VSCode's IMarkerData

### DIFF
--- a/src/converter.ts
+++ b/src/converter.ts
@@ -515,7 +515,7 @@ export class ProtocolToMonacoConverter {
 
     asMarker(diagnostic: Diagnostic): monaco.editor.IMarkerData {
         return {
-            code: diagnostic.code as string,
+            code: typeof diagnostic.code === "number" ? diagnostic.code.toString() : diagnostic.code as string,
             severity: this.asSeverity(diagnostic.severity),
             message: diagnostic.message,
             source: diagnostic.source,

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -515,7 +515,7 @@ export class ProtocolToMonacoConverter {
 
     asMarker(diagnostic: Diagnostic): monaco.editor.IMarkerData {
         return {
-            code: typeof diagnostic.code === "number" ? diagnostic.code.toString() : diagnostic.code as string,
+            code: typeof diagnostic.code === "number" ? diagnostic.code.toString() : diagnostic.code,
             severity: this.asSeverity(diagnostic.severity),
             message: diagnostic.message,
             source: diagnostic.source,


### PR DESCRIPTION
In #11, I realized that if my Diagnostic's `code` property was set to the `0` number, Monaco would refuse to render my code actions. This is because VSCode's IMarkerData expects its `code` property to be a `string`. [`as string`](https://github.com/TypeFox/monaco-languageclient/blob/8fad2e2bc7e34e687cd010680cef4fc99cead3a2/src/converter.ts#L518) is used in converter.ts to cast the Diagnostic's `code` to a `string` but this doesn't actually do anything in the transpiled JavaScript.
```JavaScript
ProtocolToMonacoConverter.prototype.asMarker = function (diagnostic) {
    return {
        code: diagnostic.code,
        severity: this.asSeverity(diagnostic.severity),
        message: diagnostic.message,
        source: diagnostic.source,
        startLineNumber: diagnostic.range.start.line + 1,
        startColumn: diagnostic.range.start.character + 1,
        endLineNumber: diagnostic.range.end.line + 1,
        endColumn: diagnostic.range.end.character + 1
    };
};
```
The fix is to truly convert the `number` to a `string` via a call to `toString()`.