### PR TITLE
Allow for lazy loading of monaco

### DIFF
--- a/src/diagnostic-collection.ts
+++ b/src/diagnostic-collection.ts
@@ -5,7 +5,6 @@
 import { DiagnosticCollection, Diagnostic } from 'vscode-base-languageclient/lib/services';
 import { DisposableCollection, Disposable } from './disposable';
 import { ProtocolToMonacoConverter } from './converter';
-import Uri = monaco.Uri;
 import IModel = monaco.editor.IModel;
 import IMarkerData = monaco.editor.IMarkerData;
 
@@ -45,7 +44,7 @@ export class MonacoDiagnosticCollection implements DiagnosticCollection {
 }
 
 export class MonacoModelDiagnostics implements Disposable {
-    readonly uri: Uri;
+    readonly uri: monaco.Uri;
     protected _markers: IMarkerData[];
     protected _diagnostics: Diagnostic[];
     constructor(
@@ -53,7 +52,7 @@ export class MonacoModelDiagnostics implements Disposable {
         diagnostics: Diagnostic[], 
         readonly owner: string,
         protected readonly p2m: ProtocolToMonacoConverter)  {
-        this.uri = Uri.parse(uri);
+        this.uri = monaco.Uri.parse(uri);
         this.diagnostics = diagnostics;
         monaco.editor.onDidCreateModel(model => this.doUpdateModelMarkers(model));
     }

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -12,17 +12,16 @@ import {
 import { MonacoDiagnosticCollection } from './diagnostic-collection';
 import { ProtocolToMonacoConverter, MonacoToProtocolConverter } from './converter';
 import { DisposableCollection, Disposable } from './disposable';
-import Uri = monaco.Uri;
 
 export interface MonacoModelIdentifier {
-    uri: Uri;
+    uri: monaco.Uri;
     languageId: string;
 }
 
 export namespace MonacoModelIdentifier {
     export function fromDocument(document: DocumentIdentifier): MonacoModelIdentifier {
         return {
-            uri: Uri.parse(document.uri),
+            uri: monaco.Uri.parse(document.uri),
             languageId: document.languageId
         }
     }


### PR DESCRIPTION
It's fine to `import X = monaco.X` for types, but not for objects such as `monaco.Uri` and `monaco.languages`. This PR inlines these references to allow monaco to be loaded lazily.

Fixes #16 