### PR TITLE
Export services from vscode-base-languageclient

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,3 +10,4 @@ export * from './converter';
 export * from './services';
 export * from 'vscode-base-languageclient/lib/base';
 export * from 'vscode-base-languageclient/lib/connection';
+export * from 'vscode-base-languageclient/lib/services';


### PR DESCRIPTION
This lets users implement service interfaces without adding a dependency on vscode-base-languageclient. Base and connection are already supported.

Would allow users to implement the `Commands` interface as per: #12 