### PR TITLE
When the language server doesn't provide a resolve option, return the original codelens

### DIFF
--- a/src/languages.ts
+++ b/src/languages.ts
@@ -271,7 +271,7 @@ export class MonacoLanguages implements Languages {
                 }
                 const protocolCodeLens = this.m2p.asCodeLens(codeLens);
                 return provider.resolveCodeLens!(protocolCodeLens, token).then(result => this.p2m.asCodeLens(result))
-            } : undefined
+            } : ((m, codeLens, t) => codeLens)
         }
     }
 


### PR DESCRIPTION
In browser test shown that monaco still call the resolver in all cases,
so we can't use undefined here.

Thanks for the library :)