### PR TITLE
State that the WorkspaceClientCapabilites's applyEdit capability is enabled

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -3,13 +3,16 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import { MonacoToProtocolConverter, ProtocolToMonacoConverter } from './converter';
-import { Workspace, TextDocumentDidChangeEvent, TextDocument, Event, Emitter } from 'vscode-base-languageclient/lib/services';
+import { Workspace, TextDocumentDidChangeEvent, TextDocument, Event, Emitter, WorkspaceClientCapabilites } from 'vscode-base-languageclient/lib/services';
 import { WorkspaceEdit } from 'vscode-base-languageclient/lib/base';
 import IModel = monaco.editor.IModel;
 import IResourceEdit = monaco.languages.IResourceEdit;
 
 export class MonacoWorkspace implements Workspace {
 
+    public readonly capabilities: WorkspaceClientCapabilites = {
+        applyEdit: true
+    };
     protected readonly documents = new Map<string, TextDocument>();
     protected readonly onDidOpenTextDocumentEmitter = new Emitter<TextDocument>();
     protected readonly onDidCloseTextDocumentEmitter = new Emitter<TextDocument>();


### PR DESCRIPTION
In #21 support for the `workspace/applyEdit` request was added so the client should state this fact in its `WorkspaceClientCapabilites`.

My language server will only provide code actions if the client supports `workspace/applyEdit` requests so I need this to be enabled correctly so that my language server will work with this editor.