### PR TITLE
Update WorkspaceClientCapabilities to state that WorkspaceEdit's documentChanges is supported

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -11,7 +11,10 @@ import IResourceEdit = monaco.languages.IResourceEdit;
 export class MonacoWorkspace implements Workspace {
 
     public readonly capabilities: WorkspaceClientCapabilites = {
-        applyEdit: true
+        applyEdit: true,
+        workspaceEdit: {
+            documentChanges: true
+        }
     };
     protected readonly documents = new Map<string, TextDocument>();
     protected readonly onDidOpenTextDocumentEmitter = new Emitter<TextDocument>();


### PR DESCRIPTION
Support for `workspace/applyEdit` was added in #21 but the capabilities of the client was not updated to include `workspaceEdit: { documentChanges: true }`. This pull request adds this to the capabilities so that servers will know that this client supports this feature.

In an [earlier comment](https://github.com/TypeFox/monaco-languageclient/pull/55#discussion_r167476391) I had stated that our support for `documentChanges` was incomplete because no version checking was made. However, I was wrong because the versions were being checked by `vscode-base-languageclient`.

https://github.com/TypeFox/vscode-languageserver-node/blob/e0c1f194dabede0409f0d8f4e4e2eeccc65e1535/client/src/base.ts#L1502-L1512

Hence, the versions of the `documentChanges` have actually already been verified by the time they get to our `applyEdit` function implementation.

Sorry for the any confusion that I may have caused.