### PR TITLE
Drop Node.js 7 from the CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "6"
-  - "7"
   - "8"
   - "9"
 before_install:


### PR DESCRIPTION
Node.js 7 reached end-of-life in 2017-06-30 and has been superceded by Node.js 8 which is an LTS release. Node.js 8 is included in the CI build so there is no reason to build Node.js 7 anymore. Node.js 9 is being built so the "latest and greatest" case is covered.