### PR TITLE
Upgrade to Monaco 0.11.x

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -2376,9 +2376,10 @@
     },
     "monaco-languageclient": {
       "version": "file:..",
+      "integrity": null,
       "requires": {
         "glob-to-regexp": "0.3.0",
-        "monaco-editor-core": "0.10.1",
+        "monaco-editor-core": "0.11.6",
         "vscode-base-languageclient": "0.0.1-alpha.3"
       },
       "dependencies": {
@@ -2442,7 +2443,7 @@
           }
         },
         "monaco-editor-core": {
-          "version": "0.10.1",
+          "version": "0.11.6",
           "bundled": true
         },
         "once": {

--- a/example/src/client.ts
+++ b/example/src/client.ts
@@ -25,7 +25,10 @@ const value = `{
 }`;
 const editor = monaco.editor.create(document.getElementById("container")!, {
     model: monaco.editor.createModel(value, 'json', monaco.Uri.parse('inmemory://model.json')),
-    glyphMargin: true
+    glyphMargin: true,
+    lightbulb: {
+        enabled: true
+    }
 });
 
 // create the web socket

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,9 +83,9 @@
       }
     },
     "monaco-editor-core": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.10.1.tgz",
-      "integrity": "sha1-FRIdnijlHwlNnFVr+FLcnBPcQqE="
+      "version": "0.11.6",
+      "resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.11.6.tgz",
+      "integrity": "sha512-WGJnnmtSY7qRYLRBOL23+pdQR6flUNKPAkREscc/ctiNRJHCqo0jFiSvuqh4VMfoVGkyprGCEjkBc+8/7nQuEA=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "glob-to-regexp": "^0.3.0",
-    "monaco-editor-core": "^0.10.1",
+    "monaco-editor-core": "^0.11.6",
     "vscode-base-languageclient": "^0.0.1-alpha.2"
   },
   "scripts": {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2017, 2018 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import { Commands, Disposable } from 'vscode-base-languageclient/lib/services';
@@ -9,8 +9,9 @@ export class MonacoCommands implements Commands {
     public constructor(protected readonly editor: monaco.editor.IStandaloneCodeEditor) { }
 
     public registerCommand(command: string, callback: (...args: any[]) => any, thisArg?: any): Disposable {
-        return this.editor._commandService.addCommand(command, {
-            handler: (_accessor, ...args: any[]) => callback(...args)
+        return this.editor._commandService.addCommand({
+            id: command,
+            handler: (_accessor: any, ...args: any[]) => callback(...args)
         });
     }
 }

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -271,11 +271,11 @@ export class MonacoToProtocolConverter {
 
 export class ProtocolToMonacoConverter {
 
-    asResourceEdits(resource: monaco.Uri, edits: TextEdit[], modelVersionId?: number,): monaco.languages.ResourceTextEdit {
+    asResourceEdits(resource: monaco.Uri, edits: TextEdit[], modelVersionId?: number): monaco.languages.ResourceTextEdit {
         return {
             resource: resource,
             edits: this.asTextEdits(edits),
-            modelVersionId: modelVersionId
+            modelVersionId
         }
     }
 
@@ -515,18 +515,15 @@ export class ProtocolToMonacoConverter {
     }
 
     asIMarkdownString(string: MarkedString): monaco.IMarkdownString {
-        let value = (string as any).value;
-        if (value === "") {
-            return { value: "" };
-        } else if (value) {
-            let language = (string as any).language;
+        if (typeof string === 'string') {
             return {
-                value: '```' + language + `\n` + value + `\n` + '```'
+                value: string
             }
         }
+        const { language, value } = string;
         return {
-            value: string as string
-        }
+            value: '```' + language + '\n' + value + '\n```'
+        };
     }
 
     asIMarkdownStrings(strings: MarkedString[]): monaco.IMarkdownString[] {
@@ -570,10 +567,10 @@ export class ProtocolToMonacoConverter {
             const items = result.map(item => this.asCompletionItem(item));
             return {
                 isIncomplete: false,
-                items: items
+                items
             }
         }
-        return <monaco.languages.CompletionList>{
+        return {
             isIncomplete: result.isIncomplete,
             items: result.items.map(this.asCompletionItem.bind(this))
         }

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -242,7 +242,7 @@ export class MonacoLanguages implements Languages {
                     return [];
                 }
                 const params = this.m2p.asCodeActionParams(model, range, context);
-                return provider.provideCodeActions(params, token).then(result => this.p2m.asCommands(result));
+                return provider.provideCodeActions(params, token).then(result => this.p2m.asCodeActions(result));
             }
         }
     }

--- a/src/typings/monaco/index.d.ts
+++ b/src/typings/monaco/index.d.ts
@@ -23,6 +23,7 @@ declare module monaco.commands {
     }
 
     export interface ICommand {
+        id: string,
         handler: ICommandHandler;
     }
 }
@@ -43,7 +44,7 @@ declare module monaco.instantiation {
 declare module monaco.services {
     export class StandaloneCommandService implements monaco.commands.ICommandService {
         constructor(instantiationService: monaco.instantiation.IInstantiationService);
-        addCommand(id: string, command: monaco.commands.ICommand): IDisposable;
+        addCommand(command: monaco.commands.ICommand): IDisposable;
         onWillExecuteCommand: monaco.IEvent<monaco.commands.ICommandEvent>;
         executeCommand<T>(commandId: string, ...args: any[]): monaco.Promise<T>;
         executeCommand(commandId: string, ...args: any[]): monaco.Promise<any>;


### PR DESCRIPTION
There are a couple of API changes from 0.10.x to 0.11.x.

1. The new `lightbulb` was added for Microsoft/monaco-editor#574 and fixes #11.
2. The commands and code action changes were made to support `textDocument/codeAction` and `workspace/executeCommand` due to the changes from https://github.com/Microsoft/vscode/commit/d86955c7e8c332f79bd99aa1313bfff11d52f895.
3. Monaco API changes caused some refactoring in the code for supporting `textDocument/hover` and `workspace/applyEdit`.
4. I ran into some problems with union types and promises that forced me to change the signature of some of the conversion code for `CompletionItem[]` and `CompletionList`. I documented my problem in [Microsoft/TypeScript#7294](https://github.com/Microsoft/TypeScript/issues/7294#issuecomment-373303058).