### PR TITLE
upgrade to monaco 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,9 +83,9 @@
       }
     },
     "monaco-editor-core": {
-      "version": "0.11.6",
-      "resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.11.6.tgz",
-      "integrity": "sha512-WGJnnmtSY7qRYLRBOL23+pdQR6flUNKPAkREscc/ctiNRJHCqo0jFiSvuqh4VMfoVGkyprGCEjkBc+8/7nQuEA=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.12.0.tgz",
+      "integrity": "sha512-wOoEVAoZtrarDRcQC32Fp0ocacpQd6/Nb0FmUZOHeD3swZuPZhDLOxTyoNLjKq3d+h/6g+IARBLnDaLT5OQD4g=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "glob-to-regexp": "^0.3.0",
-    "monaco-editor-core": "^0.11.6",
+    "monaco-editor-core": "^0.12.0",
     "vscode-base-languageclient": "^0.0.1-alpha.4"
   },
   "scripts": {

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -178,13 +178,13 @@ export class MonacoToProtocolConverter {
         }
     }
 
-    asDiagnosticSeverity(value: monaco.Severity): DiagnosticSeverity | undefined {
+    asDiagnosticSeverity(value: monaco.MarkerSeverity): DiagnosticSeverity | undefined {
         switch (value) {
-            case monaco.Severity.Error:
+            case monaco.MarkerSeverity.Error:
                 return DiagnosticSeverity.Error;
-            case monaco.Severity.Warning:
+            case monaco.MarkerSeverity.Warning:
                 return DiagnosticSeverity.Warning;
-            case monaco.Severity.Info:
+            case monaco.MarkerSeverity.Info:
                 return DiagnosticSeverity.Information;
         }
         return undefined;
@@ -553,17 +553,17 @@ export class ProtocolToMonacoConverter {
         return contents.map(string => this.asIMarkdownString(string));
     }
 
-    asSeverity(severity?: number): monaco.Severity {
+    asSeverity(severity?: number): monaco.MarkerSeverity {
         if (severity === 1) {
-            return monaco.Severity.Error;
+            return monaco.MarkerSeverity.Error;
         }
         if (severity === 2) {
-            return monaco.Severity.Warning;
+            return monaco.MarkerSeverity.Warning;
         }
         if (severity === 3) {
-            return monaco.Severity.Info;
+            return monaco.MarkerSeverity.Info;
         }
-        return monaco.Severity.Ignore;
+        return monaco.MarkerSeverity.Hint;
     }
 
     asMarker(diagnostic: Diagnostic): monaco.editor.IMarkerData {


### PR DESCRIPTION
Monaco `0.12.0` fixes some important bugs with previous version, cf. https://github.com/Microsoft/monaco-editor/issues?q=is%3Aissue+milestone%3A%22March+2018%22+is%3Aclosed.

API changes needed to be handled here are related to the `monaco.editor.IMarkerData` and `monaco.MarkerSeverity` interfaces.