### PR TITLE
Convert all values of MarkerSeverity in the converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - updated dependency to Monaco 0.11 ([#61](https://github.com/TypeFox/monaco-languageclient/issues/61))
 - support `CompletionItem`'s `additionalTextEdits` property ([#39](https://github.com/TypeFox/monaco-languageclient/issues/39))
+- convert `monaco.MarkerSeverity.Hint` values to `DiagnosticSeverity.Hint` ([#71](https://github.com/TypeFox/monaco-languageclient/pull/71))
 
 ## [0.4.0] - 2018-02-13
 - add support for `textDocument/documentLink` and `documentLink/resolve` ([#53](https://github.com/TypeFox/monaco-languageclient/issues/53))

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -186,6 +186,8 @@ export class MonacoToProtocolConverter {
                 return DiagnosticSeverity.Warning;
             case monaco.MarkerSeverity.Info:
                 return DiagnosticSeverity.Information;
+            case monaco.MarkerSeverity.Hint:
+                return DiagnosticSeverity.Hint;
         }
         return undefined;
     }


### PR DESCRIPTION
It seems that `monaco.MarkerSeverity.Hint` is not being considered when converting a Monaco marker to an LSP Diagnostic so I fixed the converter.

https://github.com/TypeFox/monaco-languageclient/blob/3c7a4eb45df71d0461982ebc7a155e65d0c89129/src/converter.ts#L181-L191