### PR TITLE
add explicit dependency to `vscode-languageserver-types`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "glob-to-regexp": "^0.3.0",
     "monaco-editor-core": "^0.12.0",
-    "vscode-base-languageclient": "^0.0.1-alpha.4"
+    "vscode-base-languageclient": "^0.0.1-alpha.4",
+    "vscode-languageserver-types": "^3.7.0"
   },
   "scripts": {
     "prepare": "npm run clean && npm run compile",


### PR DESCRIPTION
pulling of required version should be forced, otherwise lockfiles of npm/yarn may prevent an update of `vscode-languageserver-types`.

Signed-off-by: Alex Tugarev <alex.tugarev@typefox.io>