### PR TITLE
Return updated items in `resolve*` operations

### DIFF
--- a/src/languages.ts
+++ b/src/languages.ts
@@ -93,7 +93,11 @@ export class MonacoLanguages implements Languages {
             },
             resolveCompletionItem: provider.resolveCompletionItem ? (item, token) => {
                 const protocolItem = this.m2p.asCompletionItem(item);
-                return provider.resolveCompletionItem!(protocolItem, token).then(item => this.p2m.asCompletionItem(item));
+                return provider.resolveCompletionItem!(protocolItem, token).then(resolvedItem => {
+                    const resolvedCompletionItem = this.p2m.asCompletionItem(resolvedItem);
+                    Object.assign(item, resolvedCompletionItem);
+                    return item;
+                });
             } : undefined
         };
     }
@@ -270,7 +274,11 @@ export class MonacoLanguages implements Languages {
                     return codeLens;
                 }
                 const protocolCodeLens = this.m2p.asCodeLens(codeLens);
-                return provider.resolveCodeLens!(protocolCodeLens, token).then(result => this.p2m.asCodeLens(result))
+                return provider.resolveCodeLens!(protocolCodeLens, token).then(result => {
+                    const resolvedCodeLens = this.p2m.asCodeLens(result);
+                    Object.assign(codeLens, resolvedCodeLens);
+                    return codeLens;
+                });
             } : ((m, codeLens, t) => codeLens)
         }
     }
@@ -385,7 +393,11 @@ export class MonacoLanguages implements Languages {
                 // and the link doesn't have a url set
                 if (provider.resolveDocumentLink && (link.url === null || link.url === undefined)) {
                     const documentLink = this.m2p.asDocumentLink(link);
-                    return provider.resolveDocumentLink(documentLink, token).then(result => this.p2m.asILink(result));
+                    return provider.resolveDocumentLink(documentLink, token).then(result => {
+                        const resolvedLink = this.p2m.asILink(result);
+                        Object.assign(link, resolvedLink);
+                        return link;
+                    });
                 }
                 return link;
             }


### PR DESCRIPTION
at least with latest monaco 0.12.0 the resolution of suggestion items is broken in some cases. it can be reproduced with JDT LS, when you continue typing a prefix of a suggestion shown after the suggestions were triggered explicitly. it happens that the `completion/resolve` params are [missing a `data` field](https://github.com/eclipse/eclipse.jdt.ls/issues/629#issuecomment-381702198).

the actual issue is, that monaco looses information, because the `CompletionItemProvider` won't fill up the given item, but returns a [new one, which is the converted result from LS](https://github.com/TypeFox/monaco-languageclient/compare/at/resolve-should-update-item?expand=1#diff-afa77f4a54ecc110291b19f59e543df7L96). 

monaco's `SuggestAdapter`, which calls the completion item provider, will just [update the given suggestion item](https://github.com/Microsoft/vscode/blob/standalone/0.12.x/src/vs/editor/contrib/suggest/suggest.ts#L135) and overwrites such additional fields, if they are not preserved by LSs. 

reading the docs and looking at other `CompletionItemProvider ` implementations, shows that it's OK to return the given item, which can be updated with more data from LS response.

```
		/**
		 * Given a completion item fill in more data, like [doc-comment](#CompletionItem.documentation)
		 * or [details](#CompletionItem.detail).
		 *
		 * The editor will only resolve a completion item once.
		 *
		 * @param item A completion item currently active in the UI.
		 * @param token A cancellation token.
		 * @return The resolved completion item or a thenable that resolves to of such. It is OK to return the given
		 * `item`. When no result is returned, the given `item` will be used.
		 */
		resolveCompletionItem?(item: CompletionItem, token: CancellationToken): ProviderResult<CompletionItem>;
```

the resolution of `CodeLense`s is also broken with JDT LS.
