### PR TITLE
Disabling strict compiler check in example project

### DIFF
--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "extends": "../tsconfig",
     "compilerOptions": {
+        "strict": false,
         "rootDir": "src",
         "outDir": "lib",
         "baseUrl": "."


### PR DESCRIPTION
There were a few compiler errors because of strict check inherited from the base tsconfig.json

```
src/json-server.ts:106:26 - error TS2532: Object is possibly 'undefined'.

106                 version: this.documents.get(params.textDocument.uri).version
                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


src/json-server.ts:113:40 - error TS2345: Argument of type 'TextDocument | undefined' is not assignable to parameter of type 'TextDocument'.
  Type 'undefined' is not assignable to type 'TextDocument'.

113         return this.jsonService.format(document, params.range, params.options)
                                           ~~~~~~~~


src/json-server.ts:118:51 - error TS2345: Argument of type 'TextDocument | undefined' is not assignable to parameter of type 'TextDocument'.
  Type 'undefined' is not assignable to type 'TextDocument'.

118         const jsonDocument = this.getJSONDocument(document);
                                                      ~~~~~~~~


src/json-server.ts:119:53 - error TS2345: Argument of type 'TextDocument | undefined' is not assignable to parameter of type 'TextDocument'.
  Type 'undefined' is not assignable to type 'TextDocument'.

119         return this.jsonService.findDocumentSymbols(document, jsonDocument);
                                                        ~~~~~~~~


src/json-server.ts:133:34 - error TS2532: Object is possibly 'undefined'.

133                         newText: this.documents.get(versionedTextDocumentIdentifier.uri).getText().toUpperCase()
                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


src/json-server.ts:142:51 - error TS2345: Argument of type 'TextDocument | undefined' is not assignable to parameter of type 'TextDocument'.
  Type 'undefined' is not assignable to type 'TextDocument'.

142         const jsonDocument = this.getJSONDocument(document);
                                                      ~~~~~~~~


src/json-server.ts:143:41 - error TS2345: Argument of type 'TextDocument | undefined' is not assignable to parameter of type 'TextDocument'.
  Type 'undefined' is not assignable to type 'TextDocument'.

143         return this.jsonService.doHover(document, params.position, jsonDocument);
                                            ~~~~~~~~


src/json-server.ts:168:51 - error TS2345: Argument of type 'TextDocument | undefined' is not assignable to parameter of type 'TextDocument'.
  Type 'undefined' is not assignable to type 'TextDocument'.

168         const jsonDocument = this.getJSONDocument(document);
                                                      ~~~~~~~~


src/json-server.ts:169:44 - error TS2345: Argument of type 'TextDocument | undefined' is not assignable to parameter of type 'TextDocument'.
  Type 'undefined' is not assignable to type 'TextDocument'.

169         return this.jsonService.doComplete(document, params.position, jsonDocument);

```