### PR TITLE
chore(amd): amd distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "prepare": "npm run update-vscode && npm run clean && npm run compile",
-    "compile": "tsc",
+    "compile": "tsc && tsc --outDir dist/amd --module amd",
     "watch": "tsc -w",
     "clean": "rimraf lib",
     "update-vscode": "node ./node_modules/vscode/bin/install"


### PR DESCRIPTION
the default build is done for `commonjs` only. Since consumers might using other bundlers, in my case requirejs - which requires amd bundles - it would be great to create another compile target.

typically  a structure for multi-targets would be

lib
  -> umd
  -> commonjs
  -> amd
  -> ...

Since i didn't want to override your project structure, amd here is now compiled to `dist/amd`