### PR TITLE
Ensure that SignatureHelp and SignatureHelp has non-null arrays

### DIFF
--- a/src/monaco-converter.ts
+++ b/src/monaco-converter.ts
@@ -613,7 +613,11 @@ export class ProtocolToMonacoConverter {
     asSignatureInformation(item: SignatureInformation): monaco.languages.SignatureInformation {
         let result = <monaco.languages.SignatureInformation>{ label: item.label };
         if (item.documentation) { result.documentation = this.asDocumentation(item.documentation); }
-        if (item.parameters) { result.parameters = this.asParameterInformations(item.parameters); }
+        if (item.parameters) {
+            result.parameters = this.asParameterInformations(item.parameters);
+        } else {
+            result.parameters = [];
+        }
         return result;
     }
 

--- a/src/monaco-converter.ts
+++ b/src/monaco-converter.ts
@@ -598,7 +598,11 @@ export class ProtocolToMonacoConverter {
             // activeParameter was optional in the past
             result.activeParameter = 0;
         }
-        if (item.signatures) { result.signatures = this.asSignatureInformations(item.signatures); }
+        if (item.signatures) {
+            result.signatures = this.asSignatureInformations(item.signatures);
+        } else {
+            result.signatures = [];
+        }
         return result;
     }
 


### PR DESCRIPTION
While the LSP allows a `SignatureHelp`'s signatures array to be optional, Monaco does not so we should ensure that it Monaco's representation of a `SignatureHelp` is properly initialized with a zero length array if the value from the language server is `null` or `undefined`.

See Microsoft/monaco-editor#1045.