### PR TITLE
Fix window.showMessage

### DIFF
--- a/src/vscode-api.ts
+++ b/src/vscode-api.ts
@@ -502,7 +502,7 @@ export function createVSCodeApi(servicesProvider: Services.Provider): typeof vsc
         setLanguageConfiguration: unsupported,
         onDidChangeDiagnostics: unsupported
     };
-    function showMessage(type: MessageType, arg0: any, arg1: any): Thenable<undefined | MessageActionItem> {
+    function showMessage(type: MessageType, arg0: any, ...arg1: any[]): Thenable<undefined | MessageActionItem> {
         if (typeof arg0 !== "string") {
             throw new Error('unexpected message: ' + JSON.stringify(arg0));
         }


### PR DESCRIPTION
I was seeing messages of the form `Request window/showMessageRequest failed with message: unexpected actions: {"title":"foo"}`, and I think I figured out the cause.

The actions for `showMessage` are not in an array of their own, they are concatenated to the arguments list: https://github.com/microsoft/vscode-languageserver-node/blob/master/client/src/client.ts#L2760

To treat them as an array, we need to use spread parameters.