### PR TITLE
Make Services.install be disposable

### DIFF
--- a/client/src/services.ts
+++ b/client/src/services.ts
@@ -46,11 +46,13 @@ export namespace Services {
         }
         return services;
     }
-    export function install(services: Services): void {
+    export function install(services: Services): Disposable {
         if (global[symbol]) {
             console.error(new Error('Language Client services has been overridden'));
         }
         global[symbol] = services;
+
+        return Disposable.create(() => global[symbol] = undefined)
     }
 }
 


### PR DESCRIPTION
We frequently override services, and often see the `'Language Client services has been overridden'` error message, even though it is working how we expect. 

By having `install` return a `Disposable`, it allows us to dispose of our old services first, before setting up new ones - avoiding the console error.

Other methods considered:
* `Uninstall` method
* Removing console error
* Adding parameter to `install` method to silence the console.error

Let me know if you'd prefer a different method than the current choice.