### PR TITLE
Consider null returns for textDocument/codeAction

### DIFF
--- a/src/monaco-converter.ts
+++ b/src/monaco-converter.ts
@@ -440,6 +440,9 @@ export class ProtocolToMonacoConverter {
     }
 
     asCodeActions(actions: (Command | CodeAction)[]): monaco.languages.CodeAction[] {
+        if (actions === null || actions === undefined) {
+            return [];
+        }
         return actions.map(action => this.asCodeAction(action));
     }
 


### PR DESCRIPTION
As it is possible for `textDocument/codeAction` to return a `null` value, we need to guard against this and simply return an empty array if the language server sends a null back to us.

This should fix #154.