### PR TITLE
Fix usage ReconnectingWebSocket example client.ts

### DIFF
--- a/example/src/client.ts
+++ b/example/src/client.ts
@@ -83,5 +83,5 @@ function createWebSocket(url: string): WebSocket {
         maxRetries: Infinity,
         debug: false
     };
-    return new ReconnectingWebSocket(url, undefined, socketOptions);
+    return new ReconnectingWebSocket(url, [], socketOptions);
 }


### PR DESCRIPTION
Fixed the usage of the ReconnectingWebsocket in the client.ts of the example.

Was `undefined` but should be `[]` according to the documentation: https://www.npmjs.com/package/reconnecting-websocket

This was causing websocket handshake errors for Firefox and IE.