### PR TITLE
Update Monaco dependency in the example

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,7 @@
   "version": "0.9.0",
   "dependencies": {
     "express": "^4.15.2",
-    "monaco-editor-core": "^0.15.5",
+    "monaco-editor-core": "^0.17.0",
     "monaco-languageclient": "0.9.0",
     "normalize-url": "^2.0.1",
     "reconnecting-websocket": "^3.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4518,11 +4518,6 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-monaco-editor-core@^0.15.5:
-  version "0.15.5"
-  resolved "https://registry.yarnpkg.com/monaco-editor-core/-/monaco-editor-core-0.15.5.tgz#145f1953a8e319282d92502252d68ef3486b6875"
-  integrity sha512-kM3KHRjj16cFdK5Z0EppKUu793JVMpsEesBSWlqdgrxcmjyDMXV6xK0oatPcAYp3eOfbbyjPhruxDXj85FKyIg==
-
 monaco-editor-core@^0.17.0:
   version "0.17.0"
   resolved "https://registry.yarnpkg.com/monaco-editor-core/-/monaco-editor-core-0.17.0.tgz#8d2b7f7e02ac68f68eecc881d7a26457cbc09b49"


### PR DESCRIPTION
`textDocument/documentLink` requests no longer work in the example because the Monaco bridge code uses 0.17.x APIs but the example still depends on 0.15.5.