### PR TITLE
Log a warning instead of an error when overriding the services

### DIFF
--- a/client/src/services.ts
+++ b/client/src/services.ts
@@ -56,7 +56,7 @@ export namespace Services {
     }
     export function install(services: Services): Disposable {
         if (global[symbol]) {
-            console.error(new Error('Language Client services has been overridden'));
+            console.warn('Language Client services have been overridden');
         }
         global[symbol] = services;
 


### PR DESCRIPTION
If it's an error, it should throw, not just log. If it's a warning, it should log a warning. WDYT?