### PR TITLE
Fix vscode api

### DIFF
--- a/client/src/vscode-api.ts
+++ b/client/src/vscode-api.ts
@@ -903,7 +903,8 @@ export function createVSCodeApi(servicesProvider: Services.Provider): typeof vsc
         asExternalUri: unsupported,
         openExternal: unsupported
     }
-    return {
+
+    const partialApi: Partial<typeof vscode> = {
         workspace,
         languages,
         window,
@@ -921,5 +922,7 @@ export function createVSCodeApi(servicesProvider: Services.Provider): typeof vsc
         Disposable: CodeDisposable,
         SignatureHelpTriggerKind: SignatureHelpTriggerKind,
         DiagnosticSeverity: ServicesModule.DiagnosticSeverity
-    } as any;
+    };
+
+    return partialApi as any;
 }

--- a/client/src/vscode-api.ts
+++ b/client/src/vscode-api.ts
@@ -12,7 +12,7 @@ import {
     SignatureHelpTriggerKind,
     MessageActionItem
 } from "./services";
-import * as ServicesModule from "./services"
+import * as ServicesModule from "./services";
 import { DiagnosticSeverity } from "vscode-languageserver-protocol";
 
 export function createVSCodeApi(servicesProvider: Services.Provider): typeof vscode {
@@ -936,7 +936,8 @@ export function createVSCodeApi(servicesProvider: Services.Provider): typeof vsc
         SemanticTokens,
         Disposable: CodeDisposable,
         SignatureHelpTriggerKind: SignatureHelpTriggerKind,
-        DiagnosticSeverity: ServicesModule.DiagnosticSeverity
+        DiagnosticSeverity: ServicesModule.DiagnosticSeverity,
+        EventEmitter: ServicesModule.Emitter
     };
 
     return partialApi as any;

--- a/client/src/vscode-api.ts
+++ b/client/src/vscode-api.ts
@@ -876,6 +876,21 @@ export function createVSCodeApi(servicesProvider: Services.Provider): typeof vsc
     };
     class CodeDisposable implements vscode.Disposable {
         constructor(public callOnDispose: Function) { }
+
+        static from(...inDisposables: { dispose(): any; }[]): Disposable {
+            let disposables: ReadonlyArray<{ dispose(): any; }> | undefined = inDisposables;
+            return new CodeDisposable(function () {
+                if (disposables) {
+                    for (const disposable of disposables) {
+                        if (disposable && typeof disposable.dispose === 'function') {
+                            disposable.dispose();
+                        }
+                    }
+                    disposables = undefined;
+                }
+            });
+        }
+
         dispose() {
             this.callOnDispose();
         }


### PR DESCRIPTION
It seems that vscode-languageclient now requires the `EventEmitter` from the `vscode` api (https://github.com/microsoft/vscode-languageserver-node/blob/ee617c1f0c64a9d4ef7c6dcbb37189c7ae63ecd6/client/src/common/semanticTokens.ts#L126)