### PR TITLE
MonacoConverter: Set ActiveParameter in SignatureHelp Info

### DIFF
--- a/client/src/monaco-converter.ts
+++ b/client/src/monaco-converter.ts
@@ -793,6 +793,9 @@ export class ProtocolToMonacoConverter {
         } else {
             result.parameters = [];
         }
+        if (item.activeParameter) {
+            result.activeParameter = item.activeParameter
+        }
         return result;
     }
 


### PR DESCRIPTION
Hi, sorry for this cold PR. I can make an official issue to link back to this PR if that's the standard. For now, I can describe the PR in more detail as the fix is relatively simple and nothing protocol breaking. Seems like from the contribution guidelines, I may need to bump the minor version?

## Context 

Was able to successfully plug in[ lua-language-server](https://github.com/sumneko/lua-language-server) via websocket [I had to fork and make some changes to accept monaco-editor and not monaco-core-editor for syntax highlighting] and trying to flesh out some features. I noted that one of the gaps was ActiveParameter in the SignatureHelp was not switching to the next one when I hit the "," trigger character like in VSCode. 

I confirmed that the payload from the server is correct: [note that the payload is not sending activeSignature || activeParameter at the top SignatureHelpResponse. Also excuse my signature... you can see how early in the experimental phase I am in for my pet project lol]

```
{"id":52,"jsonrpc":"2.0","result":{"signatures":[{"activeParameter":1,"documentation":{"kind":"markdown","value":"helloFelix is a quick test. Will this be picked up by Monaco editor?"},"label":"function helloFelix(activation: string|table, queue_name: string, tote_id: string)","parameters":[{"label":[20,44]},{"label":[46,64]},{"label":[66,81]}]}]}}
```

## Solution 

Turns out it was simply not setting activeParameter in the converter. 3 LOC.
