### PR TITLE
Add missing protocol convertion

### DIFF
--- a/client/src/monaco-language-client.ts
+++ b/client/src/monaco-language-client.ts
@@ -96,6 +96,8 @@ export class MonacoLanguageClient extends BaseLanguageClient {
         FoldingRangeFeature['asFoldingRanges'] = MonacoLanguageClient.bypassConversion;
         this.registerFeature(new FoldingRangeFeature(this));
         this.registerFeature(new DeclarationFeature(this));
+        this.registerFeature(new SemanticTokensFeature(this));
+        this.registerFeature(new CallHierarchyFeature(this));
 
         const features = this['_features'] as ((StaticFeature | DynamicFeature<any>)[]);
         for (const feature of features) {
@@ -108,8 +110,6 @@ export class MonacoLanguageClient extends BaseLanguageClient {
     }
 
     public registerProposedFeatures() {
-        this.registerFeature(new CallHierarchyFeature(this));
-        this.registerFeature(new SemanticTokensFeature(this));
     }
 
     protected getLocale(): string {


### PR DESCRIPTION
When upgrading to LSP 3.16.0 (and even some for LSP 3.15.0), some protocol conversion were not updated or added.