### PR TITLE
Remove dependency of vscode-jsonrpc in example #254

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,6 @@
     "reconnecting-websocket": "^3.2.2",
     "request-light": "^0.2.2",
     "vscode-json-languageservice": "^4.0.2",
-    "vscode-jsonrpc": "6.0.0",
     "vscode-languageserver": "7.0.0",
     "vscode-uri": "^3.0.2",
     "ws": "^5.0.0"

--- a/example/src/client.ts
+++ b/example/src/client.ts
@@ -4,9 +4,8 @@
  * ------------------------------------------------------------------------------------------ */
 import { listen } from '@codingame/monaco-jsonrpc';
 import * as monaco from 'monaco-editor-core'
-import { MessageConnection } from 'vscode-jsonrpc';
 import {
-    MonacoLanguageClient, CloseAction, ErrorAction,
+    MonacoLanguageClient, MessageConnection, CloseAction, ErrorAction,
     MonacoServices, createConnection
 } from 'monaco-languageclient';
 import normalizeUrl = require('normalize-url');


### PR DESCRIPTION
In reference to the issue I reported in #254 

Note: the example was working perfectly fine, but for my custom fork, I was running into issues with `unknown parameter value byName`. This change helped rectify it for me and in theory should make the example solution more robust.