### PR TITLE
Fix invalid completionItem/resolve request

### DIFF
--- a/client/src/monaco-converter.ts
+++ b/client/src/monaco-converter.ts
@@ -219,13 +219,11 @@ export class MonacoToProtocolConverter {
         const result: CompletionItem = { label: item.label as string };
         const protocolItem = ProtocolCompletionItem.is(item) ? item : undefined;
         if (item.detail) { result.detail = item.detail; }
-        // We only send items back we created. So this can't be something else than
-        // a string right now.
         if (item.documentation) {
-            if (!protocolItem || !protocolItem.documentationFormat) {
-                result.documentation = item.documentation as string;
+            if (typeof item.documentation === 'string') {
+                result.documentation = item.documentation;
             } else {
-                result.documentation = this.asDocumentation(protocolItem.documentationFormat, item.documentation);
+                result.documentation = this.asDocumentation(protocolItem?.documentationFormat ?? MarkupKind.Markdown, item.documentation);
             }
         }
         if (item.filterText) { result.filterText = item.filterText; }


### PR DESCRIPTION
When `item.documentation` is not a string but a `IMarkdownString` and the `documentationFormat` is not defined, we cast the `IMarkdownString` type to a string

The consequence of it is the returned object is missing the `kind` property, which makes it not respect the LSP protocol and makes the rust language server crash