### PR TITLE
Resolve code actions

### DIFF
--- a/client/src/monaco-languages.ts
+++ b/client/src/monaco-languages.ts
@@ -244,13 +244,11 @@ export class MonacoLanguages implements Languages {
         return {
             provideCodeActions: async (model, range, context, token) => {
                 if (!this.matchModel(selector, MonacoModelIdentifier.fromModel(model))) {
-                    // FIXME: get rid of `!` when https://github.com/microsoft/monaco-editor/issues/1560 is resolved
-                    return undefined!;
+                    return undefined;
                 }
                 const params = this.m2p.asCodeActionParams(model, range, context);
                 const result = await provider.provideCodeActions(params, token);
-                // FIXME: get rid of `|| undefined!` when https://github.com/microsoft/monaco-editor/issues/1560 is resolved
-                return result && this.p2m.asCodeActionList(result) || undefined!;
+                return result && this.p2m.asCodeActionList(result) || undefined;
             }
         }
     }

--- a/client/src/services.ts
+++ b/client/src/services.ts
@@ -133,8 +133,9 @@ export interface WorkspaceSymbolProvider {
     provideWorkspaceSymbols(params: WorkspaceSymbolParams, token: CancellationToken): ProviderResult<SymbolInformation[]>;
 }
 
-export interface CodeActionProvider {
+export interface CodeActionProvider<T extends CodeAction = CodeAction> {
     provideCodeActions(params: CodeActionParams, token: CancellationToken): ProviderResult<(Command | CodeAction)[]>;
+    resolveCodeAction?(codeAction: T, token: CancellationToken): ProviderResult<T>;
 }
 
 export interface CodeLensProvider {

--- a/client/src/vscode-api.ts
+++ b/client/src/vscode-api.ts
@@ -434,7 +434,10 @@ export function createVSCodeApi(servicesProvider: Services.Provider): typeof vsc
             return languages.registerCodeActionsProvider(selector, {
                 provideCodeActions({ textDocument, range, context }, token) {
                     return provider.provideCodeActions(<any>textDocument, <any>range, <any>context, token) as any;
-                }
+                },
+                resolveCodeAction: provider.resolveCodeAction ? (codeAction, token) => {
+                    return provider.resolveCodeAction!(<any>codeAction, <any>token) as any
+                } : undefined
             });
         },
         registerCodeLensProvider(selector, provider) {

--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,7 @@
     "express": "^4.15.2",
     "file-loader": "^4.3.0",
     "monaco-editor-core": "^0.22.3",
-    "monaco-languageclient": "^0.13.0",
+    "@codingame/monaco-languageclient": "^0.14.0",
     "normalize-url": "^2.0.1",
     "reconnecting-websocket": "^3.2.2",
     "request-light": "^0.2.2",

--- a/example/src/client.ts
+++ b/example/src/client.ts
@@ -7,7 +7,7 @@ import * as monaco from 'monaco-editor-core'
 import {
     MonacoLanguageClient, MessageConnection, CloseAction, ErrorAction,
     MonacoServices, createConnection
-} from 'monaco-languageclient';
+} from '@codingame/monaco-languageclient';
 import normalizeUrl = require('normalize-url');
 const ReconnectingWebSocket = require('reconnecting-websocket');
 

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -37,7 +37,7 @@ const common = {
     },
     resolve: {
         alias: {
-            'vscode': require.resolve('monaco-languageclient/lib/vscode-compatibility')
+            'vscode': require.resolve('@codingame/monaco-languageclient/lib/vscode-compatibility')
         },
         extensions: ['.js', '.json', '.ttf']
     }

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -4,7 +4,7 @@
   "version": "0.13.0",
   "dependencies": {
     "file-loader": "^4.3.0",
-    "monaco-languageclient": "^0.13.0",
+    "@codingame/monaco-languageclient": "^0.14.0",
     "vscode-json-languageservice": "^4.0.2",
     "vscode-languageserver-types": "^3.16.0"
   },

--- a/examples/browser/src/client.ts
+++ b/examples/browser/src/client.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 import * as monaco from 'monaco-editor-core'
 import { getLanguageService, TextDocument } from "vscode-json-languageservice";
-import { MonacoToProtocolConverter, ProtocolToMonacoConverter } from 'monaco-languageclient/lib/monaco-converter';
+import { MonacoToProtocolConverter, ProtocolToMonacoConverter } from '@codingame/monaco-languageclient/lib/monaco-converter';
 
 const LANGUAGE_ID = 'json';
 const MODEL_URI = 'inmemory://model.json'


### PR DESCRIPTION
In last version of the lsp specification, the `edit` field in a CodeAction is not mandatory anymore.

In such case, the client is supposed to call the server to resolve it when it needs to.

Unfortunately, the monaco api doesn't provide the way to do it properly.

As soon as https://github.com/microsoft/monaco-editor/issues/2663 is resolved, it will need to be properly implemented, this is a temporary "hack"