### PR TITLE
Fix dropped tags in Diagnostic -> IMarkerData

### DIFF
--- a/client/src/monaco-converter.ts
+++ b/client/src/monaco-converter.ts
@@ -954,7 +954,8 @@ export class ProtocolToMonacoConverter {
             startColumn: diagnostic.range.start.character + 1,
             endLineNumber: diagnostic.range.end.line + 1,
             endColumn: diagnostic.range.end.character + 1,
-            relatedInformation: this.asRelatedInformations(diagnostic.relatedInformation)
+            relatedInformation: this.asRelatedInformations(diagnostic.relatedInformation),
+            tags: diagnostic.tags
         }
     }
 


### PR DESCRIPTION
When converting diagnostics from the language client DIagnostic from into IMarkerData, the `tag` field was dropped.

This keeps that field present in the diagnostic.

Here's confirmation of this locally with the `Unnecessary` tag on all `false` values, and no diagnostics on `true`:
![Screen Shot 2021-10-29 at 4 22 43 PM](https://user-images.githubusercontent.com/31489089/139507658-982383da-9a7e-47d9-a0d6-bb0caf4f5b12.png)