### PR TITLE
Update CHANGELOG from 0.14.0 to 0.17.3

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.json]
+indent_size = 2

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "editorconfig.editorconfig"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,19 @@
 {
-    "typescript.tsdk": "node_modules/typescript/lib",
-    "editor.insertSpaces": true,
-    "editor.tabSize": 4,
-    "[json]": {
-        "editor.tabSize": 2
-    }
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.guides.bracketPairs": true,
+  "editor.formatOnSave": false,
+  "workbench.editor.revealIfOpen": true,
+  "[javascript]": {
+    "editor.formatOnSave": true
+  },
+  "[typescript]": {
+    "editor.formatOnSave": true
+  },
+  "eslint.validate": [
+    "javascript",
+    "typescript"
+  ],
+  "[jsonc]": {
+    "editor.defaultFormatter": "vscode.json-language-features"
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,73 +1,110 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
-## [0.15.0] - 2021-02-03
+## [0.17.3] - 2021-12-21
 
-- Upgrade to Monaco 0.22.3
+* First released as @codingame/monaco-languageclient@0.17.3 on specified date
+* Release of monaco-languageclient@0.17.3 was made up on 2022-02-23
+* Releases `0.17.1` and `0.17.2` were mistakes
+* Fix various issues: outdated api, missing stuff in compatibility-api... [#309](https://github.com/TypeFox/monaco-languageclient/pull/309)
+
+## [0.17.0] - 2021-11-10
+
+* First released as @codingame/monaco-languageclient@0.17.0 on specified date
+* Release of monaco-languageclient@0.17.0 was made up on 2022-02-23
+* Update to monaco 0.30.1 [#301](https://github.com/TypeFox/monaco-languageclient/pull/301)
+
+## [0.16.1] - 2021-11-03
+
+* First released as @codingame/monaco-languageclient@0.16.1 on specified date
+* Release of monaco-languageclient@0.16.1 was made up on 2022-02-23
+* Fix dropped tags in Diagnostic -> IMarkerData [#297](https://github.com/TypeFox/monaco-languageclient/pull/297)
+* Missing protocol convention [#298](https://github.com/TypeFox/monaco-languageclient/pull/298)
+
+## [0.16.0] - 2021-10-11
+
+* First released as @codingame/monaco-languageclient@0.16.0 on specified date
+* Release of monaco-languageclient@0.15.1 was made up on 2022-02-23
+* Updated `monaco-editor-core` version to `0.29.0`
+* Async resolve code actions [#294](https://github.com/TypeFox/monaco-languageclient/pull/294)
+
+## [0.15.1] - 2021-09-20
+
+* First released as @codingame/monaco-languageclient@0.15.1 on specified date
+* Release of monaco-languageclient@0.15.1 was made up on 2022-02-23
+* Resolve code actions [#290](https://github.com/TypeFox/monaco-languageclient/pull/290)
+* Release `0.15.0` was skipped
+
+## [0.14.0] - 2021-08-05
+
+* First released as @codingame/monaco-languageclient@0.14.0 on specified date
+* Release of monaco-languageclient@0.14.0 was made up on 2022-02-23
+* Upgraded to Monaco 0.22.3
 
 ### Breaking changes
 
-- `MonacoServices` now takes the `monaco` object instead of the `CommandRegistry`
+* `MonacoServices` now takes the `monaco` object instead of the `CommandRegistry`
 
 before:
+
 ```typescript
 MonacoServices.install(require('monaco-editor-core/esm/vs/platform/commands/common/commands').CommandsRegistry);
 ```
 
 after:
+
 ```typescript
 import * as monaco from 'monaco-editor-core'
 
 MonacoServices.install(monaco);
 ```
 
-## [0.14.0] - 2020-11-26
-
-- Upgraded to Monaco 0.21.2
-
-### Breaking changes
-
-`MonacoServices` should now be installed using the command registry instead of the editor
+* `MonacoServices` should now be installed using the command registry instead of the editor
 
 before:
+
 ```typescript
 const editor = monaco.editor.create(...);
 MonacoServices.install(editor);
 ```
 
 after:
+
 ```typescript
 MonacoServices.install(require('monaco-editor-core/esm/vs/platform/commands/common/commands').CommandsRegistry);
 ```
 
 ## [0.13.0] - 2020-04-06
 
-- Upgraded to vscode-uri 2.x [741a3df](https://github.com/TypeFox/monaco-languageclient/commit/741a3dfb865eff55c3dcc4a51f74759921d3f2a5)
+* Upgraded to vscode-uri 2.x [741a3df](https://github.com/TypeFox/monaco-languageclient/commit/741a3dfb865eff55c3dcc4a51f74759921d3f2a5)
 
 ## [0.12.0] - 2020-03-19
 
-- Upgraded to Monaco 0.19.1 [#199](https://github.com/TypeFox/monaco-languageclient/pull/199)
+* Upgraded to Monaco 0.19.1 [#199](https://github.com/TypeFox/monaco-languageclient/pull/199)
 
 ## [0.11.0] - 2020-01-23
 
-- Upgraded to Monaco 0.18.1 [#178](https://github.com/TypeFox/monaco-languageclient/pull/178)
+* Upgraded to Monaco 0.18.1 [#178](https://github.com/TypeFox/monaco-languageclient/pull/178)
 
 ## [0.10.2] - 2019-09-10
 
-- register language features regardless whether a language is registered (https://github.com/TypeFox/monaco-languageclient/commit/0559be6c20744182ede699f594fdbe6d9f3d7145)
+* register language features regardless whether a language is registered (<https://github.com/TypeFox/monaco-languageclient/commit/0559be6c20744182ede699f594fdbe6d9f3d7145>)
 
 ## [0.10.1] - 2019-09-04
 
-- aligned CompletionItemKind with Monaco 0.17.0 [#174](https://github.com/TypeFox/monaco-languageclient/pull/174)
+* aligned CompletionItemKind with Monaco 0.17.0 [#174](https://github.com/TypeFox/monaco-languageclient/pull/174)
 
 ## [0.10.0] - 2019-08-26
 
-- upgraded to LSP 5.3.0 and Monaco 0.17.0
+* upgraded to LSP 5.3.0 and Monaco 0.17.0
 
 ### Breaking changes
 
 Switch to es6 from es5. For clients who cannot migrate to es6 please use babel to transpile Monaco and LSP to es5.
-  - to configure babel wit webpack:
+
+* to configure babel wit webpack:
+
 ```js
     {
         test: /\\.js$/,
@@ -93,37 +130,43 @@ Switch to es6 from es5. For clients who cannot migrate to es6 please use babel t
 
 ## [0.9.0] - 2018-09-06
 
-- use monaco-editor-core as a dev dependency to allow alternative implementations [#119](https://github.com/TypeFox/monaco-languageclient/pull/119)
+* use monaco-editor-core as a dev dependency to allow alternative implementations [#119](https://github.com/TypeFox/monaco-languageclient/pull/119)
 
 ### Breaking changes
 
 Clients have to explicitly declare a dependency to `monaco-editor-core` or another package providing Monaco:
-- `monaco-editor-core` is tree shaked to get rid of unused VS Code's code.
-- [@typefox/monaco-editor-core](https://www.npmjs.com/package/@typefox/monaco-editor-core) is a not tree-shaked alternative.
+
+* `monaco-editor-core` is tree shaked to get rid of unused VS Code's code.
+* [@typefox/monaco-editor-core](https://www.npmjs.com/package/@typefox/monaco-editor-core) is a not tree-shaked alternative.
 
 ## [0.8.0] - 2018-09-04
-- updated dependency to Monaco 0.14.x, with adaptation for breaking changes from monaco [#107](https://github.com/TypeFox/monaco-languageclient/pull/107) - thanks to [@Twinside](https://github.com/Twinside)
-- ensure that SignatureHelp and SignatureHelp has non-null arrays [#112](https://github.com/TypeFox/monaco-languageclient/pull/112) - thanks to [@rcjsuen](https://github.com/rcjsuen)
+
+* updated dependency to Monaco 0.14.x, with adaptation for breaking changes from monaco [#107](https://github.com/TypeFox/monaco-languageclient/pull/107) - thanks to [@Twinside](https://github.com/Twinside)
+* ensure that SignatureHelp and SignatureHelp has non-null arrays [#112](https://github.com/TypeFox/monaco-languageclient/pull/112) - thanks to [@rcjsuen](https://github.com/rcjsuen)
 
 ## [0.7.3] - 2018-08-30
-- fixed folding ranges conversion - [12d8c91](https://github.com/TypeFox/monaco-languageclient/commit/12d8c91cf1676061c44d43e745b7500c77ea4a14)
-- implement `toJSON` for workspace configurations - [9e50a48](https://github.com/TypeFox/monaco-languageclient/commit/9e50a48addb474be66fa317684461976eda45192)
-- fixed markdown conversion [#103](https://github.com/TypeFox/monaco-languageclient/pull/103)
+
+* fixed folding ranges conversion - [12d8c91](https://github.com/TypeFox/monaco-languageclient/commit/12d8c91cf1676061c44d43e745b7500c77ea4a14)
+* implement `toJSON` for workspace configurations - [9e50a48](https://github.com/TypeFox/monaco-languageclient/commit/9e50a48addb474be66fa317684461976eda45192)
+* fixed markdown conversion [#103](https://github.com/TypeFox/monaco-languageclient/pull/103)
 
 ## [0.7.2] - 2018-08-02
-- amd distribution ([#97](https://github.com/TypeFox/monaco-languageclient/pull/97)) - thanks to [@zewa666](https://github.com/zewa666)
-- updated dependency to Monaco 0.13.2 ([#100](https://github.com/TypeFox/monaco-languageclient/pull/100))
-- register providers only for languages matching the documentSelector ([#101](https://github.com/TypeFox/monaco-languageclient/pull/101)) - thanks to [@gins3000](https://github.com/gins3000)
+
+* amd distribution ([#97](https://github.com/TypeFox/monaco-languageclient/pull/97)) - thanks to [@zewa666](https://github.com/zewa666)
+* updated dependency to Monaco 0.13.2 ([#100](https://github.com/TypeFox/monaco-languageclient/pull/100))
+* register providers only for languages matching the documentSelector ([#101](https://github.com/TypeFox/monaco-languageclient/pull/101)) - thanks to [@gins3000](https://github.com/gins3000)
 
 ## [0.7.0] - 2018-07-31
+
 Updated to `vscode-languageclient` 4.4.0 to support LSP 3.10.0 features like hierarchical document symbols, go to type defition/implementation, workspace folders and document color provider ([#89](https://github.com/TypeFox/monaco-languageclient/pull/89)).
 
 ### Breaking changes
 
 In order to use `vscode-languageclient` directly the compatibility layer was implemented for subset of `vscode` APIs used by the client:
 
-- `vscode-compatibility` should be used as an implementation of `vscode` module at the runtime
-  - to adjust module resolution with `webpack`:
+* `vscode-compatibility` should be used as an implementation of `vscode` module at the runtime
+  * to adjust module resolution with `webpack`:
+
   ```js
       resolve: {
           alias: {
@@ -131,19 +174,25 @@ In order to use `vscode-languageclient` directly the compatibility layer was imp
           }
       }
   ```
-  - `register-vscode` should be required once to adjust module resolution with `Node.js`, for example to stub `vscode` APIs for Mocha tests:
+
+  * `register-vscode` should be required once to adjust module resolution with `Node.js`, for example to stub `vscode` APIs for Mocha tests:
+
   ```
   --require monaco-languageclient/lib/register-vscode
   ```
-- `MonacoLanguageClient` should be used instead of `BaseLanguageClient`
-- `MonacoServices` should be installed globally to be accessible for `vscode-compatibility` module, not per a language client
-  - for the use case with a single standalone editor:
+
+* `MonacoLanguageClient` should be used instead of `BaseLanguageClient`
+* `MonacoServices` should be installed globally to be accessible for `vscode-compatibility` module, not per a language client
+  * for the use case with a single standalone editor:
+
   ```ts
   import { MonacoServices } from 'monaco-languageclient';
 
   MonacoServices.install(editor);
   ```
-  - to support sophisticated use cases one can install custom Monaco services:
+
+  * to support sophisticated use cases one can install custom Monaco services:
+
   ```ts
   import { MonacoServices, Services } from 'monaco-languageclient';
 
@@ -154,32 +203,38 @@ In order to use `vscode-languageclient` directly the compatibility layer was imp
   ```
 
 ## [0.6.0] - 2018-04-18
-- updated dependency to Monaco 0.12 ([#70](https://github.com/TypeFox/monaco-languageclient/pull/70))
-- support `CompletionItem`'s `additionalTextEdits` property ([#39](https://github.com/TypeFox/monaco-languageclient/issues/39))
-- convert `monaco.MarkerSeverity.Hint` values to `DiagnosticSeverity.Hint` ([#71](https://github.com/TypeFox/monaco-languageclient/pull/71))
+
+* updated dependency to Monaco 0.12 ([#70](https://github.com/TypeFox/monaco-languageclient/pull/70))
+* support `CompletionItem`'s `additionalTextEdits` property ([#39](https://github.com/TypeFox/monaco-languageclient/issues/39))
+* convert `monaco.MarkerSeverity.Hint` values to `DiagnosticSeverity.Hint` ([#71](https://github.com/TypeFox/monaco-languageclient/pull/71))
 
 ## [0.4.0] - 2018-02-13
-- add support for `textDocument/documentLink` and `documentLink/resolve` ([#53](https://github.com/TypeFox/monaco-languageclient/issues/53))
-- state that `workspace/applyEdit` is supported in the capabilities ([#55](https://github.com/TypeFox/monaco-languageclient/pull/55))
-- state that versioned changes are supported in a `WorkspaceEdit` ([#56](https://github.com/TypeFox/monaco-languageclient/pull/56))
-- replaced `monaco-editor` with `monaco-editor-core` ([#58](https://github.com/TypeFox/monaco-languageclient/pull/58))
+
+* add support for `textDocument/documentLink` and `documentLink/resolve` ([#53](https://github.com/TypeFox/monaco-languageclient/issues/53))
+* state that `workspace/applyEdit` is supported in the capabilities ([#55](https://github.com/TypeFox/monaco-languageclient/pull/55))
+* state that versioned changes are supported in a `WorkspaceEdit` ([#56](https://github.com/TypeFox/monaco-languageclient/pull/56))
+* replaced `monaco-editor` with `monaco-editor-core` ([#58](https://github.com/TypeFox/monaco-languageclient/pull/58))
 
 ## [0.3.0] - 2018-02-08
-- fix handling of `codeLens/resolve` if no provider exists ([#46](https://github.com/TypeFox/monaco-languageclient/pull/46))
-- removed `monaco-editor-core` dependency, keeping only `monaco-editor` ([#42](https://github.com/TypeFox/monaco-languageclient/issues/42))
-- fix typings in `glob-to-regexp`([#49](https://github.com/TypeFox/monaco-languageclient/pull/49))
+
+* fix handling of `codeLens/resolve` if no provider exists ([#46](https://github.com/TypeFox/monaco-languageclient/pull/46))
+* removed `monaco-editor-core` dependency, keeping only `monaco-editor` ([#42](https://github.com/TypeFox/monaco-languageclient/issues/42))
+* fix typings in `glob-to-regexp`([#49](https://github.com/TypeFox/monaco-languageclient/pull/49))
 
 ## [0.2.1] - 2018-01-14
-- allow a `rootUri` to be set with `createMonacoServices` ([#31](https://github.com/TypeFox/monaco-languageclient/issues/31))
+
+* allow a `rootUri` to be set with `createMonacoServices` ([#31](https://github.com/TypeFox/monaco-languageclient/issues/31))
 
 ## [0.2.0] - 2017-08-30
-- handle `number` value of zero in a `Diagnostic`'s `code` ([#14](https://github.com/TypeFox/monaco-languageclient/pull/14))
-- add support to lazily load Monaco ([#19](https://github.com/TypeFox/monaco-languageclient/pull/19))
-- add support for `textDocument/codeActions` and `workspace/executeCommand` ([#21](https://github.com/TypeFox/monaco-languageclient/pull/21))
-- updated dependency to Monaco 0.10 ([#29](https://github.com/TypeFox/monaco-languageclient/pull/29))
+
+* handle `number` value of zero in a `Diagnostic`'s `code` ([#14](https://github.com/TypeFox/monaco-languageclient/pull/14))
+* add support to lazily load Monaco ([#19](https://github.com/TypeFox/monaco-languageclient/pull/19))
+* add support for `textDocument/codeActions` and `workspace/executeCommand` ([#21](https://github.com/TypeFox/monaco-languageclient/pull/21))
+* updated dependency to Monaco 0.10 ([#29](https://github.com/TypeFox/monaco-languageclient/pull/29))
 
 ## 0.1.0 - 2017-0
-- initial 0.1.0 release, depends on Monaco 0.9.0
+
+* initial 0.1.0 release, depends on Monaco 0.9.0
 
 [0.13.0]: https://github.com/TypeFox/monaco-languageclient/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/TypeFox/monaco-languageclient/compare/v0.11.0...v0.12.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,17 +11,22 @@ There is no guarantee on time of response to issues and pull requests.
 
 #### Current Maintainers
 
-- @AlexTugarev - Alex Tugarev
+- @CGNonofr - Loïc Mangeonjean
 - @gatesn - Nicholas Gates
 - @mofux - Thomas Zilz
-- @akosyakov - Anton Kosyakov
 - @BroKun - Yukun Wang
 - @rcjsuen - Remy Suen
 - @asual - Rostislav Hristov
-- @zewa666 - Vildan Softic
 - @johnwiseheart - John Wiseheart
 - @RomanNikitenko - Roman Nikitenko
 - @azatsarynnyy - Artem Zatsarynnyi
+- @kaisalmen - Kai Salmen
+
+#### Past Maintainers
+
+- @AlexTugarev - Alex Tugarev
+- @akosyakov - Anton Kosyakov
+- @zewa666 - Vildan Softic
 
 #### How to become a maintainer?
 

--- a/License.txt
+++ b/License.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2018 TypeFox GmbH (http://www.typefox.io)
+Copyright (c) 2022 TypeFox GmbH (http://www.typefox.io)
 
 All rights reserved.
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "monaco-languageclient",
-    "version": "0.13.0",
+    "version": "0.17.3",
     "description": "Monaco Language client implementation",
     "author": "TypeFox GmbH (http://www.typefox.io)",
     "license": "MIT",

--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,7 @@
     "express": "^4.15.2",
     "file-loader": "^4.3.0",
     "monaco-editor-core": "^0.30.1",
-    "@codingame/monaco-languageclient": "^0.17.0",
+    "monaco-languageclient": "^0.17.3",
     "normalize-url": "^2.0.1",
     "reconnecting-websocket": "^3.2.2",
     "request-light": "^0.2.2",
@@ -21,7 +21,7 @@
     "compile": "tsc",
     "watch": "tsc -w",
     "clean": "rimraf lib",
-    "copy": "cp src/index.html lib/index.html",
+    "copy": "shx cp src/index.html lib/index.html",
     "build": "yarn run compile && webpack && yarn run copy",
     "start": "node lib/server.js",
     "start:ext": "node lib/server.js --external"

--- a/example/src/client.ts
+++ b/example/src/client.ts
@@ -7,7 +7,7 @@ import * as monaco from 'monaco-editor-core'
 import {
     MonacoLanguageClient, MessageConnection, CloseAction, ErrorAction,
     MonacoServices, createConnection
-} from '@codingame/monaco-languageclient';
+} from 'monaco-languageclient';
 import normalizeUrl = require('normalize-url');
 const ReconnectingWebSocket = require('reconnecting-websocket');
 

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -37,7 +37,7 @@ const common = {
     },
     resolve: {
         alias: {
-            'vscode': require.resolve('@codingame/monaco-languageclient/lib/vscode-compatibility')
+            'vscode': require.resolve('monaco-languageclient/lib/vscode-compatibility')
         },
         extensions: ['.js', '.json', '.ttf']
     }
@@ -65,4 +65,4 @@ if (process.env['NODE_ENV'] === 'production') {
             }]
         }
     })
-} 
+}

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -4,7 +4,7 @@
   "version": "0.13.0",
   "dependencies": {
     "file-loader": "^4.3.0",
-    "@codingame/monaco-languageclient": "^0.17.0",
+    "monaco-languageclient": "^0.17.3",
     "vscode-json-languageservice": "^4.1.9",
     "vscode-languageserver-types": "^3.16.0"
   },
@@ -13,7 +13,7 @@
     "compile": "tsc",
     "watch": "tsc -w",
     "clean": "rimraf lib",
-    "copy": "cp src/index.html lib/index.html",
+    "copy": "shx cp src/index.html lib/index.html",
     "build": "yarn run compile && webpack && yarn run copy",
     "update:file-deps": "yarn run clean:file-deps && yarn install",
     "clean:file-deps": "yarn run clean:monaco-languageclient",

--- a/examples/browser/src/client.ts
+++ b/examples/browser/src/client.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 import * as monaco from 'monaco-editor-core'
 import { getLanguageService, TextDocument } from "vscode-json-languageservice";
-import { MonacoToProtocolConverter, ProtocolToMonacoConverter } from '@codingame/monaco-languageclient/lib/monaco-converter';
+import { MonacoToProtocolConverter, ProtocolToMonacoConverter } from 'monaco-languageclient/lib/monaco-converter';
 
 const LANGUAGE_ID = 'json';
 const MODEL_URI = 'inmemory://model.json'

--- a/package.json
+++ b/package.json
@@ -9,13 +9,14 @@
     "css-loader": "^0.28.11",
     "lerna": "^3.16.4",
     "monaco-editor-core": "^0.30.1",
-    "rimraf": "^2.6.2",
+    "rimraf": "^3.0.2",
     "source-map-loader": "^0.2.3",
     "style-loader": "^0.20.3",
     "typescript": "^3.7.5",
     "uglifyjs-webpack-plugin": "^1.2.4",
     "webpack": "^3.11.0",
-    "webpack-merge": "^4.1.2"
+    "webpack-merge": "^4.1.2",
+    "shx": "^0.3.4"
   },
   "resolutions": {
     "vscode-languageserver-types": "3.16.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,17 +30,6 @@
   dependencies:
     vscode-jsonrpc "^6.0.0"
 
-"@codingame/monaco-languageclient@^0.17.0":
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/@codingame/monaco-languageclient/-/monaco-languageclient-0.17.0.tgz#ef1c42ed70392118ce4f563f6779d7bd2566b3d4"
-  integrity sha512-8DZjV02STdOEy6MY24q0hQGQtoTapW7iakUbznLglCPTPyvZxUGwu8DQ5YlaBZLnrT3hPhxCmxNdoGWOnsFtqQ==
-  dependencies:
-    glob-to-regexp "^0.4.1"
-    vscode-jsonrpc "6.0.0"
-    vscode-languageclient "7.0.0"
-    vscode-languageserver-textdocument "^1.0.1"
-    vscode-uri "^3.0.2"
-
 "@evocateur/libnpmaccess@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz#ecf7f6ce6b004e9f942b098d92200be4a4b1c845"
@@ -3411,6 +3400,18 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
+glob@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
+  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
@@ -3885,6 +3886,13 @@ is-core-module@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
   integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
+  integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
   dependencies:
     has "^1.0.3"
 
@@ -4703,7 +4711,7 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -5440,6 +5448,11 @@ path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-parse@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -6194,6 +6207,13 @@ readdirp@~3.5.0:
   dependencies:
     picomatch "^2.2.1"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
+  dependencies:
+    resolve "^1.1.6"
+
 reconnecting-websocket@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/reconnecting-websocket/-/reconnecting-websocket-3.2.2.tgz#8097514e926e9855e03c39e76efa2e3d1f371bee"
@@ -6341,6 +6361,15 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
+resolve@^1.1.6:
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
+  integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
+  dependencies:
+    is-core-module "^2.8.1"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 resolve@^1.10.0, resolve@^1.17.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
@@ -6378,6 +6407,13 @@ rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -6554,6 +6590,23 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shelljs@^0.8.5:
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
+  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
+shx@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.4.tgz#74289230b4b663979167f94e1935901406e40f02"
+  integrity sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==
+  dependencies:
+    minimist "^1.2.3"
+    shelljs "^0.8.5"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"
@@ -6970,6 +7023,11 @@ supports-color@^5.3.0, supports-color@^5.4.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
+
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 svgo@^0.7.0:
   version "0.7.2"


### PR DESCRIPTION
@CGNonofr along with updates to the CHANGELOG I did the following:

- Updated CHANGELOG with entries for 0.14.0 to 0.17.3
- Updated Current Maintainers list in CONTRIBUTING and introduced a "Past Maintainers" section
- Make build work cross-platform with shx
- Updated vscode settings
- Added .editorconfig and added editorconfig plugin recommendation
- Use monaco-languageclient again in examples