### PR TITLE
Introduce global engines entries for node and npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,10 @@
         "tslib": "^2.4.0",
         "typescript": "^4.6.4",
         "vite": "2.9.6"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.10.0"
       }
     },
     "node_modules/@codingame/monaco-jsonrpc": {
@@ -3759,7 +3763,7 @@
     },
     "packages/client": {
       "name": "monaco-languageclient",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "node": ">=16.0.0",
     "npm": ">=7.10.0"
   },
+  "volta": {
+    "node": "16.15.0",
+    "npm": "8.11.0"
+  },
   "scripts": {
     "clean": "npm run clean --workspaces && npm run clean:amd --workspace packages/client && npm run webpack:clean --workspace packages/examples/client",
     "compile": "npm run compile --workspaces",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   "resolutions": {
     "vscode-languageserver-types": "3.17.1"
   },
+  "engines": {
+    "node": ">=16.0.0",
+    "npm": ">=7.10.0"
+  },
   "scripts": {
     "clean": "npm run clean --workspaces && npm run clean:amd --workspace packages/client && npm run webpack:clean --workspace packages/examples/client",
     "compile": "npm run compile --workspaces",


### PR DESCRIPTION
Shouldn't we generally stick to node LTS? npm `7.10.0` is the npm version bundled with node `16.0.0` that's why I choose that version number.