### PR TITLE
Align all tsconfigs and vscode-ws-jsonrpc provides esm/cjs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,5 +45,9 @@ module.exports = {
         'dot-notation': 'off',
         '@typescript-eslint/dot-notation': ['error']
     },
-    ignorePatterns: ['.eslintrc.js', './packages/examples/browser-lsp/src/serverWorker.ts']
+    ignorePatterns: [
+        '.eslintrc.js',
+        'vite.config.ts',
+        'packages/examples/browser-lsp/src/serverWorker.ts'
+    ]
 };

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,27 +5,22 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "type": "node",
-            "request": "launch",
-            "name": "Launch Sample Server",
-            "program": "${workspaceRoot}/packages/examples/node/lib/server.js",
-            "sourceMaps": true,
-            "outFiles": [
-                "${workspaceRoot}/packages/examples/node/lib/**/*.js"
-            ]
+          "name": "Launch Sample Server",
+          "type": "node",
+          "request": "launch",
+          "args": ["${workspaceRoot}/packages/examples/node/src/server.ts"],
+          "runtimeArgs": ["--nolazy", "-r", "ts-node/register"],
+          "cwd": "${workspaceRoot}/packages/examples/node",
+          "internalConsoleOptions": "openOnSessionStart"
         },
         {
-            "type": "node",
-            "request": "launch",
-            "name": "Launch Sample Server (external)",
-            "program": "${workspaceRoot}/packages/examples/node/lib/server.js",
-            "args": [
-                "--external"
-            ],
-            "sourceMaps": true,
-            "outFiles": [
-                "${workspaceRoot}/packages/examples/node/lib/**/*.js"
-            ]
+          "name": "Launch Sample Server (external)",
+          "type": "node",
+          "request": "launch",
+          "args": ["${workspaceRoot}/packages/examples/node/dist/server.js", "--external"],
+          "runtimeArgs": ["--nolazy", "-r", "ts-node/register"],
+          "cwd": "${workspaceRoot}/packages/examples/node",
+          "internalConsoleOptions": "openOnSessionStart"
         },
         {
           "type": "pwa-chrome",

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Or you use a fresh dev environment in [Gitpod](https://www.gitpod.io) which is a
 
 ### Scripts Overview
 
-The main [package.json](./package.json) contains script entries applicable to the whole workspace like `clean` amd `compile`, but it also has entries for launching script from the packages (lib and examples).
+The main [package.json](./package.json) contains script entries applicable to the whole workspace like `clean` and `compile`, but it also has entries for launching script from the packages (lib and examples).
 
 For example if you want to rebuild the library you can do it in different ways. From CLI run one of:
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -5584,7 +5584,7 @@
     },
     "packages/client": {
       "name": "monaco-languageclient",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "glob-to-regexp": "0.4.1",
@@ -5673,7 +5673,7 @@
       }
     },
     "packages/vscode-ws-jsonrpc": {
-      "version": "1.0.1-dev.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "vscode-jsonrpc": "^8.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,22 +33,13 @@
         "npm": ">=7.10.0"
       }
     },
-    "node_modules/@cspotcode/source-map-consumer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/@cspotcode/source-map-support": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "dependencies": {
-        "@cspotcode/source-map-consumer": "0.8.0"
+        "@jridgewell/trace-mapping": "0.3.9"
       },
       "engines": {
         "node": ">=12"
@@ -148,6 +139,31 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
+      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
+      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4899,12 +4915,12 @@
       "dev": true
     },
     "node_modules/ts-node": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
-      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.1.tgz",
+      "integrity": "sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==",
       "dev": true,
       "dependencies": {
-        "@cspotcode/source-map-support": "0.7.0",
+        "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
@@ -4915,7 +4931,7 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.0",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       },
       "bin": {
@@ -5532,9 +5548,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.6.0.tgz",
-      "integrity": "sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -5648,16 +5664,16 @@
         "vscode-languageserver": "8.0.1",
         "vscode-uri": "^3.0.3",
         "vscode-ws-jsonrpc": "../../vscode-ws-jsonrpc",
-        "ws": "^8.5.0"
+        "ws": "^8.8.0"
       },
       "devDependencies": {
         "@types/express": "^4.17.13",
         "@types/node": "^16.11.7",
-        "ts-node": "^10.7.0"
+        "ts-node": "^10.8.1"
       }
     },
     "packages/vscode-ws-jsonrpc": {
-      "version": "1.0.0",
+      "version": "1.0.1-dev.0",
       "license": "MIT",
       "dependencies": {
         "vscode-jsonrpc": "^8.0.1"
@@ -5674,19 +5690,13 @@
     }
   },
   "dependencies": {
-    "@cspotcode/source-map-consumer": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-      "dev": true
-    },
     "@cspotcode/source-map-support": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "dev": true,
       "requires": {
-        "@cspotcode/source-map-consumer": "0.8.0"
+        "@jridgewell/trace-mapping": "0.3.9"
       }
     },
     "@discoveryjs/json-ext": {
@@ -5762,6 +5772,28 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
+      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
+      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -8458,12 +8490,12 @@
         "express": "^4.17.3",
         "normalize-url": "^7.0.3",
         "request-light": "^0.5.7",
-        "ts-node": "^10.7.0",
+        "ts-node": "^10.8.1",
         "vscode-json-languageservice": "^5.0.0",
         "vscode-languageserver": "8.0.1",
         "vscode-uri": "^3.0.3",
         "vscode-ws-jsonrpc": "../../vscode-ws-jsonrpc",
-        "ws": "^8.5.0"
+        "ws": "^8.8.0"
       }
     },
     "node-releases": {
@@ -9316,12 +9348,12 @@
       }
     },
     "ts-node": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
-      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.8.1.tgz",
+      "integrity": "sha512-Wwsnao4DQoJsN034wePSg5nZiw4YKXf56mPIAeD6wVmiv+RytNSWqc2f3fKvcUoV+Yn2+yocD71VOfQHbmVX4g==",
       "dev": true,
       "requires": {
-        "@cspotcode/source-map-support": "0.7.0",
+        "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
@@ -9332,7 +9364,7 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.0",
+        "v8-compile-cache-lib": "^3.0.1",
         "yn": "3.1.1"
       }
     },
@@ -9788,9 +9820,9 @@
       "dev": true
     },
     "ws": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.6.0.tgz",
-      "integrity": "sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
       "requires": {}
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "npm": "8.11.0"
   },
   "scripts": {
-    "clean": "npm run clean --workspaces && npm run clean:amd --workspace packages/client && npm run webpack:clean --workspace packages/examples/client",
+    "clean": "npm run clean --workspaces && npm run webpack:clean --workspace packages/examples/client",
     "compile": "npm run compile --workspaces",
     "lint": "npm run lint --workspaces",
     "dev": "vite --debug --force",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this npm module are documented in this file.
 
+## [2.0.2] - 2022-06-22
+
+* Align tsconfig and use `typesVersions` in **package.json** for proper TypeScript import support (used in node example)
+
 ## [2.0.1] - 2022-06-21
 
 * No cjs fragments to export #[388](https://github.com/TypeFox/monaco-languageclient/issues/388)
@@ -12,6 +16,11 @@ All notable changes to this npm module are documented in this file.
 * Merge monaco-jsonrpc and vscode-ws-jsonrpc into new sub package #[383](https://github.com/TypeFox/monaco-languageclient/pull/383)
 * Integrate eslint with eslint-config-standard #[385](https://github.com/TypeFox/monaco-languageclient/pull/385)
 * Add example with client and server both running in the browser #[386](https://github.com/TypeFox/monaco-languageclient/pull/386)
+
+## BREAKING CHANGES
+
+* If you use Webpack or vite for bundling, you have to remove the `vscode` alias entry from the configuration
+* If you customized monaco services, then you have to add them
 
 ## [1.1.0] - 2022-06-08
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -2,117 +2,127 @@
 
 All notable changes to this npm module are documented in this file.
 
+## 2.x.x BREAKING CHANGES
+
+v2+ of this library is dependant on [monaco-vscode-api](https://github.com/CodinGame/monaco-vscode-api) which removed all vscode-api/-compatibility related code. The change has mostly no effect on end users code, but it there two things that need to be taken into account:
+
+- If you use Webpack or vite for bundling, you have to remove the `vscode` alias entry from the configuration
+- If you customized monaco services, then you have to adjust them to the changed interface
+
+The npm packages exports the following:
+
+- `monaco-languagclient`
+- `monaco-languagclient/monaco-converters`
+- `monaco-languagclient/monaco-converters/cjs`
+
 ## [2.0.2] - 2022-06-22
 
-* Align tsconfig and use `typesVersions` in **package.json** for proper TypeScript import support (used in node example)
+- Align all tsconfigs and vscode-ws-jsonrpc provides esm/cjs #[390](https://github.com/TypeFox/monaco-languageclient/pull/390)
+  - Use `typesVersions` in **package.json*- for proper TypeScript import support (used in node example)
+  - Remove AMD and CJS builds adn exports of the main library. Only `monaco-converters` and `monaco-converters/cjs` are left
 
 ## [2.0.1] - 2022-06-21
 
-* No cjs fragments to export #[388](https://github.com/TypeFox/monaco-languageclient/issues/388)
+- No cjs fragments to export #[388](https://github.com/TypeFox/monaco-languageclient/issues/388)
 
 ## [2.0.0] - 2022-06-21
 
-* Use monaco vscode api #[373](https://github.com/TypeFox/monaco-languageclient/pull/373)
-* Merge monaco-jsonrpc and vscode-ws-jsonrpc into new sub package #[383](https://github.com/TypeFox/monaco-languageclient/pull/383)
-* Integrate eslint with eslint-config-standard #[385](https://github.com/TypeFox/monaco-languageclient/pull/385)
-* Add example with client and server both running in the browser #[386](https://github.com/TypeFox/monaco-languageclient/pull/386)
-
-## BREAKING CHANGES
-
-* If you use Webpack or vite for bundling, you have to remove the `vscode` alias entry from the configuration
-* If you customized monaco services, then you have to add them
+- Use monaco vscode api #[373](https://github.com/TypeFox/monaco-languageclient/pull/373)
+- Merge monaco-jsonrpc and vscode-ws-jsonrpc into new sub package #[383](https://github.com/TypeFox/monaco-languageclient/pull/383)
+- Integrate eslint with eslint-config-standard #[385](https://github.com/TypeFox/monaco-languageclient/pull/385)
+- Add example with client and server both running in the browser #[386](https://github.com/TypeFox/monaco-languageclient/pull/386)
 
 ## [1.1.0] - 2022-06-08
 
-* feat(package.json): export monaco-converter #[376](https://github.com/TypeFox/monaco-languageclient/pull/376)
-* Clean unregistered featured from registration requests #[372](https://github.com/TypeFox/monaco-languageclient/pull/372)
-* Introduce global engines entries for node and npm #[370](https://github.com/TypeFox/monaco-languageclient/pull/370)
-* Implement missing 3.17 api #[364](https://github.com/TypeFox/monaco-languageclient/pull/364)
-* Remove unsupported features #[362](https://github.com/TypeFox/monaco-languageclient/pull/362)
-* Do not include node code #[361](https://github.com/TypeFox/monaco-languageclient/pull/361)
+- feat(package.json): export monaco-converter #[376](https://github.com/TypeFox/monaco-languageclient/pull/376)
+- Clean unregistered featured from registration requests #[372](https://github.com/TypeFox/monaco-languageclient/pull/372)
+- Introduce global engines entries for node and npm #[370](https://github.com/TypeFox/monaco-languageclient/pull/370)
+- Implement missing 3.17 api #[364](https://github.com/TypeFox/monaco-languageclient/pull/364)
+- Remove unsupported features #[362](https://github.com/TypeFox/monaco-languageclient/pull/362)
+- Do not include node code #[361](https://github.com/TypeFox/monaco-languageclient/pull/361)
 
 ## [1.0.1] - 2022-05-21
 
-* Add some typing on the code/proto converters [#359](https://github.com/TypeFox/monaco-languageclient/pull/359)
-* Fix to vite 2.9.6 for now
+- Add some typing on the code/proto converters [#359](https://github.com/TypeFox/monaco-languageclient/pull/359)
+- Fix to vite 2.9.6 for now
 
 ## [1.0.0] - 2022-05-20
 
-* Switch to npm workspace and vite and thereby drop yarn, lerna and webpack [#340](https://github.com/TypeFox/monaco-languageclient/pull/340)
-  * Restructure project: All code is moved to packages directory
-  * Update and clean-up all dependencies
-  * Use monaco-editor in examples instead of monaco-editor-core
-  * README was fully revised
-  * Bugfixes resulting from this:
-    * fix: Fix vscode-compatibility using webpack [#342](https://github.com/TypeFox/monaco-languageclient/pull/342)
-    * Use ts-node for example [#344](https://github.com/TypeFox/monaco-languageclient/pull/344)
-    * Update README.md  [#345](https://github.com/TypeFox/monaco-languageclient/pull/345)
-    * Integrate webpack client example as second option [#353](https://github.com/TypeFox/monaco-languageclient/pull/353)
-* Make monaco workspace disposable [#330](https://github.com/TypeFox/monaco-languageclient/pull/330)
-* Update the protocol to version 3.17 [#350](https://github.com/TypeFox/monaco-languageclient/pull/350)
-* Fix code action diagnostics [#352](https://github.com/TypeFox/monaco-languageclient/pull/352)
-* Fix resolving, never overwrite by undefined [#354](https://github.com/TypeFox/monaco-languageclient/pull/354)
-* The `connectionProvider` now expects a `MessageTransports` instead of a `MessageConnection`
-* Bump version to 1.0.0
+- Switch to npm workspace and vite and thereby drop yarn, lerna and webpack [#340](https://github.com/TypeFox/monaco-languageclient/pull/340)
+  - Restructure project: All code is moved to packages directory
+  - Update and clean-up all dependencies
+  - Use monaco-editor in examples instead of monaco-editor-core
+  - README was fully revised
+  - Bugfixes resulting from this:
+    - fix: Fix vscode-compatibility using webpack [#342](https://github.com/TypeFox/monaco-languageclient/pull/342)
+    - Use ts-node for example [#344](https://github.com/TypeFox/monaco-languageclient/pull/344)
+    - Update README.md  [#345](https://github.com/TypeFox/monaco-languageclient/pull/345)
+    - Integrate webpack client example as second option [#353](https://github.com/TypeFox/monaco-languageclient/pull/353)
+- Make monaco workspace disposable [#330](https://github.com/TypeFox/monaco-languageclient/pull/330)
+- Update the protocol to version 3.17 [#350](https://github.com/TypeFox/monaco-languageclient/pull/350)
+- Fix code action diagnostics [#352](https://github.com/TypeFox/monaco-languageclient/pull/352)
+- Fix resolving, never overwrite by undefined [#354](https://github.com/TypeFox/monaco-languageclient/pull/354)
+- The `connectionProvider` now expects a `MessageTransports` instead of a `MessageConnection`
+- Bump version to 1.0.0
 
 ## [0.18.1] - 2022-03-21
 
-* Fix vscode api enum [#333](https://github.com/TypeFox/monaco-languageclient/pull/333)
+- Fix vscode api enum [#333](https://github.com/TypeFox/monaco-languageclient/pull/333)
 
 ## [0.18.0] - 2022-03-15
 
-* Update to monaco 0.33 & vscode 1.65 [#329](https://github.com/TypeFox/monaco-languageclient/pull/329)
-* Updated minor versions of vscode-languageserver-textdocument and vscode-uri and removed engines entry from client
+- Update to monaco 0.33 & vscode 1.65 [#329](https://github.com/TypeFox/monaco-languageclient/pull/329)
+- Updated minor versions of vscode-languageserver-textdocument and vscode-uri and removed engines entry from client
 
 ## [0.17.4] - 2022-02-22 (2022-03-08)
 
-* First released as @codingame/monaco-languageclient@0.17.4 on specified date
-* Release of monaco-languageclient@0.17.4 was made available on date in brackets
-* Register providers using the document selector directly [#317](https://github.com/TypeFox/monaco-languageclient/pull/317)
+- First released as @codingame/monaco-languageclient@0.17.4 on specified date
+- Release of monaco-languageclient@0.17.4 was made available on date in brackets
+- Register providers using the document selector directly [#317](https://github.com/TypeFox/monaco-languageclient/pull/317)
 
 ## [0.17.3] - 2021-12-21 (2022-02-23)
 
-* First released as @codingame/monaco-languageclient@0.17.3 on specified date
-* Release of monaco-languageclient@0.17.3 was made available on date in brackets
-* Releases `0.17.1` and `0.17.2` were mistakes
-* Fix various issues: outdated api, missing stuff in compatibility-api... [#309](https://github.com/TypeFox/monaco-languageclient/pull/309)
+- First released as @codingame/monaco-languageclient@0.17.3 on specified date
+- Release of monaco-languageclient@0.17.3 was made available on date in brackets
+- Releases `0.17.1` and `0.17.2` were mistakes
+- Fix various issues: outdated api, missing stuff in compatibility-api... [#309](https://github.com/TypeFox/monaco-languageclient/pull/309)
 
 ## [0.17.0] - 2021-11-10 (2022-02-23)
 
-* First released as @codingame/monaco-languageclient@0.17.0 on specified date
-* Release of monaco-languageclient@0.17.0 was made available on date in brackets
-* Update to monaco 0.30.1 [#301](https://github.com/TypeFox/monaco-languageclient/pull/301)
+- First released as @codingame/monaco-languageclient@0.17.0 on specified date
+- Release of monaco-languageclient@0.17.0 was made available on date in brackets
+- Update to monaco 0.30.1 [#301](https://github.com/TypeFox/monaco-languageclient/pull/301)
 
 ## [0.16.1] - 2021-11-03 (2022-02-23)
 
-* First released as @codingame/monaco-languageclient@0.16.1 on specified date
-* Release of monaco-languageclient@0.16.1 was made available on date in brackets
-* Fix dropped tags in Diagnostic -> IMarkerData [#297](https://github.com/TypeFox/monaco-languageclient/pull/297)
-* Missing protocol convention [#298](https://github.com/TypeFox/monaco-languageclient/pull/298)
+- First released as @codingame/monaco-languageclient@0.16.1 on specified date
+- Release of monaco-languageclient@0.16.1 was made available on date in brackets
+- Fix dropped tags in Diagnostic -> IMarkerData [#297](https://github.com/TypeFox/monaco-languageclient/pull/297)
+- Missing protocol convention [#298](https://github.com/TypeFox/monaco-languageclient/pull/298)
 
 ## [0.16.0] - 2021-10-11 (2022-02-23)
 
-* First released as @codingame/monaco-languageclient@0.16.0 on specified date
-* Release of monaco-languageclient@0.15.1 was made available on date in brackets
-* Updated `monaco-editor-core` version to `0.29.0`
-* Async resolve code actions [#294](https://github.com/TypeFox/monaco-languageclient/pull/294)
+- First released as @codingame/monaco-languageclient@0.16.0 on specified date
+- Release of monaco-languageclient@0.15.1 was made available on date in brackets
+- Updated `monaco-editor-core` version to `0.29.0`
+- Async resolve code actions [#294](https://github.com/TypeFox/monaco-languageclient/pull/294)
 
 ## [0.15.1] - 2021-09-20 (2022-02-23)
 
-* First released as @codingame/monaco-languageclient@0.15.1 on specified date
-* Release of monaco-languageclient@0.15.1 was made available on date in brackets
-* Resolve code actions [#290](https://github.com/TypeFox/monaco-languageclient/pull/290)
-* Release `0.15.0` was skipped
+- First released as @codingame/monaco-languageclient@0.15.1 on specified date
+- Release of monaco-languageclient@0.15.1 was made available on date in brackets
+- Resolve code actions [#290](https://github.com/TypeFox/monaco-languageclient/pull/290)
+- Release `0.15.0` was skipped
 
 ## [0.14.0] - 2021-08-05 (2022-02-23)
 
-* First released as @codingame/monaco-languageclient@0.14.0 on specified date
-* Release of monaco-languageclient@0.14.0 was made available on date in brackets
-* Upgraded to Monaco 0.22.3
+- First released as @codingame/monaco-languageclient@0.14.0 on specified date
+- Release of monaco-languageclient@0.14.0 was made available on date in brackets
+- Upgraded to Monaco 0.22.3
 
 ### Breaking changes
 
-* `MonacoServices` now takes the `monaco` object instead of the `CommandRegistry`
+- `MonacoServices` now takes the `monaco` object instead of the `CommandRegistry`
 
 before:
 
@@ -123,12 +133,12 @@ MonacoServices.install(require('monaco-editor-core/esm/vs/platform/commands/comm
 after:
 
 ```typescript
-import * as monaco from 'monaco-editor-core'
+import - as monaco from 'monaco-editor-core'
 
 MonacoServices.install(monaco);
 ```
 
-* `MonacoServices` should now be installed using the command registry instead of the editor
+- `MonacoServices` should now be installed using the command registry instead of the editor
 
 before:
 
@@ -145,33 +155,33 @@ MonacoServices.install(require('monaco-editor-core/esm/vs/platform/commands/comm
 
 ## [0.13.0] - 2020-04-06
 
-* Upgraded to vscode-uri 2.x [741a3df](https://github.com/TypeFox/monaco-languageclient/commit/741a3dfb865eff55c3dcc4a51f74759921d3f2a5)
+- Upgraded to vscode-uri 2.x [741a3df](https://github.com/TypeFox/monaco-languageclient/commit/741a3dfb865eff55c3dcc4a51f74759921d3f2a5)
 
 ## [0.12.0] - 2020-03-19
 
-* Upgraded to Monaco 0.19.1 [#199](https://github.com/TypeFox/monaco-languageclient/pull/199)
+- Upgraded to Monaco 0.19.1 [#199](https://github.com/TypeFox/monaco-languageclient/pull/199)
 
 ## [0.11.0] - 2020-01-23
 
-* Upgraded to Monaco 0.18.1 [#178](https://github.com/TypeFox/monaco-languageclient/pull/178)
+- Upgraded to Monaco 0.18.1 [#178](https://github.com/TypeFox/monaco-languageclient/pull/178)
 
 ## [0.10.2] - 2019-09-10
 
-* register language features regardless whether a language is registered (<https://github.com/TypeFox/monaco-languageclient/commit/0559be6c20744182ede699f594fdbe6d9f3d7145>)
+- register language features regardless whether a language is registered (<https://github.com/TypeFox/monaco-languageclient/commit/0559be6c20744182ede699f594fdbe6d9f3d7145>)
 
 ## [0.10.1] - 2019-09-04
 
-* aligned CompletionItemKind with Monaco 0.17.0 [#174](https://github.com/TypeFox/monaco-languageclient/pull/174)
+- aligned CompletionItemKind with Monaco 0.17.0 [#174](https://github.com/TypeFox/monaco-languageclient/pull/174)
 
 ## [0.10.0] - 2019-08-26
 
-* upgraded to LSP 5.3.0 and Monaco 0.17.0
+- upgraded to LSP 5.3.0 and Monaco 0.17.0
 
 ### Breaking changes
 
 Switch to es6 from es5. For clients who cannot migrate to es6 please use babel to transpile Monaco and LSP to es5.
 
-* to configure babel wit webpack:
+- to configure babel wit webpack:
 
 ```js
     {
@@ -198,31 +208,31 @@ Switch to es6 from es5. For clients who cannot migrate to es6 please use babel t
 
 ## [0.9.0] - 2018-09-06
 
-* use monaco-editor-core as a dev dependency to allow alternative implementations [#119](https://github.com/TypeFox/monaco-languageclient/pull/119)
+- use monaco-editor-core as a dev dependency to allow alternative implementations [#119](https://github.com/TypeFox/monaco-languageclient/pull/119)
 
 ### Breaking changes
 
 Clients have to explicitly declare a dependency to `monaco-editor-core` or another package providing Monaco:
 
-* `monaco-editor-core` is tree shaked to get rid of unused VS Code's code.
-* [@typefox/monaco-editor-core](https://www.npmjs.com/package/@typefox/monaco-editor-core) is a not tree-shaked alternative.
+- `monaco-editor-core` is tree shaked to get rid of unused VS Code's code.
+- [@typefox/monaco-editor-core](https://www.npmjs.com/package/@typefox/monaco-editor-core) is a not tree-shaked alternative.
 
 ## [0.8.0] - 2018-09-04
 
-* updated dependency to Monaco 0.14.x, with adaptation for breaking changes from monaco [#107](https://github.com/TypeFox/monaco-languageclient/pull/107) - thanks to [@Twinside](https://github.com/Twinside)
-* ensure that SignatureHelp and SignatureHelp has non-null arrays [#112](https://github.com/TypeFox/monaco-languageclient/pull/112) - thanks to [@rcjsuen](https://github.com/rcjsuen)
+- updated dependency to Monaco 0.14.x, with adaptation for breaking changes from monaco [#107](https://github.com/TypeFox/monaco-languageclient/pull/107) - thanks to [@Twinside](https://github.com/Twinside)
+- ensure that SignatureHelp and SignatureHelp has non-null arrays [#112](https://github.com/TypeFox/monaco-languageclient/pull/112) - thanks to [@rcjsuen](https://github.com/rcjsuen)
 
 ## [0.7.3] - 2018-08-30
 
-* fixed folding ranges conversion - [12d8c91](https://github.com/TypeFox/monaco-languageclient/commit/12d8c91cf1676061c44d43e745b7500c77ea4a14)
-* implement `toJSON` for workspace configurations - [9e50a48](https://github.com/TypeFox/monaco-languageclient/commit/9e50a48addb474be66fa317684461976eda45192)
-* fixed markdown conversion [#103](https://github.com/TypeFox/monaco-languageclient/pull/103)
+- fixed folding ranges conversion - [12d8c91](https://github.com/TypeFox/monaco-languageclient/commit/12d8c91cf1676061c44d43e745b7500c77ea4a14)
+- implement `toJSON` for workspace configurations - [9e50a48](https://github.com/TypeFox/monaco-languageclient/commit/9e50a48addb474be66fa317684461976eda45192)
+- fixed markdown conversion [#103](https://github.com/TypeFox/monaco-languageclient/pull/103)
 
 ## [0.7.2] - 2018-08-02
 
-* amd distribution ([#97](https://github.com/TypeFox/monaco-languageclient/pull/97)) - thanks to [@zewa666](https://github.com/zewa666)
-* updated dependency to Monaco 0.13.2 ([#100](https://github.com/TypeFox/monaco-languageclient/pull/100))
-* register providers only for languages matching the documentSelector ([#101](https://github.com/TypeFox/monaco-languageclient/pull/101)) - thanks to [@gins3000](https://github.com/gins3000)
+- amd distribution ([#97](https://github.com/TypeFox/monaco-languageclient/pull/97)) - thanks to [@zewa666](https://github.com/zewa666)
+- updated dependency to Monaco 0.13.2 ([#100](https://github.com/TypeFox/monaco-languageclient/pull/100))
+- register providers only for languages matching the documentSelector ([#101](https://github.com/TypeFox/monaco-languageclient/pull/101)) - thanks to [@gins3000](https://github.com/gins3000)
 
 ## [0.7.0] - 2018-07-31
 
@@ -232,8 +242,8 @@ Updated to `vscode-languageclient` 4.4.0 to support LSP 3.10.0 features like hie
 
 In order to use `vscode-languageclient` directly the compatibility layer was implemented for subset of `vscode` APIs used by the client:
 
-* `vscode-compatibility` should be used as an implementation of `vscode` module at the runtime
-  * to adjust module resolution with `webpack`:
+- `vscode-compatibility` should be used as an implementation of `vscode` module at the runtime
+  - to adjust module resolution with `webpack`:
 
   ```js
       resolve: {
@@ -243,15 +253,15 @@ In order to use `vscode-languageclient` directly the compatibility layer was imp
       }
   ```
 
-  * `register-vscode` should be required once to adjust module resolution with `Node.js`, for example to stub `vscode` APIs for Mocha tests:
+  - `register-vscode` should be required once to adjust module resolution with `Node.js`, for example to stub `vscode` APIs for Mocha tests:
 
   ```
   --require monaco-languageclient/lib/register-vscode
   ```
 
-* `MonacoLanguageClient` should be used instead of `BaseLanguageClient`
-* `MonacoServices` should be installed globally to be accessible for `vscode-compatibility` module, not per a language client
-  * for the use case with a single standalone editor:
+- `MonacoLanguageClient` should be used instead of `BaseLanguageClient`
+- `MonacoServices` should be installed globally to be accessible for `vscode-compatibility` module, not per a language client
+  - for the use case with a single standalone editor:
 
   ```ts
   import { MonacoServices } from 'monaco-languageclient';
@@ -259,7 +269,7 @@ In order to use `vscode-languageclient` directly the compatibility layer was imp
   MonacoServices.install(editor);
   ```
 
-  * to support sophisticated use cases one can install custom Monaco services:
+  - to support sophisticated use cases one can install custom Monaco services:
 
   ```ts
   import { MonacoServices, Services } from 'monaco-languageclient';
@@ -272,37 +282,37 @@ In order to use `vscode-languageclient` directly the compatibility layer was imp
 
 ## [0.6.0] - 2018-04-18
 
-* updated dependency to Monaco 0.12 ([#70](https://github.com/TypeFox/monaco-languageclient/pull/70))
-* support `CompletionItem`'s `additionalTextEdits` property ([#39](https://github.com/TypeFox/monaco-languageclient/issues/39))
-* convert `monaco.MarkerSeverity.Hint` values to `DiagnosticSeverity.Hint` ([#71](https://github.com/TypeFox/monaco-languageclient/pull/71))
+- updated dependency to Monaco 0.12 ([#70](https://github.com/TypeFox/monaco-languageclient/pull/70))
+- support `CompletionItem`'s `additionalTextEdits` property ([#39](https://github.com/TypeFox/monaco-languageclient/issues/39))
+- convert `monaco.MarkerSeverity.Hint` values to `DiagnosticSeverity.Hint` ([#71](https://github.com/TypeFox/monaco-languageclient/pull/71))
 
 ## [0.4.0] - 2018-02-13
 
-* add support for `textDocument/documentLink` and `documentLink/resolve` ([#53](https://github.com/TypeFox/monaco-languageclient/issues/53))
-* state that `workspace/applyEdit` is supported in the capabilities ([#55](https://github.com/TypeFox/monaco-languageclient/pull/55))
-* state that versioned changes are supported in a `WorkspaceEdit` ([#56](https://github.com/TypeFox/monaco-languageclient/pull/56))
-* replaced `monaco-editor` with `monaco-editor-core` ([#58](https://github.com/TypeFox/monaco-languageclient/pull/58))
+- add support for `textDocument/documentLink` and `documentLink/resolve` ([#53](https://github.com/TypeFox/monaco-languageclient/issues/53))
+- state that `workspace/applyEdit` is supported in the capabilities ([#55](https://github.com/TypeFox/monaco-languageclient/pull/55))
+- state that versioned changes are supported in a `WorkspaceEdit` ([#56](https://github.com/TypeFox/monaco-languageclient/pull/56))
+- replaced `monaco-editor` with `monaco-editor-core` ([#58](https://github.com/TypeFox/monaco-languageclient/pull/58))
 
 ## [0.3.0] - 2018-02-08
 
-* fix handling of `codeLens/resolve` if no provider exists ([#46](https://github.com/TypeFox/monaco-languageclient/pull/46))
-* removed `monaco-editor-core` dependency, keeping only `monaco-editor` ([#42](https://github.com/TypeFox/monaco-languageclient/issues/42))
-* fix typings in `glob-to-regexp`([#49](https://github.com/TypeFox/monaco-languageclient/pull/49))
+- fix handling of `codeLens/resolve` if no provider exists ([#46](https://github.com/TypeFox/monaco-languageclient/pull/46))
+- removed `monaco-editor-core` dependency, keeping only `monaco-editor` ([#42](https://github.com/TypeFox/monaco-languageclient/issues/42))
+- fix typings in `glob-to-regexp`([#49](https://github.com/TypeFox/monaco-languageclient/pull/49))
 
 ## [0.2.1] - 2018-01-14
 
-* allow a `rootUri` to be set with `createMonacoServices` ([#31](https://github.com/TypeFox/monaco-languageclient/issues/31))
+- allow a `rootUri` to be set with `createMonacoServices` ([#31](https://github.com/TypeFox/monaco-languageclient/issues/31))
 
 ## [0.2.0] - 2017-08-30
 
-* handle `number` value of zero in a `Diagnostic`'s `code` ([#14](https://github.com/TypeFox/monaco-languageclient/pull/14))
-* add support to lazily load Monaco ([#19](https://github.com/TypeFox/monaco-languageclient/pull/19))
-* add support for `textDocument/codeActions` and `workspace/executeCommand` ([#21](https://github.com/TypeFox/monaco-languageclient/pull/21))
-* updated dependency to Monaco 0.10 ([#29](https://github.com/TypeFox/monaco-languageclient/pull/29))
+- handle `number` value of zero in a `Diagnostic`'s `code` ([#14](https://github.com/TypeFox/monaco-languageclient/pull/14))
+- add support to lazily load Monaco ([#19](https://github.com/TypeFox/monaco-languageclient/pull/19))
+- add support for `textDocument/codeActions` and `workspace/executeCommand` ([#21](https://github.com/TypeFox/monaco-languageclient/pull/21))
+- updated dependency to Monaco 0.10 ([#29](https://github.com/TypeFox/monaco-languageclient/pull/29))
 
 ## 0.1.0 - 2017-0
 
-* initial 0.1.0 release, depends on Monaco 0.9.0
+- initial 0.1.0 release, depends on Monaco 0.9.0
 
 [0.13.0]: https://github.com/TypeFox/monaco-languageclient/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/TypeFox/monaco-languageclient/compare/v0.11.0...v0.12.0

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -27,33 +27,18 @@
       "types": "./lib/monaco-converter.d.ts",
       "default": "./lib/monaco-converter.js"
     },
-    "./cjs": {
-      "types": "./dist/cjs/index.d.ts",
-      "default": "./dist/cjs/index.js"
-    },
     "./cjs/monaco-converter": {
       "types": "./dist/cjs/monaco-converter.d.ts",
       "default": "./dist/cjs/monaco-converter.js"
-    },
-    "./amd": {
-      "types": "./dist/amd/index.d.ts",
-      "default": "./dist/amd/index.js"
-    },
-    "./amd/monaco-converter": {
-      "types": "./dist/amd/monaco-converter.d.ts",
-      "default": "./dist/amd/monaco-converter.js"
     }
   },
   "typesVersions": {
     "*": {
-      "cjs": [ "dist/cjs/index" ],
-      "amd": [ "dist/amd/index" ],
       "monaco-converter": [ "lib/monaco-converter" ],
       "monaco-converter/cjs": [ "dist/cjs/monaco-converter" ]
     }
   },
   "files": [
-    "dist/amd",
     "dist/cjs",
     "lib",
     "src",
@@ -76,13 +61,11 @@
   },
   "scripts": {
     "clean": "npx shx rm -fr lib tsconfig.tsbuildinfo",
-    "clean:amd": "npx shx rm -fr dist/amd dist/tsconfig.tsbuildinfo",
-    "clean:cjs": "npx shx rm -fr dist/cjs dist/tsconfig.tsbuildinfo",
+    "clean:cjs": "npx shx rm -fr dist",
     "lint": "eslint src --ext .ts",
     "compile": "tsc",
     "watch": "tsc -w",
-    "build:amd": "npm run clean:amd && tsc --outDir dist/amd --module amd --declarationDir dist/amd --declaration",
-    "build:cjs": "npm run clean:cjs && tsc --outDir dist/cjs --module commonjs --declarationDir dist/cjs --declaration",
-    "build": "npm run clean && npm run compile && npm run build:amd && npm run build:cjs"
+    "build:cjs": "npm run clean:cjs && tsc -p ./tsconfig.cjs.json",
+    "build": "npm run clean && npm run compile && npm run build:cjs"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,11 +1,12 @@
 {
   "name": "monaco-languageclient",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Monaco Language client implementation",
   "author": {
     "name": "TypeFox GmbH ",
     "url": "http://www.typefox.io"
   },
+  "homepage": "https://github.com/TypeFox/monaco-languageclient/blob/main/packages/client/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -15,6 +16,7 @@
     "url": "https://github.com/TypeFox/monaco-languageclient/issues"
   },
   "main": "./lib/index.js",
+  "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "exports": {
     ".": {
@@ -25,21 +27,29 @@
       "types": "./lib/monaco-converter.d.ts",
       "default": "./lib/monaco-converter.js"
     },
-    "./cjs/monaco-converter": {
-      "types": "./dist/cjs/monaco-converter.d.ts",
-      "default": "./dist/cjs/monaco-converter.js"
-    },
     "./cjs": {
       "types": "./dist/cjs/index.d.ts",
       "default": "./dist/cjs/index.js"
     },
-    "./amd/monaco-converter": {
-      "types": "./dist/amd/monaco-converter.d.ts",
-      "default": "./dist/amd/monaco-converter.js"
+    "./cjs/monaco-converter": {
+      "types": "./dist/cjs/monaco-converter.d.ts",
+      "default": "./dist/cjs/monaco-converter.js"
     },
     "./amd": {
       "types": "./dist/amd/index.d.ts",
       "default": "./dist/amd/index.js"
+    },
+    "./amd/monaco-converter": {
+      "types": "./dist/amd/monaco-converter.d.ts",
+      "default": "./dist/amd/monaco-converter.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "cjs": [ "dist/cjs/index" ],
+      "amd": [ "dist/amd/index" ],
+      "monaco-converter": [ "lib/monaco-converter" ],
+      "monaco-converter/cjs": [ "dist/cjs/monaco-converter" ]
     }
   },
   "files": [
@@ -66,11 +76,11 @@
   },
   "scripts": {
     "clean": "npx shx rm -fr lib tsconfig.tsbuildinfo",
+    "clean:amd": "npx shx rm -fr dist/amd dist/tsconfig.tsbuildinfo",
+    "clean:cjs": "npx shx rm -fr dist/cjs dist/tsconfig.tsbuildinfo",
     "lint": "eslint src --ext .ts",
     "compile": "tsc",
     "watch": "tsc -w",
-    "clean:amd": "npx shx rm -fr dist/amd",
-    "clean:cjs": "npx shx rm -fr dist/cjs",
     "build:amd": "npm run clean:amd && tsc --outDir dist/amd --module amd --declarationDir dist/amd --declaration",
     "build:cjs": "npm run clean:cjs && tsc --outDir dist/cjs --module commonjs --declarationDir dist/cjs --declaration",
     "build": "npm run clean && npm run compile && npm run build:amd && npm run build:cjs"

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -10,6 +10,6 @@ export * from './monaco-services';
 export * from './monaco-converter';
 
 export {
-    Disposable, CancellationToken, Event, Emitter
+    CancellationToken, Event, Emitter
 } from 'vscode-jsonrpc/lib/common/api';
 export * from 'vscode-languageserver-protocol/lib/common/api';

--- a/packages/client/tsconfig.cjs.json
+++ b/packages/client/tsconfig.cjs.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist/cjs",
+    "declarationDir": "dist/cjs",
+    "noUnusedParameters": false,
+    "module": "CommonJS"
+  },
+  "include": [
+    "src/monaco-converter.ts",
+  ],
+  "exclude": [
+    "dist",
+    "lib",
+    "node_modules"
+  ]
+}

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,22 +1,16 @@
 {
   "extends": "../../tsconfig",
   "compilerOptions": {
-      "rootDir": "src",
-      "outDir": "lib",
-      "declarationDir": "lib",
-      "target": "es2020",
-      "module": "es2020",
-      "moduleResolution": "node",
-      "lib": [
-        "es2016",
-        "dom"
-      ],
-      "noUnusedParameters": false
+    "rootDir": "src",
+    "outDir": "lib",
+    "declarationDir": "lib",
+    "noUnusedParameters": false
   },
   "include": [
-      "src/**/*"
+    "src/**/*.ts",
   ],
   "exclude": [
+    "dist",
     "lib",
     "node_modules"
   ]

--- a/packages/examples/browser-lsp/tsconfig.json
+++ b/packages/examples/browser-lsp/tsconfig.json
@@ -4,15 +4,19 @@
     "rootDir": "src",
     "outDir": "dist",
     "declarationDir": "dist",
-    "module": "ES2020",
-    "lib": ["ES2020", "dom", "WebWorker"]
+    "lib": [
+      "ES2020",
+      "dom",
+      "WebWorker"
+    ]
   },
-  "references": [{ "path": "../../client" }],
+  "references": [{
+    "path": "../../client"
+  }],
   "include": [
     "src/**/*.ts",
   ],
   "exclude": [
-    "src/dist",
-    "node_modules"
+    "dist"
   ]
 }

--- a/packages/examples/browser-old/tsconfig.json
+++ b/packages/examples/browser-old/tsconfig.json
@@ -3,16 +3,15 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "declarationDir": "dist",
-    "module": "ES2020",
-    "lib": ["ES2020", "dom"]
+    "declarationDir": "dist"
   },
-  "references": [{ "path": "../../client" }],
+  "references": [{
+    "path": "../../client"
+  }],
   "include": [
-      "src/**/*.ts"
+    "src/**/*.ts"
   ],
   "exclude": [
-    "dist",
-    "node_modules"
+    "dist"
   ]
 }

--- a/packages/examples/browser/tsconfig.json
+++ b/packages/examples/browser/tsconfig.json
@@ -3,16 +3,15 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "declarationDir": "dist",
-    "module": "ES2020",
-    "lib": ["ES2020", "dom"]
+    "declarationDir": "dist"
   },
-  "references": [{ "path": "../../client" }],
+  "references": [{
+    "path": "../../client"
+  }],
   "include": [
-      "src/**/*.ts"
+    "src/**/*.ts"
   ],
   "exclude": [
-    "dist",
-    "node_modules"
+    "dist"
   ]
 }

--- a/packages/examples/client/tsconfig.json
+++ b/packages/examples/client/tsconfig.json
@@ -4,15 +4,15 @@
     "rootDir": "src",
     "outDir": "dist",
     "declarationDir": "dist",
-    "module": "ES2020",
-    "lib": ["ES2020", "dom"]
   },
-  "references": [{ "path": "../../client" }],
+  "references": [{
+    "path": "../../client"
+  }],
   "include": [
     "src/**/*.ts",
   ],
   "exclude": [
-    "src/dist",
-    "node_modules"
+    "dist",
+    "webpack/dist"
   ]
 }

--- a/packages/examples/node/package.json
+++ b/packages/examples/node/package.json
@@ -10,20 +10,21 @@
     "vscode-json-languageservice": "^5.0.0",
     "vscode-languageserver": "8.0.1",
     "vscode-uri": "^3.0.3",
-    "ws": "^8.5.0"
+    "ws": "^8.8.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.13",
     "@types/node": "^16.11.7",
-    "ts-node": "^10.7.0"
+    "ts-node": "^10.8.1"
   },
   "scripts": {
-    "clean": "npx shx rm -fr lib tsconfig.tsbuildinfo",
+    "clean": "npx shx rm -fr dist tsconfig.tsbuildinfo",
     "lint": "eslint src --ext .ts",
     "compile": "tsc -b .",
     "build": "npm run clean && npm run compile",
     "watch": "tsc -w",
     "start": "node -r ts-node/register src/server.ts",
-    "start:ext": "node -r ts-node/register lib/server.js --external"
+    "start:alt": "node dist/server.js",
+    "start:ext": "node -r ts-node/register src/server.ts --external"
   }
 }

--- a/packages/examples/node/src/json-server-launcher.ts
+++ b/packages/examples/node/src/json-server-launcher.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import * as path from 'path';
-import * as rpc from 'vscode-ws-jsonrpc';
-import * as server from 'vscode-ws-jsonrpc/lib/server';
+import * as rpc from 'vscode-ws-jsonrpc/cjs';
+import * as server from 'vscode-ws-jsonrpc/cjs/server';
 import * as lsp from 'vscode-languageserver';
 import { start } from './json-server';
 import { Message } from 'vscode-languageserver';

--- a/packages/examples/node/src/server.ts
+++ b/packages/examples/node/src/server.ts
@@ -7,7 +7,7 @@ import * as http from 'http';
 import * as url from 'url';
 import * as net from 'net';
 import express from 'express';
-import * as rpc from 'vscode-ws-jsonrpc';
+import * as rpc from 'vscode-ws-jsonrpc/cjs';
 import { launch } from './json-server-launcher';
 
 process.on('uncaughtException', function (err: any) {
@@ -29,7 +29,8 @@ const wss = new ws.Server({
     perMessageDeflate: false
 });
 server.on('upgrade', (request: http.IncomingMessage, socket: net.Socket, head: Buffer) => {
-    const pathname = request.url ? new url.URL(request.url).pathname : undefined;
+    // eslint-disable-next-line n/no-deprecated-api
+    const pathname = request.url ? url.parse(request.url).pathname : undefined;
     if (pathname === '/sampleServer') {
         wss.handleUpgrade(request, socket, head, webSocket => {
             const socket: rpc.IWebSocket = {

--- a/packages/examples/node/tsconfig.json
+++ b/packages/examples/node/tsconfig.json
@@ -1,16 +1,21 @@
 {
   "extends": "../../../tsconfig",
   "compilerOptions": {
-      "rootDir": "src",
-      "outDir": "lib",
-      "declarationDir": "lib"
+    "rootDir": "src",
+    "outDir": "dist",
+    "declarationDir": "dist",
+    "module": "CommonJS"
   },
-  "references": [{ "path": "../../client" }],
+  "references": [{
+    "path": "../../client"
+  },
+  {
+    "path": "../../vscode-ws-jsonrpc"
+  }],
   "include": [
-      "src/**/*"
+      "src/**/*.ts"
   ],
   "exclude": [
-    "dist",
-    "node_modules"
+    "dist"
   ]
 }

--- a/packages/vscode-ws-jsonrpc/CHANGELOG.md
+++ b/packages/vscode-ws-jsonrpc/CHANGELOG.md
@@ -2,13 +2,25 @@
 
 All notable changes to this npm module are documented in this file.
 
+## 1.x.x BREAKING CHANGES
+
+The default export now provides esm code. If you require CommonJS modules you can use the additional exports.
+The npm packages exports the following:
+
+- `vscode-ws-jsonrpc`
+- `vscode-ws-jsonrpc/server`
+- `vscode-ws-jsonrpc/socket`
+- `vscode-ws-jsonrpc/cjs`
+- `vscode-ws-jsonrpc/cjs/server`
+- `vscode-ws-jsonrpc/cjs/socket`
+
 ## [1.0.1] - 2022-06-22
 
-* Library ships as src, esm and cjs builds. Use `typesVersions` in **package.json** for proper TypeScript import support
+- Library ships as src, esm and cjs builds. Use `typesVersions` in **package.json** for proper TypeScript import support
 
 ## [1.0.0] - 2022-06-21
 
-* Merged npm packages `@codingame/monaco-jsonrpc` and `vscode-ws-jsonrpc` into this package.
-* Integrate eslint with eslint-config-standard #[385](https://github.com/TypeFox/monaco-languageclient/pull/385)
+- Merged npm packages `@codingame/monaco-jsonrpc` and `vscode-ws-jsonrpc` into this package.
+- Integrate eslint with eslint-config-standard #[385](https://github.com/TypeFox/monaco-languageclient/pull/385)
 
 There was no CHANGELOG available in the previous repositories.

--- a/packages/vscode-ws-jsonrpc/CHANGELOG.md
+++ b/packages/vscode-ws-jsonrpc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this npm module are documented in this file.
 
+## [1.0.1] - 2022-06-22
+
+* Library ships as src, esm and cjs builds. Use `typesVersions` in **package.json** for proper TypeScript import support
+
 ## [1.0.0] - 2022-06-21
 
 * Merged npm packages `@codingame/monaco-jsonrpc` and `vscode-ws-jsonrpc` into this package.

--- a/packages/vscode-ws-jsonrpc/package.json
+++ b/packages/vscode-ws-jsonrpc/package.json
@@ -69,11 +69,11 @@
   },
   "scripts": {
     "clean": "npx shx rm -fr lib tsconfig.tsbuildinfo",
-    "clean:cjs": "npx shx rm -fr dist/cjs dist/tsconfig.tsbuildinfo",
+    "clean:cjs": "npx shx rm -fr dist",
     "lint": "eslint src --ext .ts",
     "compile": "tsc",
     "watch": "tsc -w",
-    "build:cjs": "npm run clean:cjs && tsc --outDir dist/cjs --module commonjs --declarationDir dist/cjs --declaration",
+    "build:cjs": "npm run clean:cjs && tsc -p ./tsconfig.cjs.json",
     "build": "npm run clean && npm run compile && npm run build:cjs"
   }
 }

--- a/packages/vscode-ws-jsonrpc/package.json
+++ b/packages/vscode-ws-jsonrpc/package.json
@@ -1,8 +1,12 @@
 {
   "name": "vscode-ws-jsonrpc",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "VSCode JSON RPC over WebSocket",
-  "author": "TypeFox GmbH (http://www.typefox.io)",
+  "author": {
+    "name": "TypeFox GmbH ",
+    "url": "http://www.typefox.io"
+  },
+  "homepage": "https://github.com/TypeFox/monaco-languageclient/blob/main/packages/client/README.md",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -12,8 +16,45 @@
     "url": "https://github.com/TypeFox/monaco-languageclient/issues"
   },
   "main": "./lib/index.js",
+  "module": "./lib/index.js",
   "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/index.d.ts",
+      "default": "./lib/index.js"
+    },
+    "./server": {
+      "types": "./lib/server/index.d.ts",
+      "default": "./lib/server/index.js"
+    },
+    "./socket": {
+      "types": "./lib/socket/index.d.ts",
+      "default": "./lib/socket/index.js"
+    },
+    "./cjs": {
+      "types": "./dist/cjs/index.d.ts",
+      "default": "./dist/cjs/index.js"
+    },
+    "./cjs/server": {
+      "types": "./dist/cjs/server/index.d.ts",
+      "default": "./dist/cjs/server/index.js"
+    },
+    "./cjs/socket": {
+      "types": "./dist/cjs/socket/index.d.ts",
+      "default": "./dist/cjs/socket/index.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "server": [ "lib/server" ],
+      "socket": [ "lib/server" ],
+      "cjs": [ "dist/cjs/index" ],
+      "cjs/server": [ "dist/cjs/server/index" ],
+      "cjs/socket": [ "dist/cjs/server/index" ]
+    }
+  },
   "files": [
+    "dist/cjs",
     "lib",
     "src",
     "README.md",
@@ -28,13 +69,11 @@
   },
   "scripts": {
     "clean": "npx shx rm -fr lib tsconfig.tsbuildinfo",
+    "clean:cjs": "npx shx rm -fr dist/cjs dist/tsconfig.tsbuildinfo",
     "lint": "eslint src --ext .ts",
     "compile": "tsc",
     "watch": "tsc -w",
-    "build": "npm run clean && npm run compile"
-  },
-  "homepage": "https://github.com/TypeFox/monaco-languageclient/blob/main/packages/vscode-ws-jsonrpc/README.md",
-  "directories": {
-    "lib": "lib"
+    "build:cjs": "npm run clean:cjs && tsc --outDir dist/cjs --module commonjs --declarationDir dist/cjs --declaration",
+    "build": "npm run clean && npm run compile && npm run build:cjs"
   }
 }

--- a/packages/vscode-ws-jsonrpc/tsconfig.cjs.json
+++ b/packages/vscode-ws-jsonrpc/tsconfig.cjs.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist/cjs",
+    "declarationDir": "dist/cjs",
+    "module": "CommonJS"
+  },
+  "include": [
+    "src/**/*.ts",
+  ],
+  "exclude": [
+    "dist",
+    "lib",
+    "node_modules"
+  ]
+}

--- a/packages/vscode-ws-jsonrpc/tsconfig.json
+++ b/packages/vscode-ws-jsonrpc/tsconfig.json
@@ -4,15 +4,13 @@
     "rootDir": "src",
     "outDir": "lib",
     "declarationDir": "lib",
-    "target": "ES2017",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "lib": [
-      "es2016",
-      "dom"
-    ],
   },
   "include": [
-    "src"
+    "src/**/*.ts",
+  ],
+  "exclude": [
+    "dist",
+    "lib",
+    "node_modules"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "ES2020",
+    "moduleResolution": "Node",
     "lib": [
       "ES2020",
       "dom"
     ],
-    "moduleResolution": "Node",
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "composite": true, // Enable project compilation

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
         rollupOptions: {
             input: {
                 client: path.resolve(__dirname, '/packages/examples/client/index.html'),
+                browserLsp: path.resolve(__dirname, '/packages/examples/browser-lsp/index.html'),
                 browser: path.resolve(__dirname, '/packages/examples/browser/index.html'),
                 browserOld: path.resolve(__dirname, '/packages/examples/browser-old/index.html')
             }


### PR DESCRIPTION
Added `typesVersions` to monaco-languageclient and vscode-ws-jsonrpc, so exports can be properly imported with TS:

I did not understand why the "exports" lead to import problems in typescript (node example) until I found this:
https://github.com/teppeis/typescript-subpath-exports-workaround

`vscode-ws-jsonrpc` gets a 1.0.1 release once this is merged.
and it makes sense to release a 2.0.2 of `monaco-languageclient`, because of the  `typesVersions`. Do you have other things that should be fixed as well? 