### PR TITLE
Close websocket

### DIFF
--- a/packages/examples/react-client/src/app.tsx
+++ b/packages/examples/react-client/src/app.tsx
@@ -132,11 +132,11 @@ export const ReactMonacoEditor: React.FC<EditorProps> = ({
 
         window.onbeforeunload = () => {
           // On page reload/exit, close web socket connection
-          !!lspWebSocket && lspWebSocket.close();
+          lspWebSocket?.close();
         };
         return () => {
             // On component unmount, close web socket connection
-            !!lspWebSocket && lspWebSocket.close();
+            lspWebSocket?.close();
         };
     }, []);
 

--- a/packages/examples/react-client/src/app.tsx
+++ b/packages/examples/react-client/src/app.tsx
@@ -60,6 +60,7 @@ function createWebSocket(url: string) {
         languageClient.start();
         reader.onClose(() => languageClient.stop());
     };
+    return webSocket;
 }
 
 function createLanguageClient(transports: MessageTransports): MonacoLanguageClient {
@@ -97,7 +98,8 @@ export const ReactMonacoEditor: React.FC<EditorProps> = ({
     const editorRef = useRef<monaco.editor.IStandaloneCodeEditor>();
     const ref = createRef<HTMLDivElement>();
     const url = useMemo(() => createUrl(hostname, port, path), [hostname, port, path]);
-
+    let LSPWebSocket: WebSocket;
+    
     useEffect(() => {
         if (ref.current != null) {
             // register Monaco languages
@@ -121,14 +123,21 @@ export const ReactMonacoEditor: React.FC<EditorProps> = ({
             // install Monaco language client services
             MonacoServices.install();
 
-            createWebSocket(url);
+            LSPWebSocket = createWebSocket(url);
 
             return () => {
                 editorRef.current!.dispose();
             };
         }
 
-        return () => {};
+        window.onbeforeunload = () => {
+          // On page reload/exit, close web socket connection
+          !!LSPWebSocket && LSPWebSocket.close();
+        };
+        return () => {
+            // On component unmount, close web socket connection
+            !!LSPWebSocket && LSPWebSocket.close();
+        };
     }, []);
 
     return (

--- a/packages/examples/react-client/src/app.tsx
+++ b/packages/examples/react-client/src/app.tsx
@@ -98,7 +98,7 @@ export const ReactMonacoEditor: React.FC<EditorProps> = ({
     const editorRef = useRef<monaco.editor.IStandaloneCodeEditor>();
     const ref = createRef<HTMLDivElement>();
     const url = useMemo(() => createUrl(hostname, port, path), [hostname, port, path]);
-    let LSPWebSocket: WebSocket;
+    let lspWebSocket: WebSocket;
     
     useEffect(() => {
         if (ref.current != null) {
@@ -123,7 +123,7 @@ export const ReactMonacoEditor: React.FC<EditorProps> = ({
             // install Monaco language client services
             MonacoServices.install();
 
-            LSPWebSocket = createWebSocket(url);
+            lspWebSocket = createWebSocket(url);
 
             return () => {
                 editorRef.current!.dispose();
@@ -132,11 +132,11 @@ export const ReactMonacoEditor: React.FC<EditorProps> = ({
 
         window.onbeforeunload = () => {
           // On page reload/exit, close web socket connection
-          !!LSPWebSocket && LSPWebSocket.close();
+          !!lspWebSocket && lspWebSocket.close();
         };
         return () => {
             // On component unmount, close web socket connection
-            !!LSPWebSocket && LSPWebSocket.close();
+            !!lspWebSocket && lspWebSocket.close();
         };
     }, []);
 


### PR DESCRIPTION
**Issue**
When I implemented the current react-client example on a long-running server instance, I saw exploding memory usage but no CPU usage. The memory hung for a long time but was never released. I checked my console network tab, and the connections were never being closed.  

**This pull request**
I believe there need to be calls made to close the web sockets, or else there will be a build up of memory on the server.
I added calls to close the web socket on component unmount and page exit/reload