### PR TITLE
Adapt to monaco-vscode-api-1.79.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The following table describes which version of **monaco-languageclient** and **m
 
 | monaco-languageclient | monaco-vscode-api | monaco-editor | comment |
 | :----         | :----   | :---   | :--- |
-| 6.1.0         | 1.79.0  | 0.38.0 | Released 2023-06-0x |
+| 6.1.0         | 1.79.1  | 0.38.0 | Released 2023-06-0x |
 | 6.0.3         | 1.78.8  | 0.37.1 | Released 2023-05-31 |
 | 6.0.2         | 1.78.6  | 0.37.1 | Released 2023-05-24 |
 | 6.0.1         | 1.78.6  | 0.37.1 | Released 2023-05-12 |

--- a/package-lock.json
+++ b/package-lock.json
@@ -5896,9 +5896,9 @@
     },
     "node_modules/vscode": {
       "name": "@codingame/monaco-vscode-api",
-      "version": "1.79.0",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-1.79.0.tgz",
-      "integrity": "sha512-Gut3JyQMMUA6Jg8h3/25qHBXFrgAWRIa82dboOv0YqGEPYYsZ9JLtElZx7nDSdgdFTIU/pNnutgtOIe6Oby84w==",
+      "version": "1.79.1",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-1.79.1.tgz",
+      "integrity": "sha512-S6t3ZnnonHy0SqpUdRg60YcFluUGLj6S8KXiu//WQgfmZ/ccsc5gASMSjlcZLRGzs02KOXKppNGwHSgq6Cx3Tg==",
       "bin": {
         "monaco-treemending": "monaco-treemending.js"
       },
@@ -6309,12 +6309,12 @@
     },
     "packages/client": {
       "name": "monaco-languageclient",
-      "version": "6.1.0-next.0",
+      "version": "6.1.0-next.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "monaco-editor": "~0.38.0",
-        "vscode": "npm:@codingame/monaco-vscode-api@~1.79.0",
+        "vscode": "npm:@codingame/monaco-vscode-api@~1.79.1",
         "vscode-jsonrpc": "~8.1.0",
         "vscode-languageclient": "~8.1.0"
       },
@@ -6324,7 +6324,7 @@
       },
       "peerDependencies": {
         "monaco-editor": "~0.38.0",
-        "vscode": "npm:@codingame/monaco-vscode-api@~1.79.0"
+        "vscode": "npm:@codingame/monaco-vscode-api@~1.79.1"
       },
       "peerDependenciesMeta": {
         "monaco-editor": {
@@ -6343,7 +6343,7 @@
         "langium": "~1.2.0",
         "langium-statemachine-dsl": "~1.2.0",
         "monaco-editor-workers": "0.38.0",
-        "monaco-languageclient": "6.1.0-next.0",
+        "monaco-languageclient": "6.1.0-next.1",
         "normalize-url": "~8.0.0",
         "react": "~18.2.0",
         "react-dom": "~18.2.0",
@@ -6370,7 +6370,7 @@
       "version": "0.0.0",
       "dependencies": {
         "monaco-editor-workers": "0.38.0",
-        "monaco-languageclient": "6.1.0-next.0",
+        "monaco-languageclient": "6.1.0-next.1",
         "normalize-url": "~8.0.0",
         "vscode-ws-jsonrpc": "3.0.0"
       },
@@ -6383,7 +6383,7 @@
       "version": "0.0.0",
       "dependencies": {
         "monaco-editor-workers": "0.38.0",
-        "monaco-languageclient": "6.1.0-next.0",
+        "monaco-languageclient": "6.1.0-next.1",
         "normalize-url": "~8.0.0",
         "vscode-ws-jsonrpc": "3.0.0"
       },

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this npm module are documented in this file.
 ## [6.1.0] - 2023-06-0x
 
 - Updated to `monaco-vscode-api` version `1.79.0` and `monaco-editor` version `0.38.0` [#493](https://github.com/TypeFox/monaco-languageclient/issues/493)
+- Updated to `monaco-vscode-api` version `1.79.1` [#501](https://github.com/TypeFox/monaco-languageclient/pull/501)
 - `initService` creates `window.MonacoEnvironment` if not yet available
 
 ## [6.0.3] - 2023-05-31

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monaco-languageclient",
-  "version": "6.1.0-next.0",
+  "version": "6.1.0-next.1",
   "description": "Monaco Language client implementation",
   "author": {
     "name": "TypeFox GmbH",
@@ -49,13 +49,13 @@
   ],
   "dependencies": {
     "monaco-editor": "~0.38.0",
-    "vscode": "npm:@codingame/monaco-vscode-api@~1.79.0",
+    "vscode": "npm:@codingame/monaco-vscode-api@~1.79.1",
     "vscode-jsonrpc": "~8.1.0",
     "vscode-languageclient": "~8.1.0"
   },
   "peerDependencies": {
     "monaco-editor": "~0.38.0",
-    "vscode": "npm:@codingame/monaco-vscode-api@~1.79.0"
+    "vscode": "npm:@codingame/monaco-vscode-api@~1.79.1"
   },
   "peerDependenciesMeta": {
     "monaco-editor": {
@@ -67,7 +67,7 @@
   },
   "scripts": {
     "postinstall": "monaco-treemending",
-    "clean": "npx shx rm -fr lib *.tsbuildinfo",
+    "clean": "shx rm -fr lib *.tsbuildinfo",
     "compile": "tsc --build tsconfig.src.json",
     "build:msg": "echo Building monaco-languageclient:",
     "build": "npm run build:msg && npm run clean && npm run compile"

--- a/packages/client/src/monaco-language-client.ts
+++ b/packages/client/src/monaco-language-client.ts
@@ -124,14 +124,7 @@ export class MonacoLanguageClient extends BaseLanguageClient {
         this.registerFeature(new WillSaveFeature(this));
         this.registerFeature(new WillSaveWaitUntilFeature(this));
         this.registerFeature(new DidSaveTextDocumentFeature(this));
-    }
-
-    /**
-     * These are all contained in BaseLanguageClient#registerBuiltinFeatures but not registered
-     * in MonacoLanguageClient. This method is not called!
-     */
-    public registerNotUsedFeatures() {
-        // theses feature will become supported once https://github.com/CodinGame/monaco-vscode-api/pull/110 is ready
+        // enabled since monaco-vscode-api 1.79.0 (PR https://github.com/CodinGame/monaco-vscode-api/pull/110)
         this.registerFeature(new WorkspaceSymbolFeature(this));
         this.registerFeature(new DidCreateFilesFeature(this));
         this.registerFeature(new DidRenameFilesFeature(this));
@@ -142,7 +135,13 @@ export class MonacoLanguageClient extends BaseLanguageClient {
         this.registerFeature(new CallHierarchyFeature(this));
         this.registerFeature(new TypeHierarchyFeature(this));
         this.registerFeature(new InlineValueFeature(this));
+    }
 
+    /**
+     * These are all contained in BaseLanguageClient#registerBuiltinFeatures but not registered
+     * in MonacoLanguageClient. This method is not called!
+     */
+    public registerNotUsedFeatures() {
         // these will stay unsupported for now
         this.registerFeature(new ProgressFeature(this));
         this.registerFeature(new NotebookDocumentSyncFeature(this));

--- a/packages/client/src/monaco-vscode-api-services.ts
+++ b/packages/client/src/monaco-vscode-api-services.ts
@@ -86,9 +86,11 @@ const importAllServices = async (config?: InitializeServiceConfig) => {
         }
     }
     if (lc.enableQuickaccessService === true) {
-        addService('quickaccess', import('vscode/service-override/quickaccess'));
         // quickaccess requires keybindings
-        lc.enableKeybindingsService = true;
+        if (lc.enableKeybindingsService === undefined || lc.enableKeybindingsService === false) {
+            throw new Error('"quickaccess" requires "keybindings" service. Please add it to the "initServices" config.');
+        }
+        addService('quickaccess', import('vscode/service-override/quickaccess'));
     }
     if (lc.configureConfigurationServiceConfig !== undefined) {
         addService('configuration', import('vscode/service-override/configuration'));
@@ -100,9 +102,11 @@ const importAllServices = async (config?: InitializeServiceConfig) => {
         addService('notifications', import('vscode/service-override/notifications'));
     }
     if (lc.enableThemeService === true) {
-        addService('theme', import('vscode/service-override/theme'));
         // theme requires textmate
-        lc.enableTextmateService = true;
+        if (lc.enableTextmateService === undefined || lc.enableTextmateService === false) {
+            throw new Error('"theme" requires "textmate" service. Please add it to the "initServices" config.');
+        }
+        addService('theme', import('vscode/service-override/theme'));
     }
     if (lc.enableTextmateService === true) {
         addService('textmate', import('vscode/service-override/textmate'));

--- a/packages/examples/main/package.json
+++ b/packages/examples/main/package.json
@@ -23,7 +23,7 @@
     "langium": "~1.2.0",
     "langium-statemachine-dsl": "~1.2.0",
     "monaco-editor-workers": "0.38.0",
-    "monaco-languageclient": "6.1.0-next.0",
+    "monaco-languageclient": "6.1.0-next.1",
     "normalize-url": "~8.0.0",
     "react": "~18.2.0",
     "react-dom": "~18.2.0",
@@ -49,7 +49,7 @@
     "npm": "9.6.6"
   },
   "scripts": {
-    "clean": "npx shx rm -fr dist *.tsbuildinfo",
+    "clean": "shx rm -fr dist *.tsbuildinfo",
     "compile": "tsc --build tsconfig.src.json",
     "build:msg": "echo Building main examples:",
     "build:worker:vite": "vite --config  vite.langium-worker.ts build",

--- a/packages/examples/main/src/browser/main.ts
+++ b/packages/examples/main/src/browser/main.ts
@@ -3,14 +3,12 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import { languages, workspace, TextDocument as VsCodeTextDocument } from 'vscode';
-
-import { buildWorkerDefinition } from 'monaco-editor-workers';
-
 import { getLanguageService, TextDocument } from 'vscode-json-languageservice';
 import { createConverter as createCodeConverter } from 'vscode-languageclient/lib/common/codeConverter.js';
 import { createConverter as createProtocolConverter } from 'vscode-languageclient/lib/common/protocolConverter.js';
 import { createDefaultJsonContent, createJsonEditor } from '../common.js';
 
+import { buildWorkerDefinition } from 'monaco-editor-workers';
 buildWorkerDefinition('../../../node_modules/monaco-editor-workers/dist/workers/', new URL('', window.location.href).href, false);
 
 const codeConverter = createCodeConverter();

--- a/packages/examples/main/src/client/main.ts
+++ b/packages/examples/main/src/client/main.ts
@@ -3,9 +3,8 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { buildWorkerDefinition } from 'monaco-editor-workers';
 import { createDefaultJsonContent, createJsonEditor, createUrl, createWebSocket } from '../common.js';
-
+import { buildWorkerDefinition } from 'monaco-editor-workers';
 buildWorkerDefinition('../../../node_modules/monaco-editor-workers/dist/workers/', new URL('', window.location.href).href, false);
 
 const start = async () => {

--- a/packages/examples/main/src/common.ts
+++ b/packages/examples/main/src/common.ts
@@ -3,15 +3,17 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import 'monaco-editor/esm/vs/editor/edcore.main.js';
+import 'monaco-editor/esm/vs/editor/editor.all.js';
+import 'monaco-editor/esm/vs/editor/standalone/browser/accessibilityHelp/accessibilityHelp.js';
+import 'monaco-editor/esm/vs/editor/standalone/browser/iPadShowKeyboard/iPadShowKeyboard.js';
 import { editor, languages, Uri } from 'monaco-editor/esm/vs/editor/editor.api.js';
 import { createConfiguredEditor, createModelReference, IReference, ITextFileEditorModel } from 'vscode/monaco';
+import 'vscode/default-extensions/theme-defaults';
+import 'vscode/default-extensions/json';
 import { initServices, MonacoLanguageClient } from 'monaco-languageclient';
 import normalizeUrl from 'normalize-url';
 import { CloseAction, ErrorAction, MessageTransports } from 'vscode-languageclient';
 import { WebSocketMessageReader, WebSocketMessageWriter, toSocket } from 'vscode-ws-jsonrpc';
-import 'vscode/default-extensions/theme-defaults';
-import 'vscode/default-extensions/json';
 
 export const createLanguageClient = (transports: MessageTransports): MonacoLanguageClient => {
     return new MonacoLanguageClient({
@@ -79,11 +81,13 @@ export const createJsonEditor = async (config: {
     if (config.init === true) {
         await initServices({
             enableThemeService: true,
-            enableModelEditorService: true,
-            modelEditorServiceConfig: {
-                useDefaultFunction: true
+            enableModelService: true,
+            configureEditorOrViewsServiceConfig: {
+                enableViewsService: false,
+                useDefaultOpenEditorFunction: true
             },
             enableLanguagesService: true,
+            enableQuickaccessService: true,
             debugLogging: true
         });
     }

--- a/packages/examples/main/src/common.ts
+++ b/packages/examples/main/src/common.ts
@@ -81,12 +81,14 @@ export const createJsonEditor = async (config: {
     if (config.init === true) {
         await initServices({
             enableThemeService: true,
+            enableTextmateService: true,
             enableModelService: true,
             configureEditorOrViewsServiceConfig: {
                 enableViewsService: false,
                 useDefaultOpenEditorFunction: true
             },
             enableLanguagesService: true,
+            enableKeybindingsService: true,
             enableQuickaccessService: true,
             debugLogging: true
         });

--- a/packages/examples/main/src/langium/main.ts
+++ b/packages/examples/main/src/langium/main.ts
@@ -14,7 +14,7 @@ import { CloseAction, ErrorAction, MessageTransports } from 'vscode-languageclie
 import { createConfiguredEditor } from 'vscode/monaco';
 import { registerExtension } from 'vscode/extensions';
 import { updateUserConfiguration } from 'vscode/service-override/configuration';
-import getKeybindingsServiceOverride from 'vscode/service-override/keybindings';
+import getPreferencesServiceOverride from 'vscode/service-override/preferences';
 import 'vscode/default-extensions/theme-defaults';
 
 import { buildWorkerDefinition } from 'monaco-editor-workers';
@@ -132,25 +132,25 @@ try {
         configureConfigurationServiceConfig: {
             defaultWorkspaceUri: '/tmp'
         },
-        // This should demonstate that you can chose to not use the built-in loading meachnism,
-        // but do it manually, see below
-        enableKeybindingsService: false,
+        enableKeybindingsService: true,
         enableLanguagesService: true,
         enableAudioCueService: true,
         enableDebugService: true,
         enableDialogService: true,
         enableNotificationService: true,
-        enablePreferencesService: true,
+        // This should demonstrate that you can chose to not use the built-in loading mechanism,
+        // but do it manually, see below
+        enablePreferencesService: false,
         enableSnippetsService: true,
         enableQuickaccessService: true,
         userServices: {
-            // manually add the KeyBindingsService
-            ...getKeybindingsServiceOverride()
+            // manually add the PreferencesService
+            ...getPreferencesServiceOverride()
         },
         debugLogging: true
     });
     await setup();
     await run();
 } catch (e) {
-    console.log(e);
+    console.error(e);
 }

--- a/packages/examples/main/src/langium/main.ts
+++ b/packages/examples/main/src/langium/main.ts
@@ -2,22 +2,22 @@
  * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
-// support all editor features
-import 'monaco-editor/esm/vs/editor/edcore.main.js';
-import * as monaco from 'monaco-editor/esm/vs/editor/editor.api.js';
 
-import { buildWorkerDefinition } from 'monaco-editor-workers';
+import 'monaco-editor/esm/vs/editor/editor.all.js';
+import 'monaco-editor/esm/vs/editor/standalone/browser/accessibilityHelp/accessibilityHelp.js';
+import 'monaco-editor/esm/vs/editor/standalone/browser/iPadShowKeyboard/iPadShowKeyboard.js';
+import { editor, Uri } from 'monaco-editor/esm/vs/editor/editor.api.js';
 
 import { MonacoLanguageClient, initServices } from 'monaco-languageclient';
 import { BrowserMessageReader, BrowserMessageWriter } from 'vscode-languageserver-protocol/browser.js';
 import { CloseAction, ErrorAction, MessageTransports } from 'vscode-languageclient';
-
 import { createConfiguredEditor } from 'vscode/monaco';
 import { registerExtension } from 'vscode/extensions';
 import { updateUserConfiguration } from 'vscode/service-override/configuration';
 import getKeybindingsServiceOverride from 'vscode/service-override/keybindings';
 import 'vscode/default-extensions/theme-defaults';
 
+import { buildWorkerDefinition } from 'monaco-editor-workers';
 buildWorkerDefinition('../../../node_modules/monaco-editor-workers/dist/workers/', new URL('', window.location.href).href, false);
 
 const languageId = 'statemachine';
@@ -72,7 +72,7 @@ const setup = async () => {
 
     updateUserConfiguration(`{
     "editor.fontSize": 14,
-    "workbench.colorTheme": "Default Dark+ Experimental"
+    "workbench.colorTheme": "Default Dark Modern"
 }`);
 };
 
@@ -82,7 +82,7 @@ const run = async () => {
     const editorText = await responseStatemachine.text();
 
     const editorOptions = {
-        model: monaco.editor.createModel(editorText, languageId, monaco.Uri.parse('inmemory://example.statemachine')),
+        model: editor.createModel(editorText, languageId, Uri.parse('inmemory://example.statemachine')),
         automaticLayout: true
     };
     createConfiguredEditor(document.getElementById('container')!, editorOptions);
@@ -124,12 +124,12 @@ try {
     await initServices({
         enableThemeService: true,
         enableTextmateService: true,
-        enableModelEditorService: true,
-        modelEditorServiceConfig: {
-            useDefaultFunction: true
+        enableModelService: true,
+        configureEditorOrViewsServiceConfig: {
+            enableViewsService: false,
+            useDefaultOpenEditorFunction: true
         },
-        enableConfigurationService: true,
-        configurationServiceConfig: {
+        configureConfigurationServiceConfig: {
             defaultWorkspaceUri: '/tmp'
         },
         // This should demonstate that you can chose to not use the built-in loading meachnism,
@@ -142,7 +142,7 @@ try {
         enableNotificationService: true,
         enablePreferencesService: true,
         enableSnippetsService: true,
-        enableViewsService: true,
+        enableQuickaccessService: true,
         userServices: {
             // manually add the KeyBindingsService
             ...getKeybindingsServiceOverride()

--- a/packages/examples/main/src/react/app.tsx
+++ b/packages/examples/main/src/react/app.tsx
@@ -2,12 +2,14 @@
  * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
-import 'monaco-editor/esm/vs/editor/edcore.main.js';
+import 'monaco-editor/esm/vs/editor/editor.all.js';
+import 'monaco-editor/esm/vs/editor/standalone/browser/accessibilityHelp/accessibilityHelp.js';
+import 'monaco-editor/esm/vs/editor/standalone/browser/iPadShowKeyboard/iPadShowKeyboard.js';
 import { editor } from 'monaco-editor/esm/vs/editor/editor.api.js';
-import { buildWorkerDefinition } from 'monaco-editor-workers';
 import React, { createRef, useEffect, useMemo, useRef } from 'react';
 import { createJsonEditor, createUrl, createWebSocket } from '../common.js';
 
+import { buildWorkerDefinition } from 'monaco-editor-workers';
 buildWorkerDefinition('../../../node_modules/monaco-editor-workers/dist/workers/', new URL('', window.location.href).href, false);
 
 let init = true;

--- a/packages/verify/pnpm/package.json
+++ b/packages/verify/pnpm/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.0",
   "private": "true",
   "dependencies": {
-    "monaco-languageclient": "~6.0.3",
-    "monaco-editor": "~0.37.1",
-    "vscode": "npm:@codingame/monaco-vscode-api@~1.78.8"
+    "monaco-languageclient": "6.1.0-next.1",
+    "monaco-editor": "~0.38.0",
+    "vscode": "npm:@codingame/monaco-vscode-api@~1.79.1"
   },
   "devDependencies": {
     "shx": "~0.3.4"

--- a/packages/verify/vite/package.json
+++ b/packages/verify/vite/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "monaco-editor-workers": "0.38.0",
-    "monaco-languageclient": "6.1.0-next.0",
+    "monaco-languageclient": "6.1.0-next.1",
     "vscode-ws-jsonrpc": "3.0.0",
     "normalize-url": "~8.0.0"
   },
@@ -17,7 +17,7 @@
     "npm": "9.6.6"
   },
   "scripts": {
-    "clean": "npx shx rm -fr dist",
+    "clean": "shx rm -fr dist",
     "copy:monacoworkers": "shx mkdir -p dist/workers && shx cp -r ../../../node_modules/monaco-editor-workers/dist/workers/editorWorker* ./dist/workers",
     "build:msg": "echo Building client-vite example:",
     "build": "npm run build:msg && npm run clean && vite build && npm run copy:monacoworkers",

--- a/packages/verify/vite/src/client/main.ts
+++ b/packages/verify/vite/src/client/main.ts
@@ -3,9 +3,8 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { buildWorkerDefinition } from 'monaco-editor-workers';
 import { createDefaultJsonContent, createJsonEditor, createUrl, createWebSocket } from 'examples-main';
-
+import { buildWorkerDefinition } from 'monaco-editor-workers';
 buildWorkerDefinition('./workers', new URL('', window.location.href).href, false);
 
 const start = async () => {

--- a/packages/verify/webpack/package.json
+++ b/packages/verify/webpack/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "dependencies": {
     "monaco-editor-workers": "0.38.0",
-    "monaco-languageclient": "6.1.0-next.0",
+    "monaco-languageclient": "6.1.0-next.1",
     "vscode-ws-jsonrpc": "3.0.0",
     "normalize-url": "~8.0.0"
   },
@@ -22,7 +22,7 @@
     "npm": "9.6.6"
   },
   "scripts": {
-    "clean": "npx shx rm -fr dist *.tsbuildinfo",
+    "clean": "shx rm -fr dist *.tsbuildinfo",
     "copy:monacoworkers": "shx mkdir -p dist/client/workers && shx cp -r ../../../node_modules/monaco-editor-workers/dist/workers/editorWorker* ./dist/client/workers",
     "build:msg": "echo Building client-webpack example:",
     "build": "npm run build:msg && npm run clean && webpack && npm run copy:monacoworkers",

--- a/packages/verify/webpack/src/client/main.ts
+++ b/packages/verify/webpack/src/client/main.ts
@@ -3,9 +3,8 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { buildWorkerDefinition } from 'monaco-editor-workers';
 import { createDefaultJsonContent, createJsonEditor, createUrl, createWebSocket } from 'examples-main';
-
+import { buildWorkerDefinition } from 'monaco-editor-workers';
 buildWorkerDefinition('dist/client/workers', new URL('', window.location.href).href, false);
 
 const start = async () => {

--- a/packages/verify/yarn/package.json
+++ b/packages/verify/yarn/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": "true",
   "dependencies": {
-    "monaco-languageclient": "~6.0.3"
+    "monaco-languageclient": "6.1.0-next.1"
   },
   "devDependencies": {
     "shx": "~0.3.4"

--- a/packages/vscode-ws-jsonrpc/package.json
+++ b/packages/vscode-ws-jsonrpc/package.json
@@ -65,7 +65,7 @@
     "vscode-jsonrpc": "~8.1.0"
   },
   "scripts": {
-    "clean": "npx shx rm -fr lib *.tsbuildinfo",
+    "clean": "shx rm -fr lib *.tsbuildinfo",
     "compile": "tsc --build tsconfig.src.json",
     "build:msg": "echo Building vscode-ws-jsonrpc:",
     "build": "npm run build:msg && npm run clean && npm run compile"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,35 +23,7 @@ export default defineConfig(() => {
             port: 8080,
             origin: 'http://localhost:8080'
         },
-        assetsInclude: ['**/*.wasm'],
-        optimizeDeps: [
-
-            'monaco-editor',
-            'vscode',
-            'vscode/extensions',
-            'vscode/services',
-            'vscode/monaco',
-            'vscode/service-override/model',
-            'vscode/service-override/editor',
-            'vscode/service-override/notifications',
-            'vscode/service-override/dialogs',
-            'vscode/service-override/configuration',
-            'vscode/service-override/keybindings',
-            'vscode/service-override/textmate',
-            'vscode/service-override/theme',
-            'vscode/service-override/languages',
-            'vscode/service-override/audioCue',
-            'vscode/service-override/views',
-            'vscode/service-override/quickaccess',
-            'vscode/service-override/debug',
-            'vscode/service-override/preferences',
-            'vscode/service-override/snippets',
-            'vscode/service-override/files',
-            'vscode/default-extensions/theme-defaults',
-            'vscode/default-extensions/javascript',
-            'vscode/default-extensions/typescript',
-            'vscode/default-extensions/json'
-        ]
+        assetsInclude: ['**/*.wasm']
     };
     return config;
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,35 @@ export default defineConfig(() => {
             port: 8080,
             origin: 'http://localhost:8080'
         },
-        assetsInclude: ['**/*.wasm']
+        assetsInclude: ['**/*.wasm'],
+        optimizeDeps: [
+
+            'monaco-editor',
+            'vscode',
+            'vscode/extensions',
+            'vscode/services',
+            'vscode/monaco',
+            'vscode/service-override/model',
+            'vscode/service-override/editor',
+            'vscode/service-override/notifications',
+            'vscode/service-override/dialogs',
+            'vscode/service-override/configuration',
+            'vscode/service-override/keybindings',
+            'vscode/service-override/textmate',
+            'vscode/service-override/theme',
+            'vscode/service-override/languages',
+            'vscode/service-override/audioCue',
+            'vscode/service-override/views',
+            'vscode/service-override/quickaccess',
+            'vscode/service-override/debug',
+            'vscode/service-override/preferences',
+            'vscode/service-override/snippets',
+            'vscode/service-override/files',
+            'vscode/default-extensions/theme-defaults',
+            'vscode/default-extensions/javascript',
+            'vscode/default-extensions/typescript',
+            'vscode/default-extensions/json'
+        ]
     };
     return config;
 });


### PR DESCRIPTION
@CGNonofr I have a problem even if I only include files and model. Any idea on this?
![image](https://github.com/TypeFox/monaco-languageclient/assets/21079138/6ee4ed56-6ca1-4122-9610-fb27e0c6b9bb)

I changed `initServices` that users can only include editor or views as you outlined in the monaco-vscode-api README
