### PR TITLE
Update copyright statements and replace header rule with less strict one

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,4 @@
 const path = require('path');
-const headerDef = path.resolve(__dirname, './config/header.js');
 
 module.exports = {
     env: {
@@ -42,7 +41,12 @@ module.exports = {
         '@typescript-eslint/no-unused-vars': ['warn', {
             argsIgnorePattern: '^_'
         }],
-        'header/header': [2, headerDef],
+        // Use MIT/Generated file header
+        "header/header": [
+            2,
+            "block",
+            { "pattern": "MIT License|DO NOT EDIT MANUALLY!" }
+        ],
         'dot-notation': 'off',
         '@typescript-eslint/dot-notation': ['error'],
         'space-before-function-paren': ['error', {

--- a/License.txt
+++ b/License.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io)
+Copyright (c) 2018-2024 TypeFox GmbH (http://www.typefox.io)
 
 All rights reserved.
 

--- a/config/header.js
+++ b/config/header.js
@@ -1,4 +1,0 @@
-/* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
- * Licensed under the MIT License. See License.txt in the project root for license information.
- * ------------------------------------------------------------------------------------------ */

--- a/packages/client/License.txt
+++ b/packages/client/License.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io)
+Copyright (c) 2018-2024 TypeFox GmbH (http://www.typefox.io)
 
 All rights reserved.
 

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/client/src/monaco-language-client.ts
+++ b/packages/client/src/monaco-language-client.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/client/src/monaco-vscode-api-services.ts
+++ b/packages/client/src/monaco-vscode-api-services.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/examples/License.txt
+++ b/packages/examples/License.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2018-2023 TypeFox GmbH (http://www.typefox.io)
+Copyright (c) 2018-2024 TypeFox GmbH (http://www.typefox.io)
 
 All rights reserved.
 

--- a/packages/examples/src/browser/main.ts
+++ b/packages/examples/src/browser/main.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import { languages, workspace, TextDocument as VsCodeTextDocument } from 'vscode';

--- a/packages/examples/src/common/client-commons.ts
+++ b/packages/examples/src/common/client-commons.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/examples/src/common/server-commons.ts
+++ b/packages/examples/src/common/server-commons.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import { resolve } from 'path';

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/examples/src/json/client/main.ts
+++ b/packages/examples/src/json/client/main.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/examples/src/json/server/direct.ts
+++ b/packages/examples/src/json/server/direct.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import { resolve } from 'path';

--- a/packages/examples/src/json/server/json-server.ts
+++ b/packages/examples/src/json/server/json-server.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import { readFile } from 'fs';

--- a/packages/examples/src/json/server/main.ts
+++ b/packages/examples/src/json/server/main.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import { WebSocketServer } from 'ws';
@@ -9,7 +9,7 @@ import { getLocalDirectory } from '../../utils/fs-utils.js';
 import { upgradeWsServer } from '../../common/server-commons.js';
 
 export const runJsonServer = (baseDir: string, relativeDir: string) => {
-    process.on('uncaughtException', function(err: any) {
+    process.on('uncaughtException', (err: any) => {
         console.error('Uncaught Exception: ', err.toString());
         if (err.stack) {
             console.error(err.stack);

--- a/packages/examples/src/langium/localeLoader.ts
+++ b/packages/examples/src/langium/localeLoader.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/examples/src/langium/statemachineClient.ts
+++ b/packages/examples/src/langium/statemachineClient.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/examples/src/node.ts
+++ b/packages/examples/src/node.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/examples/src/python/client/main.ts
+++ b/packages/examples/src/python/client/main.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/examples/src/python/server/direct.ts
+++ b/packages/examples/src/python/server/direct.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/examples/src/python/server/main.ts
+++ b/packages/examples/src/python/server/main.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import { WebSocketServer } from 'ws';
@@ -10,7 +10,7 @@ import { getLocalDirectory } from '../../utils/fs-utils.js';
 import { upgradeWsServer } from '../../common/server-commons.js';
 
 export const runPythonServer = (baseDir: string, relativeDir: string) => {
-    process.on('uncaughtException', function(err: any) {
+    process.on('uncaughtException', (err: any) => {
         console.error('Uncaught Exception: ', err.toString());
         if (err.stack) {
             console.error(err.stack);

--- a/packages/examples/src/utils/fs-utils.ts
+++ b/packages/examples/src/utils/fs-utils.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import { dirname } from 'path';

--- a/packages/verify/vite/src/client/main.ts
+++ b/packages/verify/vite/src/client/main.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/verify/webpack/src/client/main.ts
+++ b/packages/verify/webpack/src/client/main.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/verify/webpack/webpack.config.js
+++ b/packages/verify/webpack/webpack.config.js
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/vscode-ws-jsonrpc/License.txt
+++ b/packages/vscode-ws-jsonrpc/License.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io)
+Copyright (c) 2018-2024 TypeFox GmbH (http://www.typefox.io)
 
 All rights reserved.
 

--- a/packages/vscode-ws-jsonrpc/src/connection.ts
+++ b/packages/vscode-ws-jsonrpc/src/connection.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/vscode-ws-jsonrpc/src/disposable.ts
+++ b/packages/vscode-ws-jsonrpc/src/disposable.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/vscode-ws-jsonrpc/src/index.ts
+++ b/packages/vscode-ws-jsonrpc/src/index.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/vscode-ws-jsonrpc/src/logger.ts
+++ b/packages/vscode-ws-jsonrpc/src/logger.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 import { Logger } from 'vscode-jsonrpc';

--- a/packages/vscode-ws-jsonrpc/src/server/connection.ts
+++ b/packages/vscode-ws-jsonrpc/src/server/connection.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/vscode-ws-jsonrpc/src/server/index.ts
+++ b/packages/vscode-ws-jsonrpc/src/server/index.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/vscode-ws-jsonrpc/src/server/launch.ts
+++ b/packages/vscode-ws-jsonrpc/src/server/launch.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/vscode-ws-jsonrpc/src/socket/connection.ts
+++ b/packages/vscode-ws-jsonrpc/src/socket/connection.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/vscode-ws-jsonrpc/src/socket/index.ts
+++ b/packages/vscode-ws-jsonrpc/src/socket/index.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/vscode-ws-jsonrpc/src/socket/reader.ts
+++ b/packages/vscode-ws-jsonrpc/src/socket/reader.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/vscode-ws-jsonrpc/src/socket/socket.ts
+++ b/packages/vscode-ws-jsonrpc/src/socket/socket.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 

--- a/packages/vscode-ws-jsonrpc/src/socket/writer.ts
+++ b/packages/vscode-ws-jsonrpc/src/socket/writer.ts
@@ -1,5 +1,5 @@
 /* --------------------------------------------------------------------------------------------
- * Copyright (c) 2018-2022 TypeFox GmbH (http://www.typefox.io). All rights reserved.
+ * Copyright (c) 2024 TypeFox GmbH (http://www.typefox.io). All rights reserved.
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 


### PR DESCRIPTION
All source files now contain just 2024. If it changes in the future and it happens to be another year that could/should be updated. The lint rule is more relaxed now.

Fixes #592 