### PR TITLE
Implement dispose method on WebSocketMessageReader.

### DIFF
--- a/packages/vscode-ws-jsonrpc/src/socket/reader.ts
+++ b/packages/vscode-ws-jsonrpc/src/socket/reader.ts
@@ -53,10 +53,18 @@ export class WebSocketMessageReader extends AbstractMessageReader implements Mes
         return {
             dispose: () => {
                 if (this.callback === callback) {
+                    this.state = 'initial';
                     this.callback = undefined;
                 }
             }
         };
+    }
+
+    override dispose() {
+        super.dispose();
+        this.state = 'initial';
+        this.callback = undefined;
+        this.events.splice(0, this.events.length);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Implementing `dispose()` according to the spec:
https://github.com/microsoft/vscode-languageserver-node/blob/21f4f0af6bf1623483c3e65f36e550bfdb6245a6/jsonrpc/src/common/messageReader.ts#L48

Although the `listen()` method returns a disposable callback, it seems like it's not used. Instead, the `dispose()` method is called on the reader (see [here](https://github.com/microsoft/vscode-languageserver-node/blob/21f4f0af6bf1623483c3e65f36e550bfdb6245a6/jsonrpc/src/common/connection.ts#L1553)).

Without implementing the dispose method, you can stop the language client, but calling `languageClient.start()` will not restart it properly.