### PR TITLE
monaco-editor-react works in strict mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "http-server": "~14.1.1",
         "shelljs": "~0.8.5",
         "shx": "~0.3.4",
-        "typescript": "~5.4.4",
+        "typescript": "~5.4.5",
         "vite": "~5.2.8",
         "vitest": "~1.4.0",
         "webdriverio": "~8.35.1"
@@ -8304,9 +8304,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
-      "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "http-server": "~14.1.1",
     "shelljs": "~0.8.5",
     "shx": "~0.3.4",
-    "typescript": "~5.4.4",
+    "typescript": "~5.4.5",
     "vite": "~5.2.8",
     "vitest": "~1.4.0",
     "webdriverio": "~8.35.1"

--- a/packages/examples/src/python/client/config.ts
+++ b/packages/examples/src/python/client/config.ts
@@ -81,6 +81,10 @@ export const createUserConfig = (code: string): UserConfig => {
                 useDiffEditor: false,
                 code
             }
+        },
+        loggerConfig: {
+            enabled: true,
+            debugEnabled: true
         }
     };
 };

--- a/packages/examples/src/python/client/reactPython.tsx
+++ b/packages/examples/src/python/client/reactPython.tsx
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See LICENSE in the package root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import React from 'react';
+import React, { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 import { MonacoEditorReactComp } from '@typefox/monaco-editor-react';
 import { createUserConfig } from './config.js';
@@ -27,21 +27,21 @@ export const runPythonReact = () => {
         console.log(`Dirty? ${isDirty} Content: ${text}`);
     };
 
-    const comp = <MonacoEditorReactComp
-        userConfig={createUserConfig(code)}
-        style={{
-            'paddingTop': '5px',
-            'height': '80vh'
-        }}
-        onTextChanged={onTextChanged}
-        onLoad={(wrapper: MonacoEditorLanguageClientWrapper) => {
-            console.log(`Loaded ${wrapper.reportStatus().join('\n').toString()}`);
-        }}
-        onError={(e) => {
-            console.error(e);
-        }}
-    />;
-
-    const root = ReactDOM.createRoot(document.getElementById('root')!);
-    root.render(comp);
+    ReactDOM.createRoot(document.getElementById('root')!).render(
+        <StrictMode>
+            <MonacoEditorReactComp
+                userConfig={createUserConfig(code)}
+                style={{
+                    'paddingTop': '5px',
+                    'height': '80vh'
+                }}
+                onTextChanged={onTextChanged}
+                onLoad={(wrapper: MonacoEditorLanguageClientWrapper) => {
+                    console.log(`Loaded ${wrapper.reportStatus().join('\n').toString()}`);
+                }}
+                onError={(e) => {
+                    console.error(e);
+                }}
+            />
+        </StrictMode>);
 };

--- a/packages/wrapper/src/editorAppClassic.ts
+++ b/packages/wrapper/src/editorAppClassic.ts
@@ -94,7 +94,20 @@ export class EditorAppClassic extends EditorAppBase {
             different = isModelUpdateRequired(orgConfig, config) !== ModelUpdateType.NONE;
         }
         type ClassicKeys = keyof typeof orgConfig;
-        const propsClassic = ['useDiffEditor', 'domReadOnly', 'readOnly', 'awaitExtensionReadiness', 'overrideAutomaticLayout', 'editorOptions', 'diffEditorOptions', 'languageDef', 'languageExtensionConfig', 'theme', 'themeData'];
+        const propsClassic = [
+            // model required changes are not taken into account in this list
+            'useDiffEditor',
+            'domReadOnly',
+            'readOnly',
+            'awaitExtensionReadiness',
+            'overrideAutomaticLayout',
+            'editorOptions',
+            'diffEditorOptions',
+            'theme',
+            'languageDef',
+            'languageExtensionConfig',
+            'themeData'
+        ];
         const propCompareClassic = (name: string) => {
             return !isEqual(orgConfig[name as ClassicKeys], config[name as ClassicKeys]);
         };

--- a/packages/wrapper/src/editorAppExtended.ts
+++ b/packages/wrapper/src/editorAppExtended.ts
@@ -115,7 +115,18 @@ export class EditorAppExtended extends EditorAppBase {
         if (includeModelData) {
             different = isModelUpdateRequired(orgConfig, config) !== ModelUpdateType.NONE;
         }
-        const propsExtended = ['useDiffEditor', 'domReadOnly', 'readOnly', 'awaitExtensionReadiness', 'overrideAutomaticLayout', 'editorOptions', 'diffEditorOptions', 'userConfiguration', 'extensions'];
+        const propsExtended = [
+            // model required changes are not taken into account in this list
+            'useDiffEditor',
+            'domReadOnly',
+            'readOnly',
+            'awaitExtensionReadiness',
+            'overrideAutomaticLayout',
+            'editorOptions',
+            'diffEditorOptions',
+            'extensions',
+            'userConfiguration'
+        ];
         type ExtendedKeys = keyof typeof orgConfig;
         const propCompareExtended = (name: string) => {
             return !isEqual(orgConfig[name as ExtendedKeys], config[name as ExtendedKeys]);

--- a/packages/wrapper/src/logger.ts
+++ b/packages/wrapper/src/logger.ts
@@ -14,6 +14,10 @@ export class Logger {
     private debugEnabled: boolean;
 
     constructor(config?: LoggerConfig) {
+        this.updateConfig(config);
+    }
+
+    updateConfig(config?: LoggerConfig) {
         this.enabled = !config ? true : config!.enabled === true;
         this.debugEnabled = this.enabled && config?.debugEnabled === true;
     }

--- a/packages/wrapper/src/utils.ts
+++ b/packages/wrapper/src/utils.ts
@@ -25,7 +25,7 @@ export const createUrl = (config: WebSocketConfigOptions | WebSocketConfigOption
         if (options.path) {
             buildUrl += `/${options.path}`;
         }
-        if (options.extraParams){
+        if (options.extraParams) {
             const url = new URL(buildUrl);
 
             for (const [key, value] of Object.entries(options.extraParams)) {

--- a/packages/wrapper/test/wrapper.test.ts
+++ b/packages/wrapper/test/wrapper.test.ts
@@ -57,4 +57,20 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
             await wrapper.initAndStart(config, document.getElementById('monaco-editor-root'));
         }).rejects.toThrowError('init was already performed. Please call dispose first if you want to re-start.');
     });
+
+    test('Test if ', async () => {
+        createMonacoEditorDiv();
+        const wrapper = new MonacoEditorLanguageClientWrapper();
+        const userConfigClassic = createBaseConfig('classic');
+        wrapper.init(userConfigClassic);
+        expect(wrapper.isReInitRequired(userConfigClassic, userConfigClassic)).toBeFalsy();
+
+        const userConfigExtended = createBaseConfig('extended');
+        expect(wrapper.isReInitRequired(userConfigClassic, userConfigExtended)).toBeTruthy();
+
+        const userConfigClassicNew = createBaseConfig('classic');
+        userConfigClassicNew.wrapperConfig.editorAppConfig.useDiffEditor = true;
+
+        expect(wrapper.isReInitRequired(userConfigClassicNew, userConfigClassic)).toBeTruthy();
+    });
 });


### PR DESCRIPTION
Re-Initialization was not properly safe-guarded. This update ensure this is the case. Re-init check functionality was mostly moved to the wrapper as it is unrelated to react, but to user and editor configuration. A simple unit test is introduced as well. The `logger` from the wrapper is exposed, so it can be used by the react-component.

This fixes #631 and #621 