### PR TITLE
Update code configuration. languageId is no longer required.

### DIFF
--- a/packages/examples/src/browser/main.ts
+++ b/packages/examples/src/browser/main.ts
@@ -162,7 +162,7 @@ export const runBrowserEditor = async () => {
 
     await wrapper.start(htmlElement);
 
-    wrapper.getModel()?.onDidChangeContent(() => {
+    wrapper.getTextModel()?.onDidChangeContent(() => {
         validate();
     });
 };

--- a/packages/examples/src/browser/main.ts
+++ b/packages/examples/src/browser/main.ts
@@ -43,9 +43,12 @@ export const runBrowserEditor = async () => {
             },
             editorAppConfig: {
                 $type: 'extended',
-                languageId: 'json',
-                code,
-                codeUri,
+                codeResources: {
+                    main: {
+                        text: code,
+                        uri: codeUri
+                    }
+                },
                 useDiffEditor: false,
                 userConfiguration: {
                     json: JSON.stringify({

--- a/packages/examples/src/common/example-apps-common.ts
+++ b/packages/examples/src/common/example-apps-common.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See LICENSE in the package root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { CodeResources, MonacoEditorLanguageClientWrapper, UserConfig } from 'monaco-editor-wrapper';
+import { MonacoEditorLanguageClientWrapper, UserConfig } from 'monaco-editor-wrapper';
 import * as monaco from 'monaco-editor';
 
 const wrapper = new MonacoEditorLanguageClientWrapper();
@@ -20,14 +20,6 @@ export const startEditor = async (userConfig: UserConfig, htmlElement: HTMLEleme
 
 export const getWrapper = () => {
     return wrapper;
-};
-
-export const updateModel = async (codeResources: CodeResources) => {
-    if (wrapper.getMonacoEditorApp()?.getConfig().useDiffEditor) {
-        await wrapper.updateDiffModel(codeResources);
-    } else {
-        await wrapper.updateModel(codeResources);
-    }
 };
 
 export const swapEditors = async (userConfig: UserConfig, htmlElement: HTMLElement | null, code: string, codeOriginal?: string) => {
@@ -64,9 +56,9 @@ const configureCodeEditors = (userConfig: UserConfig, code: string, codeOriginal
 
 const saveMainCode = (saveFromDiff: boolean) => {
     if (saveFromDiff) {
-        return wrapper.getModel(true)!.getValue();
+        return wrapper.getTextModel(true)!.getValue();
     } else {
-        return wrapper.getModel()!.getValue();
+        return wrapper.getTextModel()!.getValue();
     }
 };
 
@@ -79,9 +71,9 @@ const toggleSwapDiffButton = (enabled: boolean) => {
 
 const logEditorInfo = (userConfig: UserConfig) => {
     console.log(`# of configured languages: ${monaco.languages.getLanguages().length}`);
-    console.log(`Main code: ${wrapper.getModel(true)?.getValue() ?? ''}`);
+    console.log(`Main code: ${wrapper.getTextModel(true)?.getValue() ?? ''}`);
     if (userConfig.wrapperConfig.editorAppConfig.useDiffEditor) {
-        console.log(`Modified code: ${wrapper.getModel()!.getValue()}`);
+        console.log(`Modified code: ${wrapper.getTextModel()!.getValue()}`);
     }
 };
 

--- a/packages/examples/src/common/example-apps-common.ts
+++ b/packages/examples/src/common/example-apps-common.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See LICENSE in the package root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { ModelUpdate, MonacoEditorLanguageClientWrapper, UserConfig } from 'monaco-editor-wrapper';
+import { CodeResources, MonacoEditorLanguageClientWrapper, UserConfig } from 'monaco-editor-wrapper';
 import * as monaco from 'monaco-editor';
 
 const wrapper = new MonacoEditorLanguageClientWrapper();
@@ -22,11 +22,11 @@ export const getWrapper = () => {
     return wrapper;
 };
 
-export const updateModel = async (modelUpdate: ModelUpdate) => {
+export const updateModel = async (codeResources: CodeResources) => {
     if (wrapper.getMonacoEditorApp()?.getConfig().useDiffEditor) {
-        await wrapper.updateDiffModel(modelUpdate);
+        await wrapper.updateDiffModel(codeResources);
     } else {
-        await wrapper.updateModel(modelUpdate);
+        await wrapper.updateModel(codeResources);
     }
 };
 
@@ -53,11 +53,12 @@ const restartEditor = async (userConfig: UserConfig, htmlElement: HTMLElement | 
 };
 
 const configureCodeEditors = (userConfig: UserConfig, code: string, codeOriginal?: string) => {
-    if (userConfig.wrapperConfig.editorAppConfig.useDiffEditor) {
-        userConfig.wrapperConfig.editorAppConfig.code = code;
-        userConfig.wrapperConfig.editorAppConfig.codeOriginal = codeOriginal;
-    } else {
-        userConfig.wrapperConfig.editorAppConfig.code = code;
+    const codeResources = userConfig.wrapperConfig.editorAppConfig.codeResources;
+    if (codeResources.main) {
+        codeResources.main.text = code;
+    }
+    if (userConfig.wrapperConfig.editorAppConfig.useDiffEditor && codeResources.original && codeOriginal) {
+        codeResources.original.text = codeOriginal;
     }
 };
 

--- a/packages/examples/src/groovy/client/main.ts
+++ b/packages/examples/src/groovy/client/main.ts
@@ -44,6 +44,7 @@ const userConfig: UserConfig = {
         }
     },
     languageClientConfig: {
+        languageId: 'groovy',
         options: {
             $type: 'WebSocketUrl',
             url: `ws://localhost:${groovyConfig.port}${groovyConfig.path}`

--- a/packages/examples/src/groovy/client/main.ts
+++ b/packages/examples/src/groovy/client/main.ts
@@ -32,8 +32,12 @@ const userConfig: UserConfig = {
         },
         editorAppConfig: {
             $type: 'extended',
-            languageId: 'groovy',
-            code,
+            codeResources: {
+                main: {
+                    text: code,
+                    fileExt: 'groovy'
+                }
+            },
             useDiffEditor: false,
             userConfiguration: {
                 json: JSON.stringify({

--- a/packages/examples/src/json/client/wrapperWs.ts
+++ b/packages/examples/src/json/client/wrapperWs.ts
@@ -5,7 +5,7 @@
 
 import getKeybindingsServiceOverride from '@codingame/monaco-vscode-keybindings-service-override';
 // this is required syntax highlighting
-import  '@codingame/monaco-vscode-json-default-extension';
+import '@codingame/monaco-vscode-json-default-extension';
 import { disposeEditor, startEditor, swapEditors } from '../../common/example-apps-common.js';
 import { UserConfig } from 'monaco-editor-wrapper';
 import { useWorkerFactory } from 'monaco-editor-wrapper/workerFactory';
@@ -53,6 +53,7 @@ export const jsonClientUserConfig: UserConfig = {
         }
     },
     languageClientConfig: {
+        languageId: 'json',
         options: {
             $type: 'WebSocketUrl',
             url: 'ws://localhost:30000/sampleServer',

--- a/packages/examples/src/json/client/wrapperWs.ts
+++ b/packages/examples/src/json/client/wrapperWs.ts
@@ -20,11 +20,11 @@ export const configureMonacoWorkers = () => {
     });
 };
 
-let codeMain = `{
+let code = `{
     "$schema": "http://json.schemastore.org/coffeelint",
     "line_endings": {"value": "windows"}
 }`;
-const codeOrg = `{
+const codeOriginal = `{
     "$schema": "http://json.schemastore.org/coffeelint",
     "line_endings": {"value": "unix"}
 }`;
@@ -39,10 +39,18 @@ export const jsonClientUserConfig: UserConfig = {
         },
         editorAppConfig: {
             $type: 'extended',
-            languageId: 'json',
-            code: codeMain,
+            codeResources: {
+                main: {
+                    text: code,
+                    fileExt: 'json'
+                },
+                original: {
+                    text: codeOriginal,
+                    fileExt: 'json'
+                }
+            },
             useDiffEditor: false,
-            codeOriginal: codeOrg,
+
             userConfiguration: {
                 json: JSON.stringify({
                     'workbench.colorTheme': 'Default Dark Modern',
@@ -77,13 +85,13 @@ export const runJsonWrapper = () => {
     try {
         const htmlElement = document.getElementById('monaco-editor-root');
         document.querySelector('#button-start')?.addEventListener('click', () => {
-            startEditor(jsonClientUserConfig, htmlElement, codeMain, codeOrg);
+            startEditor(jsonClientUserConfig, htmlElement, code, codeOriginal);
         });
         document.querySelector('#button-swap')?.addEventListener('click', () => {
-            swapEditors(jsonClientUserConfig, htmlElement, codeMain, codeOrg);
+            swapEditors(jsonClientUserConfig, htmlElement, code, codeOriginal);
         });
         document.querySelector('#button-dispose')?.addEventListener('click', async () => {
-            codeMain = await disposeEditor(jsonClientUserConfig.wrapperConfig.editorAppConfig.useDiffEditor);
+            code = await disposeEditor(jsonClientUserConfig.wrapperConfig.editorAppConfig.useDiffEditor);
         });
     } catch (e) {
         console.error(e);

--- a/packages/examples/src/langium/langium-dsl/config/classicConfig.ts
+++ b/packages/examples/src/langium/langium-dsl/config/classicConfig.ts
@@ -44,16 +44,23 @@ export const setupLangiumClientClassic = async (): Promise<UserConfig> => {
             },
             editorAppConfig: {
                 $type: 'classic',
-                languageId: 'langium',
-                code: code,
+                codeResources: {
+                    main: {
+                        text: code,
+                        fileExt: 'langium',
+                        enforceLanguageId: 'langium'
+                    }
+                },
                 useDiffEditor: false,
-                theme: 'vs-dark',
                 editorOptions: {
                     'semanticHighlighting.enabled': true,
-                    wordBasedSuggestions: 'off'
+                    wordBasedSuggestions: 'off',
+                    theme: 'vs-dark'
                 },
-                languageExtensionConfig: { id: 'langium' },
-                languageDef: LangiumMonarchContent,
+                languageDef: {
+                    monarchLanguage: LangiumMonarchContent,
+                    languageExtensionConfig: { id: 'langium' },
+                }
             }
         },
         languageClientConfig: {

--- a/packages/examples/src/langium/langium-dsl/config/classicConfig.ts
+++ b/packages/examples/src/langium/langium-dsl/config/classicConfig.ts
@@ -57,6 +57,7 @@ export const setupLangiumClientClassic = async (): Promise<UserConfig> => {
             }
         },
         languageClientConfig: {
+            languageId: 'langium',
             options: {
                 $type: 'WorkerDirect',
                 worker: langiumWorker

--- a/packages/examples/src/langium/langium-dsl/config/extendedConfig.ts
+++ b/packages/examples/src/langium/langium-dsl/config/extendedConfig.ts
@@ -33,8 +33,12 @@ export const setupLangiumClientExtended = async (): Promise<UserConfig> => {
             },
             editorAppConfig: {
                 $type: 'extended',
-                languageId: 'langium',
-                code: code,
+                codeResources: {
+                    main: {
+                        text: code,
+                        fileExt: 'langium'
+                    }
+                },
                 useDiffEditor: false,
                 extensions: [{
                     config: {

--- a/packages/examples/src/langium/langium-dsl/config/extendedConfig.ts
+++ b/packages/examples/src/langium/langium-dsl/config/extendedConfig.ts
@@ -70,6 +70,7 @@ export const setupLangiumClientExtended = async (): Promise<UserConfig> => {
             }
         },
         languageClientConfig: {
+            languageId: 'langium',
             options: {
                 $type: 'WorkerDirect',
                 worker: langiumWorker

--- a/packages/examples/src/langium/statemachine/config/wrapperStatemachineConfig.ts
+++ b/packages/examples/src/langium/statemachine/config/wrapperStatemachineConfig.ts
@@ -31,8 +31,12 @@ export const createLangiumGlobalConfig = async (worker: Worker, messagePort?: Me
             },
             editorAppConfig: {
                 $type: 'extended',
-                languageId: 'statemachine',
-                code: code,
+                codeResources: {
+                    main: {
+                        text: code,
+                        fileExt: 'statemachine'
+                    }
+                },
                 useDiffEditor: false,
                 extensions: [{
                     config: {

--- a/packages/examples/src/langium/statemachine/config/wrapperStatemachineConfig.ts
+++ b/packages/examples/src/langium/statemachine/config/wrapperStatemachineConfig.ts
@@ -68,6 +68,7 @@ export const createLangiumGlobalConfig = async (worker: Worker, messagePort?: Me
             }
         },
         languageClientConfig: {
+            languageId: 'statemachine',
             options: {
                 $type: 'WorkerDirect',
                 worker,

--- a/packages/examples/src/langium/statemachine/config/wrapperStatemachineConfig.ts
+++ b/packages/examples/src/langium/statemachine/config/wrapperStatemachineConfig.ts
@@ -8,16 +8,25 @@ import getLifecycleServiceOverride from '@codingame/monaco-vscode-lifecycle-serv
 import getLocalizationServiceOverride from '@codingame/monaco-vscode-localization-service-override';
 import { createDefaultLocaleConfiguration } from 'monaco-languageclient/vscode/services';
 import { UserConfig } from 'monaco-editor-wrapper';
-import { getTextContent } from '../../../common/example-apps-common.js';
 
-export const createLangiumGlobalConfig = async (worker: Worker, messagePort?: MessagePort): Promise<UserConfig> => {
-    const code = await getTextContent(new URL('./src/langium/statemachine/content/example.statemachine', window.location.href));
-
+export const createLangiumGlobalConfig = async (params: {
+    text?: string,
+    worker: Worker,
+    messagePort?: MessagePort
+}): Promise<UserConfig> => {
     const extensionFilesOrContents = new Map<string, string | URL>();
     const statemachineLanguageConfig = new URL('./src/langium/statemachine/config/language-configuration.json', window.location.href);
     const responseStatemachineTm = new URL('./src/langium/statemachine/syntaxes/statemachine.tmLanguage.json', window.location.href);
     extensionFilesOrContents.set('/statemachine-configuration.json', statemachineLanguageConfig);
     extensionFilesOrContents.set('/statemachine-grammar.json', responseStatemachineTm);
+
+    let main;
+    if (params.text) {
+        main = {
+            text: params.text,
+            fileExt: 'statemachine'
+        };
+    }
 
     return {
         wrapperConfig: {
@@ -32,10 +41,7 @@ export const createLangiumGlobalConfig = async (worker: Worker, messagePort?: Me
             editorAppConfig: {
                 $type: 'extended',
                 codeResources: {
-                    main: {
-                        text: code,
-                        fileExt: 'statemachine'
-                    }
+                    main
                 },
                 useDiffEditor: false,
                 extensions: [{
@@ -75,8 +81,8 @@ export const createLangiumGlobalConfig = async (worker: Worker, messagePort?: Me
             languageId: 'statemachine',
             options: {
                 $type: 'WorkerDirect',
-                worker,
-                messagePort
+                worker: params.worker,
+                messagePort: params.messagePort
             }
         }
     };

--- a/packages/examples/src/langium/statemachine/main-react.tsx
+++ b/packages/examples/src/langium/statemachine/main-react.tsx
@@ -18,7 +18,9 @@ export const configureMonacoWorkers = () => {
 
 export const runStatemachineReact = async () => {
     try {
-        const langiumGlobalConfig = await createLangiumGlobalConfig(loadStatemachineWorkerRegular());
+        const langiumGlobalConfig = await createLangiumGlobalConfig({
+            worker: loadStatemachineWorkerRegular()
+        });
         const comp = <MonacoEditorReactComp
             userConfig={langiumGlobalConfig}
             style={{

--- a/packages/examples/src/python/client/config.ts
+++ b/packages/examples/src/python/client/config.ts
@@ -14,8 +14,9 @@ import { MonacoLanguageClient } from 'monaco-languageclient';
 export const createUserConfig = (workspaceRoot: string, code: string, codeUri: string): UserConfig => {
     return {
         languageClientConfig: {
+            languageId: 'python',
+            name: 'Python Language Server Example',
             options: {
-                name: 'Python Language Server Example',
                 $type: 'WebSocket',
                 host: 'localhost',
                 port: 30001,

--- a/packages/examples/src/python/client/config.ts
+++ b/packages/examples/src/python/client/config.ts
@@ -57,9 +57,12 @@ export const createUserConfig = (workspaceRoot: string, code: string, codeUri: s
             },
             editorAppConfig: {
                 $type: 'extended',
-                languageId: 'python',
-                code,
-                codeUri,
+                codeResources: {
+                    main: {
+                        text: code,
+                        uri: codeUri
+                    }
+                },
                 extensions: [{
                     config: {
                         name: 'python-client',

--- a/packages/examples/src/ts/wrapperAdvanced.ts
+++ b/packages/examples/src/ts/wrapperAdvanced.ts
@@ -157,7 +157,7 @@ const sleepOne = (milliseconds: number) => {
         appConfig42.useDiffEditor = false;
         const w42Start = wrapper42.initAndStart(wrapper42Config, document.getElementById('monaco-editor-root-42'));
 
-        const w43Start = wrapper43.updateDiffModel({
+        const w43Start = await wrapper43.updateCodeResources({
             main: {
                 text: 'text 5678',
                 fileExt: 'txt'

--- a/packages/examples/src/ts/wrapperAdvanced.ts
+++ b/packages/examples/src/ts/wrapperAdvanced.ts
@@ -43,9 +43,10 @@ Same again.`
         }
     },
     languageClientConfig: {
+        languageId: 'json',
+        name: 'wrapper42 language client',
         options: {
             $type: 'WebSocket',
-            name: 'wrapper42 language client',
             host: 'localhost',
             port: 30000,
             path: 'sampleServer',

--- a/packages/examples/src/ts/wrapperAdvanced.ts
+++ b/packages/examples/src/ts/wrapperAdvanced.ts
@@ -30,16 +30,23 @@ const wrapper42Config: UserConfig = {
         },
         editorAppConfig: {
             $type: 'classic',
-            languageId: 'text/plain',
-            useDiffEditor: true,
-            codeOriginal: `This line is equal.
+            codeResources: {
+                original: {
+                    text: `This line is equal.
 This number is different 2002
 Misspeelled!
 Same again.`,
-            code: `This line is equal.
+                    fileExt: 'txt'
+                },
+                main: {
+                    text: `This line is equal.
 This number is different 2022
 Misspelled!
-Same again.`
+Same again.`,
+                    fileExt: 'txt'
+                }
+            },
+            useDiffEditor: true,
         }
     },
     languageClientConfig: {
@@ -66,10 +73,17 @@ const wrapper43Config: UserConfig = {
         },
         editorAppConfig: {
             $type: 'classic',
-            languageId: 'text/plain',
+            codeResources: {
+                original: {
+                    text: 'This line is equal.\nThis number is different 3022.\nMisspelled!Same again.',
+                    fileExt: 'txt'
+                },
+                main: {
+                    text: 'This line is equal.\nThis number is different 3002.\nMisspelled!Same again.',
+                    fileExt: 'txt'
+                }
+            },
             useDiffEditor: true,
-            codeOriginal: 'This line is equal.\nThis number is different 3022.\nMisspelled!Same again.',
-            code: 'This line is equal.\nThis number is different 3002.\nMisspelled!Same again.',
             editorOptions: {
                 lineNumbers: 'off'
             },
@@ -91,11 +105,15 @@ const wrapper44Config: UserConfig = {
         },
         editorAppConfig: {
             $type: 'classic',
-            languageId: 'javascript',
-            useDiffEditor: false,
-            code: `function logMe() {
+            codeResources: {
+                main: {
+                    text: `function logMe() {
     console.log('Hello monaco-editor-wrapper!');
 };`,
+                    fileExt: 'js'
+                }
+            },
+            useDiffEditor: false,
             editorOptions: {
                 minimap: {
                     enabled: true
@@ -128,28 +146,46 @@ const sleepOne = (milliseconds: number) => {
         await wrapper42.dispose();
         wrapper42Config.languageClientConfig = undefined;
         const appConfig42 = wrapper42Config.wrapperConfig.editorAppConfig as EditorAppConfigClassic;
-        appConfig42.languageId = 'javascript';
-        appConfig42.useDiffEditor = false;
-        appConfig42.code = `function logMe() {
+        appConfig42.codeResources = {
+            main: {
+                text: `function logMe() {
     console.log('Hello swap editors!');
-};`;
+};`,
+                fileExt: 'js'
+            }
+        };
+        appConfig42.useDiffEditor = false;
         const w42Start = wrapper42.initAndStart(wrapper42Config, document.getElementById('monaco-editor-root-42'));
 
         const w43Start = wrapper43.updateDiffModel({
-            languageId: 'javascript',
-            code: 'text 5678',
-            codeOriginal: 'text 1234'
+            main: {
+                text: 'text 5678',
+                fileExt: 'txt'
+            },
+            original: {
+                text: 'text 1234',
+                fileExt: 'txt'
+            }
         });
 
         await wrapper44.dispose();
         const appConfig44 = wrapper44Config.wrapperConfig.editorAppConfig as EditorAppConfigClassic;
-        appConfig44.languageId = 'text/plain';
         appConfig44.useDiffEditor = true;
-        appConfig44.codeOriginal = 'oh la la la!';
-        appConfig44.code = 'oh lo lo lo!';
+        appConfig44.codeResources = {
+            original: {
+                text: 'oh la la la!',
+                fileExt: 'txt'
+            },
+            main: {
+                text: 'oh lo lo lo!',
+                fileExt: 'txt'
+            }
+        };
         // This affects all editors globally and is only effective
         // if it is not in contrast to one configured later
-        appConfig44.theme = 'vs-light';
+        appConfig44.editorOptions = {
+            theme: 'vs-light'
+        };
         const w44Start = wrapper44.initAndStart(wrapper44Config, document.getElementById('monaco-editor-root-44'));
 
         await w42Start;
@@ -168,7 +204,9 @@ const sleepTwo = (milliseconds: number) => {
         await wrapper44.dispose();
         const appConfig44 = wrapper44Config.wrapperConfig.editorAppConfig as EditorAppConfigClassic;
         appConfig44.useDiffEditor = false;
-        appConfig44.theme = 'vs-dark';
+        appConfig44.editorOptions = {
+            theme: 'vs-dark'
+        };
         await wrapper44.initAndStart(wrapper44Config, document.getElementById('monaco-editor-root-44'));
         console.log('Restarted wrapper44.');
     }, milliseconds);

--- a/packages/examples/src/ts/wrapperTs.ts
+++ b/packages/examples/src/ts/wrapperTs.ts
@@ -9,7 +9,7 @@ import getKeybindingsServiceOverride from '@codingame/monaco-vscode-keybindings-
 import '@codingame/monaco-vscode-theme-defaults-default-extension';
 import '@codingame/monaco-vscode-typescript-basics-default-extension';
 import '@codingame/monaco-vscode-typescript-language-features-default-extension';
-import { disposeEditor, getWrapper, startEditor, swapEditors, updateModel } from '../common/example-apps-common.js';
+import { disposeEditor, getWrapper, startEditor, swapEditors } from '../common/example-apps-common.js';
 import { CodePlusUri, UserConfig } from 'monaco-editor-wrapper';
 import { useWorkerFactory } from 'monaco-editor-wrapper/workerFactory';
 
@@ -98,17 +98,25 @@ export const runTsWrapper = async () => {
         document.querySelector('#button-swap-code')?.addEventListener('click', () => {
             const codeResources = wrapper.getMonacoEditorApp()?.getConfig().codeResources;
             if ((codeResources?.main as CodePlusUri).uri === codeUri) {
-                updateModel({
+                wrapper.updateCodeResources({
                     main: {
                         text: codeOriginal,
                         uri: codeOriginalUri
+                    },
+                    original: {
+                        text: code,
+                        uri: codeUri
                     }
                 });
             } else {
-                updateModel({
+                wrapper.updateCodeResources({
                     main: {
                         text: code,
                         uri: codeUri
+                    },
+                    original: {
+                        text: codeOriginal,
+                        uri: codeOriginalUri
                     }
                 });
             }

--- a/packages/examples/src/ts/wrapperTs.ts
+++ b/packages/examples/src/ts/wrapperTs.ts
@@ -10,7 +10,7 @@ import '@codingame/monaco-vscode-theme-defaults-default-extension';
 import '@codingame/monaco-vscode-typescript-basics-default-extension';
 import '@codingame/monaco-vscode-typescript-language-features-default-extension';
 import { disposeEditor, getWrapper, startEditor, swapEditors, updateModel } from '../common/example-apps-common.js';
-import { UserConfig } from 'monaco-editor-wrapper';
+import { CodePlusUri, UserConfig } from 'monaco-editor-wrapper';
 import { useWorkerFactory } from 'monaco-editor-wrapper/workerFactory';
 
 export const configureMonacoWorkers = () => {
@@ -60,10 +60,16 @@ export const runTsWrapper = async () => {
             },
             editorAppConfig: {
                 $type: 'extended',
-                languageId: 'typescript',
-                code,
-                codeUri: codeUri,
-                codeOriginal: codeOriginal,
+                codeResources: {
+                    main: {
+                        text: code,
+                        uri: codeUri
+                    },
+                    original: {
+                        text: codeOriginal,
+                        uri: codeOriginalUri,
+                    }
+                },
                 useDiffEditor: false,
                 editorOptions: monacoEditorConfig,
                 diffEditorOptions: monacoDiffEditorConfig
@@ -90,22 +96,26 @@ export const runTsWrapper = async () => {
             swapEditors(userConfig, htmlElement, code, codeOriginal);
         });
         document.querySelector('#button-swap-code')?.addEventListener('click', () => {
-            if (wrapper.getMonacoEditorApp()?.getConfig().codeUri === codeUri) {
+            const codeResources = wrapper.getMonacoEditorApp()?.getConfig().codeResources;
+            if ((codeResources?.main as CodePlusUri).uri === codeUri) {
                 updateModel({
-                    code: codeOriginal,
-                    codeUri: codeOriginalUri,
-                    languageId: 'typescript',
+                    main: {
+                        text: codeOriginal,
+                        uri: codeOriginalUri
+                    }
                 });
             } else {
                 updateModel({
-                    code: code,
-                    codeUri: codeUri,
-                    languageId: 'typescript',
+                    main: {
+                        text: code,
+                        uri: codeUri
+                    }
                 });
             }
         });
         document.querySelector('#button-dispose')?.addEventListener('click', async () => {
-            if (wrapper.getMonacoEditorApp()?.getConfig().codeUri === codeUri) {
+            const codeResources = wrapper.getMonacoEditorApp()?.getConfig().codeResources;
+            if ((codeResources?.main as CodePlusUri).uri === codeUri) {
                 code = await disposeEditor(userConfig.wrapperConfig.editorAppConfig.useDiffEditor);
             } else {
                 codeOriginal = await disposeEditor(userConfig.wrapperConfig.editorAppConfig.useDiffEditor);

--- a/packages/examples/wrapper_ts.html
+++ b/packages/examples/wrapper_ts.html
@@ -12,7 +12,7 @@
     <h2>Monaco Editor Wrapper TypeScript Example</h2>
     <button type="button" id="button-start">Start</button>
     <button type="button" id="button-swap-code">Swap Code</button>
-    <button type="button" id="button-swap">Swap Diff</button>
+    <button type="button" id="button-swap">Show Diff</button>
     <button type="button" id="button-dispose">Dispose</button>
     <div id="monaco-editor-root" style="height: 80vh;"></div>
     <script type="module">

--- a/packages/wrapper-react/src/index.tsx
+++ b/packages/wrapper-react/src/index.tsx
@@ -52,7 +52,7 @@ export class MonacoEditorReactComp<T extends MonacoEditorProps = MonacoEditorPro
             await this.handleReinit();
         } else {
             // the function now ensure a model update is only required if something else than the code changed
-            this.wrapper.updateModel(userConfig.wrapperConfig.editorAppConfig.codeResources);
+            this.wrapper.updateCodeResources(userConfig.wrapperConfig.editorAppConfig.codeResources);
 
             const config = userConfig.wrapperConfig.editorAppConfig;
             const prevConfig = prevProps.userConfig.wrapperConfig.editorAppConfig;
@@ -169,7 +169,7 @@ export class MonacoEditorReactComp<T extends MonacoEditorProps = MonacoEditorPro
 
         if (!onTextChanged) return;
 
-        const model = this.wrapper.getModel();
+        const model = this.wrapper.getTextModel();
         if (model) {
             const verifyModelContent = () => {
                 const modelText = model.getValue();

--- a/packages/wrapper-react/src/index.tsx
+++ b/packages/wrapper-react/src/index.tsx
@@ -52,7 +52,7 @@ export class MonacoEditorReactComp<T extends MonacoEditorProps = MonacoEditorPro
             await this.handleReinit();
         } else {
             // the function now ensure a model update is only required if something else than the code changed
-            this.wrapper.updateModel(userConfig.wrapperConfig.editorAppConfig);
+            this.wrapper.updateModel(userConfig.wrapperConfig.editorAppConfig.codeResources);
 
             const config = userConfig.wrapperConfig.editorAppConfig;
             const prevConfig = prevProps.userConfig.wrapperConfig.editorAppConfig;
@@ -173,7 +173,7 @@ export class MonacoEditorReactComp<T extends MonacoEditorProps = MonacoEditorPro
         if (model) {
             const verifyModelContent = () => {
                 const modelText = model.getValue();
-                onTextChanged(modelText, modelText !== userConfig.wrapperConfig.editorAppConfig.code);
+                onTextChanged(modelText, modelText !== userConfig.wrapperConfig.editorAppConfig.codeResources.main?.text);
             };
 
             this._subscription = model.onDidChangeContent(() => {

--- a/packages/wrapper/src/commonTypes.ts
+++ b/packages/wrapper/src/commonTypes.ts
@@ -12,20 +12,16 @@ export type WebSocketCallOptions = {
     reportStatus?: boolean;
 }
 
-export type LanguageClientConfigBase = {
-    name?: string;
-}
-
 export type LanguageClientConfigType = 'WebSocket' | 'WebSocketUrl' | 'WorkerConfig' | 'Worker';
 
-export type WebSocketUrl = LanguageClientConfigBase & {
+export type WebSocketUrl = {
     secured: boolean;
     host: string;
     port?: number;
     path?: string;
 }
 
-export type WebSocketConfigOptions = LanguageClientConfigBase & {
+export type WebSocketConfigOptions = {
     $type: 'WebSocket'
     secured: boolean;
     host: string;
@@ -36,21 +32,22 @@ export type WebSocketConfigOptions = LanguageClientConfigBase & {
     stopOptions?: WebSocketCallOptions;
 }
 
-export type WebSocketConfigOptionsUrl = LanguageClientConfigBase & {
+export type WebSocketConfigOptionsUrl = {
     $type: 'WebSocketUrl'
     url: string;
     startOptions?: WebSocketCallOptions;
     stopOptions?: WebSocketCallOptions;
 }
 
-export type WorkerConfigOptions = LanguageClientConfigBase & {
+export type WorkerConfigOptions = {
     $type: 'WorkerConfig'
     url: URL;
     type: 'classic' | 'module';
     messagePort?: MessagePort;
+    workerName?: string;
 };
 
-export type WorkerConfigDirect = LanguageClientConfigBase & {
+export type WorkerConfigDirect = {
     $type: 'WorkerDirect';
     worker: Worker;
     messagePort?: MessagePort;

--- a/packages/wrapper/src/editorAppBase.ts
+++ b/packages/wrapper/src/editorAppBase.ts
@@ -114,15 +114,12 @@ export abstract class EditorAppBase {
         await this.updateEditorModels(modelRefs.modelRef, modelRefs.modelRefOriginal);
     }
 
-    protected disposeEditor() {
+    protected disposeEditors() {
         if (this.editor) {
             this.modelRef?.dispose();
             this.editor.dispose();
             this.editor = undefined;
         }
-    }
-
-    protected disposeDiffEditor() {
         if (this.diffEditor) {
             this.modelRef?.dispose();
             this.modelRefOriginal?.dispose();

--- a/packages/wrapper/src/editorAppClassic.ts
+++ b/packages/wrapper/src/editorAppClassic.ts
@@ -87,8 +87,7 @@ export class EditorAppClassic extends EditorAppBase {
     }
 
     disposeApp(): void {
-        this.disposeEditor();
-        this.disposeDiffEditor();
+        this.disposeEditors();
     }
 
     isAppConfigDifferent(orgConfig: EditorAppConfigClassic, config: EditorAppConfigClassic, includeModelData: boolean): boolean {

--- a/packages/wrapper/src/editorAppClassic.ts
+++ b/packages/wrapper/src/editorAppClassic.ts
@@ -6,7 +6,7 @@
 import * as monaco from 'monaco-editor';
 import { Logger } from 'monaco-languageclient/tools';
 import { EditorAppBase, EditorAppConfigBase, ModelUpdateType, isEqual, isModelUpdateRequired } from './editorAppBase.js';
-import { UserConfig } from './wrapper.js';
+import { UserConfig } from './userConfig.js';
 
 export type EditorAppConfigClassic = EditorAppConfigBase & {
     $type: 'classic';

--- a/packages/wrapper/src/editorAppExtended.ts
+++ b/packages/wrapper/src/editorAppExtended.ts
@@ -104,8 +104,7 @@ export class EditorAppExtended extends EditorAppBase {
     }
 
     disposeApp(): void {
-        this.disposeEditor();
-        this.disposeDiffEditor();
+        this.disposeEditors();
         this.extensionRegisterResults.forEach((k) => k?.dispose());
     }
 

--- a/packages/wrapper/src/editorAppExtended.ts
+++ b/packages/wrapper/src/editorAppExtended.ts
@@ -5,11 +5,11 @@
 
 import type * as vscode from 'vscode';
 import * as monaco from 'monaco-editor';
-import { EditorAppBase, EditorAppConfigBase, ModelUpdateType, isEqual, isModelUpdateRequired } from './editorAppBase.js';
+import { EditorAppBase, EditorAppConfigBase } from './editorAppBase.js';
 import { registerExtension, IExtensionManifest, ExtensionHostKind } from 'vscode/extensions';
 import { Logger } from 'monaco-languageclient/tools';
 import { UserConfig } from './userConfig.js';
-import { verifyUrlorCreateDataUrl } from './utils.js';
+import { verifyUrlorCreateDataUrl, ModelUpdateType, isEqual, isModelUpdateRequired } from './utils.js';
 
 export type ExtensionConfig = {
     config: IExtensionManifest | object;
@@ -48,7 +48,6 @@ export class EditorAppExtended extends EditorAppBase {
 
     private config: EditorAppConfigExtended;
     private extensionRegisterResults: Map<string, RegisterLocalProcessExtensionResult | RegisterExtensionResult | undefined> = new Map();
-    private logger: Logger | undefined;
 
     constructor(id: string, userConfig: UserConfig, logger?: Logger) {
         super(id);
@@ -113,7 +112,7 @@ export class EditorAppExtended extends EditorAppBase {
     isAppConfigDifferent(orgConfig: EditorAppConfigExtended, config: EditorAppConfigExtended, includeModelData: boolean): boolean {
         let different = false;
         if (includeModelData) {
-            different = isModelUpdateRequired(orgConfig, config) !== ModelUpdateType.NONE;
+            different = isModelUpdateRequired(orgConfig.codeResources, config.codeResources) !== ModelUpdateType.NONE;
         }
         const propsExtended = [
             // model required changes are not taken into account in this list

--- a/packages/wrapper/src/editorAppExtended.ts
+++ b/packages/wrapper/src/editorAppExtended.ts
@@ -8,7 +8,7 @@ import * as monaco from 'monaco-editor';
 import { EditorAppBase, EditorAppConfigBase, ModelUpdateType, isEqual, isModelUpdateRequired } from './editorAppBase.js';
 import { registerExtension, IExtensionManifest, ExtensionHostKind } from 'vscode/extensions';
 import { Logger } from 'monaco-languageclient/tools';
-import { UserConfig } from './wrapper.js';
+import { UserConfig } from './userConfig.js';
 import { verifyUrlorCreateDataUrl } from './utils.js';
 
 export type ExtensionConfig = {

--- a/packages/wrapper/src/index.ts
+++ b/packages/wrapper/src/index.ts
@@ -5,16 +5,15 @@
 
 import {
     EditorAppBase,
-    isCodeUpdateRequired,
-    isModelUpdateRequired,
-    isEqual,
-    ModelUpdateType
 } from './editorAppBase.js';
 
 import type {
     EditorAppConfigBase,
     EditorAppType,
-    ModelUpdate
+    CodeContent,
+    CodePlusUri,
+    CodePlusFileExt,
+    CodeResources
 } from './editorAppBase.js';
 
 import type {
@@ -83,19 +82,19 @@ export type {
     LanguageClientConfig,
     LanguageClientError,
     UserConfig,
-    ModelUpdate
+    CodeContent,
+    CodePlusUri,
+    CodePlusFileExt,
+    CodeResources
 };
 
 export {
     MonacoEditorLanguageClientWrapper,
     LanguageClientWrapper,
     EditorAppBase,
-    isCodeUpdateRequired,
-    isModelUpdateRequired,
-    isEqual,
-    ModelUpdateType,
     EditorAppClassic,
     EditorAppExtended
 };
 
 export * from './utils.js';
+export type * from './utils.js';

--- a/packages/wrapper/src/index.ts
+++ b/packages/wrapper/src/index.ts
@@ -13,7 +13,8 @@ import type {
     CodeContent,
     CodePlusUri,
     CodePlusFileExt,
-    CodeResources
+    CodeResources,
+    ModelRefs
 } from './editorAppBase.js';
 
 import type {
@@ -85,7 +86,8 @@ export type {
     CodeContent,
     CodePlusUri,
     CodePlusFileExt,
-    CodeResources
+    CodeResources,
+    ModelRefs
 };
 
 export {

--- a/packages/wrapper/src/index.ts
+++ b/packages/wrapper/src/index.ts
@@ -58,7 +58,7 @@ import {
 import type {
     UserConfig,
     WrapperConfig
-} from './wrapper.js';
+} from './userConfig.js';
 
 import {
     MonacoEditorLanguageClientWrapper,

--- a/packages/wrapper/src/userConfig.ts
+++ b/packages/wrapper/src/userConfig.ts
@@ -1,0 +1,22 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2024 TypeFox and others.
+ * Licensed under the MIT License. See LICENSE in the package root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { InitializeServiceConfig } from 'monaco-languageclient/vscode/services';
+import type { LoggerConfig } from 'monaco-languageclient/tools';
+import { EditorAppConfigExtended } from './editorAppExtended.js';
+import { EditorAppConfigClassic } from './editorAppClassic.js';
+import { LanguageClientConfig } from './languageClientWrapper.js';
+
+export type WrapperConfig = {
+    serviceConfig?: InitializeServiceConfig;
+    editorAppConfig: EditorAppConfigExtended | EditorAppConfigClassic;
+};
+
+export type UserConfig = {
+    id?: string;
+    loggerConfig?: LoggerConfig;
+    wrapperConfig: WrapperConfig;
+    languageClientConfig?: LanguageClientConfig;
+}

--- a/packages/wrapper/src/utils.ts
+++ b/packages/wrapper/src/utils.ts
@@ -46,14 +46,11 @@ export const verifyUrlorCreateDataUrl = (input: string | URL) => {
     return (input instanceof URL) ? input.href : new URL(`data:text/plain;base64,${btoa(input)}`).href;
 };
 
-export const getEditorUri = (id: string, diffCode: boolean, code?: CodePlusUri | CodePlusFileExt, basePath?: string) => {
-    if (!code) {
-        throw new Error('The provided code definition is undefined.');
-    }
+export const getEditorUri = (id: string, original: boolean, code: CodePlusUri | CodePlusFileExt, basePath?: string) => {
     if (Object.hasOwn(code, 'uri')) {
         return vscode.Uri.parse((code as CodePlusUri).uri);
     } else {
-        return vscode.Uri.parse(`${basePath ?? '/workspace'}/model${diffCode ? 'Original' : ''}${id}.${(code as CodePlusFileExt).fileExt}`);
+        return vscode.Uri.parse(`${basePath ?? '/workspace'}/model${original ? 'Original' : ''}${id}.${(code as CodePlusFileExt).fileExt}`);
     }
 };
 

--- a/packages/wrapper/src/utils.ts
+++ b/packages/wrapper/src/utils.ts
@@ -3,7 +3,9 @@
  * Licensed under the MIT License. See LICENSE in the package root for license information.
  * ------------------------------------------------------------------------------------------ */
 
+import * as vscode from 'vscode';
 import { WebSocketConfigOptions, WebSocketConfigOptionsUrl } from './commonTypes.js';
+import { CodePlusFileExt, CodePlusUri, CodeResources } from './editorAppBase.js';
 
 export const createUrl = (config: WebSocketConfigOptions | WebSocketConfigOptionsUrl) => {
     let buildUrl = '';
@@ -42,4 +44,68 @@ export const createUrl = (config: WebSocketConfigOptions | WebSocketConfigOption
 
 export const verifyUrlorCreateDataUrl = (input: string | URL) => {
     return (input instanceof URL) ? input.href : new URL(`data:text/plain;base64,${btoa(input)}`).href;
+};
+
+export const getEditorUri = (id: string, diffCode: boolean, code?: CodePlusUri | CodePlusFileExt, basePath?: string) => {
+    if (!code) {
+        throw new Error('The provided code definition is undefined.');
+    }
+    if (Object.hasOwn(code, 'uri')) {
+        return vscode.Uri.parse((code as CodePlusUri).uri);
+    } else {
+        return vscode.Uri.parse(`${basePath ?? '/workspace'}/model${diffCode ? 'Original' : ''}${id}.${(code as CodePlusFileExt).fileExt}`);
+    }
+};
+
+export enum ModelUpdateType {
+    NONE,
+    CODE,
+    MODEL,
+    CODE_AND_MODEL
+}
+
+export const isCodeUpdateRequired = (codeResourcesPrevious: CodeResources, codeResources: CodeResources) => {
+    const a = evaluateCodeUpdate(codeResourcesPrevious.main);
+    const b = evaluateCodeUpdate(codeResources.main);
+    const c = evaluateCodeUpdate(codeResourcesPrevious.original);
+    const d = evaluateCodeUpdate(codeResources.original);
+    return a !== b || c !== d ? ModelUpdateType.CODE : ModelUpdateType.NONE;
+};
+
+export const evaluateCodeUpdate = (code?: CodePlusUri | CodePlusFileExt) => {
+    return code && Object.hasOwn(code, 'text') ? code.text : undefined;
+};
+
+export const isModelUpdateRequired = (codeResourcesPrevious: CodeResources, codeResources: CodeResources): ModelUpdateType => {
+    const codeUpdateType = isCodeUpdateRequired(codeResourcesPrevious, codeResources);
+    const codeChanged = codeUpdateType === ModelUpdateType.CODE;
+
+    const a = evaluateCodeModel(codeResourcesPrevious.main);
+    const b = evaluateCodeModel(codeResources.main);
+    const c = evaluateCodeModel(codeResourcesPrevious.original);
+    const d = evaluateCodeModel(codeResources.original);
+    const modelChanged = a !== b || c !== d;
+
+    return (modelChanged && codeChanged) ? ModelUpdateType.CODE_AND_MODEL : (modelChanged ? ModelUpdateType.MODEL : (codeChanged ? ModelUpdateType.CODE : ModelUpdateType.NONE));
+};
+
+export const evaluateCodeModel = (code?: CodePlusUri | CodePlusFileExt) => {
+    if (code) {
+        return Object.hasOwn(code, 'uri') ? (code as CodePlusUri).uri : (Object.hasOwn(code, 'fileExt') ? (code as CodePlusFileExt).fileExt : undefined);
+    } else {
+        return undefined;
+    }
+};
+
+/**
+ * The check for equality relies on JSON.stringify for instances of type Object.
+ * Everything else is directly compared.
+ * In this context, the check for equality is sufficient.
+ */
+export const isEqual = (obj1: unknown, obj2: unknown) => {
+    if (obj1 instanceof Object && obj2 instanceof Object) {
+        return JSON.stringify(obj1) === JSON.stringify(obj2);
+    } else {
+        return obj1 === obj2;
+    }
 };

--- a/packages/wrapper/src/wrapper.ts
+++ b/packages/wrapper/src/wrapper.ts
@@ -4,13 +4,15 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as monaco from 'monaco-editor';
+import { ITextFileEditorModel } from 'vscode/monaco';
+import { IReference } from '@codingame/monaco-vscode-editor-service-override';
 import { MonacoLanguageClient } from 'monaco-languageclient';
 import { initServices } from 'monaco-languageclient/vscode/services';
 import { Logger } from 'monaco-languageclient/tools';
 import { checkServiceConsistency, configureServices } from './vscode/services.js';
 import { EditorAppExtended } from './editorAppExtended.js';
 import { EditorAppClassic } from './editorAppClassic.js';
-import { CodeResources } from './editorAppBase.js';
+import { CodeResources, ModelRefs } from './editorAppBase.js';
 import { LanguageClientWrapper } from './languageClientWrapper.js';
 import { WorkerConfigDirect, WorkerConfigOptions } from './commonTypes.js';
 import { UserConfig } from './userConfig.js';
@@ -145,20 +147,24 @@ export class MonacoEditorLanguageClientWrapper {
         return this.languageClientWrapper?.getLanguageClient();
     }
 
-    getModel(original?: boolean): monaco.editor.ITextModel | undefined {
-        return this.editorApp?.getModel(original);
+    getTextModel(original?: boolean): monaco.editor.ITextModel | undefined {
+        return this.editorApp?.getTextModel(original);
+    }
+
+    getModelRefs(): ModelRefs | undefined {
+        return this.editorApp?.getModelRefs();
     }
 
     getWorker(): Worker | undefined {
         return this.languageClientWrapper?.getWorker();
     }
 
-    async updateModel(codeResources: CodeResources): Promise<void> {
-        await this.editorApp?.updateModel(codeResources);
+    async updateCodeResources(codeResources: CodeResources): Promise<void> {
+        return this.editorApp?.updateCodeResources(codeResources);
     }
 
-    async updateDiffModel(codeResources: CodeResources): Promise<void> {
-        await this.editorApp?.updateDiffModel(codeResources);
+    async updateEditorModels(main: IReference<ITextFileEditorModel>, original?: IReference<ITextFileEditorModel>): Promise<void> {
+        return this.editorApp?.updateEditorModels(main, original);
     }
 
     public reportStatus() {

--- a/packages/wrapper/src/wrapper.ts
+++ b/packages/wrapper/src/wrapper.ts
@@ -10,7 +10,7 @@ import { Logger } from 'monaco-languageclient/tools';
 import { checkServiceConsistency, configureServices } from './vscode/services.js';
 import { EditorAppExtended } from './editorAppExtended.js';
 import { EditorAppClassic } from './editorAppClassic.js';
-import { ModelUpdate } from './editorAppBase.js';
+import { CodeResources } from './editorAppBase.js';
 import { LanguageClientWrapper } from './languageClientWrapper.js';
 import { WorkerConfigDirect, WorkerConfigOptions } from './commonTypes.js';
 import { UserConfig } from './userConfig.js';
@@ -37,8 +37,8 @@ export class MonacoEditorLanguageClientWrapper {
         }
 
         const editorAppConfig = userConfig.wrapperConfig.editorAppConfig;
-        if (editorAppConfig.useDiffEditor && !editorAppConfig.codeOriginal) {
-            throw new Error(`Use diff editor was used without a valid config. code: ${editorAppConfig.code} codeOriginal: ${editorAppConfig.codeOriginal}`);
+        if (editorAppConfig.useDiffEditor && !editorAppConfig.codeResources.original) {
+            throw new Error(`Use diff editor was used without a valid config. code: ${editorAppConfig.codeResources.main} codeOriginal: ${editorAppConfig.codeResources.original}`);
         }
 
         // Always dispose old instances before start
@@ -153,12 +153,12 @@ export class MonacoEditorLanguageClientWrapper {
         return this.languageClientWrapper?.getWorker();
     }
 
-    async updateModel(modelUpdate: ModelUpdate): Promise<void> {
-        await this.editorApp?.updateModel(modelUpdate);
+    async updateModel(codeResources: CodeResources): Promise<void> {
+        await this.editorApp?.updateModel(codeResources);
     }
 
-    async updateDiffModel(modelUpdate: ModelUpdate): Promise<void> {
-        await this.editorApp?.updateDiffModel(modelUpdate);
+    async updateDiffModel(codeResources: CodeResources): Promise<void> {
+        await this.editorApp?.updateDiffModel(codeResources);
     }
 
     public reportStatus() {

--- a/packages/wrapper/src/wrapper.ts
+++ b/packages/wrapper/src/wrapper.ts
@@ -5,27 +5,15 @@
 
 import * as monaco from 'monaco-editor';
 import { MonacoLanguageClient } from 'monaco-languageclient';
-import { InitializeServiceConfig, initServices } from 'monaco-languageclient/vscode/services';
+import { initServices } from 'monaco-languageclient/vscode/services';
 import { Logger } from 'monaco-languageclient/tools';
-import type { LoggerConfig } from 'monaco-languageclient/tools';
 import { checkServiceConsistency, configureServices } from './vscode/services.js';
-import { EditorAppExtended, EditorAppConfigExtended } from './editorAppExtended.js';
-import { EditorAppClassic, EditorAppConfigClassic } from './editorAppClassic.js';
+import { EditorAppExtended } from './editorAppExtended.js';
+import { EditorAppClassic } from './editorAppClassic.js';
 import { ModelUpdate } from './editorAppBase.js';
-import { LanguageClientConfig, LanguageClientWrapper } from './languageClientWrapper.js';
+import { LanguageClientWrapper } from './languageClientWrapper.js';
 import { WorkerConfigDirect, WorkerConfigOptions } from './commonTypes.js';
-
-export type WrapperConfig = {
-    serviceConfig?: InitializeServiceConfig;
-    editorAppConfig: EditorAppConfigExtended | EditorAppConfigClassic;
-};
-
-export type UserConfig = {
-    id?: string;
-    loggerConfig?: LoggerConfig;
-    wrapperConfig: WrapperConfig;
-    languageClientConfig?: LanguageClientConfig;
-}
+import { UserConfig } from './userConfig.js';
 
 /**
  * This class is responsible for the overall ochestration.
@@ -78,12 +66,13 @@ export class MonacoEditorLanguageClientWrapper {
             logger: this.logger
         });
 
-        this.languageClientWrapper = new LanguageClientWrapper();
-        await this.languageClientWrapper.init({
-            languageId: this.editorApp.getConfig().languageId,
-            languageClientConfig: userConfig.languageClientConfig,
-            logger: this.logger
-        });
+        if (userConfig.languageClientConfig) {
+            this.languageClientWrapper = new LanguageClientWrapper();
+            await this.languageClientWrapper.init({
+                languageClientConfig: userConfig.languageClientConfig,
+                logger: this.logger
+            });
+        }
 
         this.initDone = true;
     }
@@ -130,6 +119,10 @@ export class MonacoEditorLanguageClientWrapper {
             return this.languageClientWrapper.isStarted();
         }
         return true;
+    }
+
+    haveLanguageClient(): boolean {
+        return this.languageClientWrapper !== undefined;
     }
 
     getMonacoEditorApp() {

--- a/packages/wrapper/test/editorAppBase.test.ts
+++ b/packages/wrapper/test/editorAppBase.test.ts
@@ -4,8 +4,8 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { describe, expect, test } from 'vitest';
-import { isCodeUpdateRequired, isModelUpdateRequired, EditorAppClassic, ModelUpdateType } from 'monaco-editor-wrapper';
-import { createBaseConfig, createEditorAppConfig, createWrapperConfig } from './helper.js';
+import { isCodeUpdateRequired, isModelUpdateRequired, ModelUpdateType } from 'monaco-editor-wrapper';
+import { createEditorAppConfig, createWrapperConfig } from './helper.js';
 
 describe('Test EditorAppBase', () => {
 
@@ -17,16 +17,6 @@ describe('Test EditorAppBase', () => {
     test('extended type: empty EditorAppConfigExtended', () => {
         const wrapperConfig = createWrapperConfig('extended');
         expect(wrapperConfig.editorAppConfig.$type).toBe('extended');
-    });
-
-    test('config defaults', () => {
-        const config = createBaseConfig('classic');
-        const app = new EditorAppClassic('config defaults', config);
-        expect(app.getConfig().codeResources.main?.text).toEqual('');
-        expect(app.getConfig().codeResources.original).toBeUndefined();
-        expect(app.getConfig().useDiffEditor).toBeFalsy();
-        expect(app.getConfig().readOnly).toBeFalsy();
-        expect(app.getConfig().domReadOnly).toBeFalsy();
     });
 
     test('isCodeUpdateRequired', () => {

--- a/packages/wrapper/test/editorAppBase.test.ts
+++ b/packages/wrapper/test/editorAppBase.test.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { describe, expect, test } from 'vitest';
-import { isModelUpdateRequired, EditorAppClassic, ModelUpdateType } from 'monaco-editor-wrapper';
+import { isCodeUpdateRequired, isModelUpdateRequired, EditorAppClassic, ModelUpdateType } from 'monaco-editor-wrapper';
 import { createBaseConfig, createEditorAppConfig, createWrapperConfig } from './helper.js';
 
 describe('Test EditorAppBase', () => {
@@ -22,29 +22,50 @@ describe('Test EditorAppBase', () => {
     test('config defaults', () => {
         const config = createBaseConfig('classic');
         const app = new EditorAppClassic('config defaults', config);
-        expect(app.getConfig().languageId).toEqual('my-lang');
-        expect(app.getConfig().code).toEqual('');
-        expect(app.getConfig().codeOriginal).toEqual('');
+        expect(app.getConfig().codeResources.main?.text).toEqual('');
+        expect(app.getConfig().codeResources.original).toBeUndefined();
         expect(app.getConfig().useDiffEditor).toBeFalsy();
-        expect(app.getConfig().codeUri).toBeUndefined();
-        expect(app.getConfig().codeOriginalUri).toBeUndefined();
         expect(app.getConfig().readOnly).toBeFalsy();
         expect(app.getConfig().domReadOnly).toBeFalsy();
     });
 
+    test('isCodeUpdateRequired', () => {
+        let codeUpdateType = isCodeUpdateRequired({ main: { text: '', fileExt: 'js' } }, { main: { text: '', fileExt: 'js' } });
+        expect(codeUpdateType).toBe(ModelUpdateType.NONE);
+
+        codeUpdateType = isCodeUpdateRequired({}, {});
+        expect(codeUpdateType).toBe(ModelUpdateType.NONE);
+
+        codeUpdateType = isCodeUpdateRequired({ main: { text: 'bar', fileExt: 'js' } }, { main: { text: '', fileExt: 'js' } });
+        expect(codeUpdateType).toBe(ModelUpdateType.CODE);
+
+        codeUpdateType = isCodeUpdateRequired({ main: { text: '', fileExt: 'js' } }, { main: { text: 'bar', fileExt: 'js' } });
+        expect(codeUpdateType).toBe(ModelUpdateType.CODE);
+
+        codeUpdateType = isCodeUpdateRequired({}, { main: { text: 'bar', fileExt: 'js' } });
+        expect(codeUpdateType).toBe(ModelUpdateType.CODE);
+
+        codeUpdateType = isCodeUpdateRequired({ main: { text: 'bar', fileExt: 'js' } }, {});
+        expect(codeUpdateType).toBe(ModelUpdateType.CODE);
+    });
+
     test('isModelUpdateRequired', () => {
         const config = createEditorAppConfig('classic');
-        let modelUpdateType = isModelUpdateRequired(config, { languageId: 'my-lang', code: '' });
+
+        let modelUpdateType = isModelUpdateRequired(config.codeResources, { main: { text: '', fileExt: 'js' } });
         expect(modelUpdateType).toBe(ModelUpdateType.NONE);
 
-        modelUpdateType = isModelUpdateRequired(config, { languageId: 'my-lang' });
-        expect(modelUpdateType).toBe(ModelUpdateType.NONE);
-
-        modelUpdateType = isModelUpdateRequired(config, { languageId: 'my-lang', code: 'test' });
+        modelUpdateType = isModelUpdateRequired(config.codeResources, { main: { text: 'bar', fileExt: 'js' } });
         expect(modelUpdateType).toBe(ModelUpdateType.CODE);
 
-        modelUpdateType = isModelUpdateRequired(config, { languageId: 'javascript', code: 'test' });
-        expect(modelUpdateType).toBe(ModelUpdateType.MODEL);
+        modelUpdateType = isModelUpdateRequired(config.codeResources, { main: { text: 'bar', uri: 'file:///bar.js' } });
+        expect(modelUpdateType).toBe(ModelUpdateType.CODE_AND_MODEL);
+
+        modelUpdateType = isModelUpdateRequired(config.codeResources, { original: { text: 'bar', fileExt: 'python' } });
+        expect(modelUpdateType).toBe(ModelUpdateType.CODE_AND_MODEL);
+
+        modelUpdateType = isModelUpdateRequired(config.codeResources, {});
+        expect(modelUpdateType).toBe(ModelUpdateType.CODE_AND_MODEL);
     });
 
 });

--- a/packages/wrapper/test/editorAppClassic.test.ts
+++ b/packages/wrapper/test/editorAppClassic.test.ts
@@ -49,11 +49,17 @@ describe('Test EditorAppClassic', () => {
         const app = new EditorAppClassic('test', createBaseConfig('classic'));
         expect(app.isAppConfigDifferent(orgConfig, config, false)).toBeFalsy();
 
-        config.code = 'test';
+        config.codeResources.main = {
+            text: 'test',
+            fileExt: 'js'
+        };
         expect(app.isAppConfigDifferent(orgConfig, config, false)).toBeFalsy();
         expect(app.isAppConfigDifferent(orgConfig, config, true)).toBeTruthy();
 
-        config.code = '';
+        config.codeResources.main = {
+            text: '',
+            fileExt: 'js'
+        };
         config.useDiffEditor = true;
         expect(app.isAppConfigDifferent(orgConfig, config, false)).toBeTruthy();
     });

--- a/packages/wrapper/test/editorAppClassic.test.ts
+++ b/packages/wrapper/test/editorAppClassic.test.ts
@@ -75,4 +75,15 @@ describe('Test EditorAppClassic', () => {
         const app = new EditorAppClassic('config defaults', config1);
         expect(app.isAppConfigDifferent(configclassic1, configclassic2, false)).toBeFalsy();
     });
+
+    test('config defaults', () => {
+        const config = createBaseConfig('classic');
+        const app = new EditorAppClassic('config defaults', config);
+        expect(app.getConfig().codeResources.main?.text).toEqual('');
+        expect(app.getConfig().codeResources.original).toBeUndefined();
+        expect(app.getConfig().useDiffEditor).toBeFalsy();
+        expect(app.getConfig().readOnly).toBeFalsy();
+        expect(app.getConfig().domReadOnly).toBeFalsy();
+    });
+
 });

--- a/packages/wrapper/test/editorAppExtended.test.ts
+++ b/packages/wrapper/test/editorAppExtended.test.ts
@@ -58,4 +58,14 @@ describe('Test EditorAppExtended', () => {
         }];
         expect(app.isAppConfigDifferent(orgConfig, config, false)).toBeTruthy();
     });
+
+    test('config defaults', () => {
+        const config = createBaseConfig('extended');
+        const app = new EditorAppExtended('config defaults', config);
+        expect(app.getConfig().codeResources.main?.text).toEqual('');
+        expect(app.getConfig().codeResources.original).toBeUndefined();
+        expect(app.getConfig().useDiffEditor).toBeFalsy();
+        expect(app.getConfig().readOnly).toBeFalsy();
+        expect(app.getConfig().domReadOnly).toBeFalsy();
+    });
 });

--- a/packages/wrapper/test/editorAppExtended.test.ts
+++ b/packages/wrapper/test/editorAppExtended.test.ts
@@ -36,10 +36,16 @@ describe('Test EditorAppExtended', () => {
         const app = new EditorAppExtended('test', createBaseConfig('extended'));
         expect(app.isAppConfigDifferent(orgConfig, config, false)).toBeFalsy();
 
-        config.code = 'test';
+        config.codeResources.main = {
+            text: 'test',
+            fileExt: 'js'
+        };
         expect(app.isAppConfigDifferent(orgConfig, config, true)).toBeTruthy();
 
-        config.code = '';
+        config.codeResources.main = {
+            text: '',
+            fileExt: 'js'
+        };
         config.extensions = [{
             config: {
                 name: 'Tester',

--- a/packages/wrapper/test/helper.ts
+++ b/packages/wrapper/test/helper.ts
@@ -46,9 +46,18 @@ export const updateExtendedAppPrototyp = async () => {
  * Error: Unable to load extension-file://vscode.theme-defaults/themes/light_modern.json:
  * Unable to read file 'extension-file://vscode.theme-defaults/themes/light_modern.json' (TypeError: Failed to fetch)
  */
-export const createWrapper = async (userConfig: UserConfig) => {
+export const createAndInitWrapper = async (userConfig: UserConfig) => {
     updateExtendedAppPrototyp();
     const wrapper = new MonacoEditorLanguageClientWrapper();
     await wrapper.init(userConfig);
     return wrapper;
+};
+
+/**
+ * Helper to generate a quick worker from a function blob
+ */
+export const createWorkerFromFunction = (fn: () => void): Worker => {
+    return new Worker(URL.createObjectURL(
+        new Blob([`(${fn.toString()})()`], { type: 'application/javascript' })
+    ));
 };

--- a/packages/wrapper/test/helper.ts
+++ b/packages/wrapper/test/helper.ts
@@ -26,8 +26,12 @@ export const createWrapperConfig = (type: EditorAppType) => {
 export const createEditorAppConfig = (type: EditorAppType) => {
     return {
         $type: type,
-        languageId: 'my-lang',
-        code: '',
+        codeResources: {
+            main: {
+                text: '',
+                fileExt: 'js'
+            }
+        },
         useDiffEditor: false,
     };
 };

--- a/packages/wrapper/test/languageClientWrapper.test.ts
+++ b/packages/wrapper/test/languageClientWrapper.test.ts
@@ -4,47 +4,41 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { describe, expect, test } from 'vitest';
-import { createBaseConfig, createWrapper } from './helper.js';
+import { LanguageClientConfig, LanguageClientWrapper } from 'monaco-editor-wrapper';
+import { createBaseConfig, createWorkerFromFunction, createAndInitWrapper } from './helper.js';
 
 describe('Test LanguageClientWrapper', () => {
 
-    test('Not Running after construction', async () => {
-        const wrapper = await createWrapper(createBaseConfig('extended'));
+    test('Not defined after construction without configuration', async () => {
+        const wrapper = await createAndInitWrapper(createBaseConfig('extended'));
 
         const languageClientWrapper = wrapper.getLanguageClientWrapper();
-        expect(languageClientWrapper).toBeDefined();
-
-        expect(languageClientWrapper!.haveLanguageClient()).toBeFalsy();
-        expect(languageClientWrapper!.haveLanguageClientConfig()).toBeFalsy();
-        expect(languageClientWrapper!.isStarted()).toBeFalsy();
+        expect(languageClientWrapper).toBeUndefined();
     });
 
     test('Constructor: no config', async () => {
-        const wrapper = await createWrapper(createBaseConfig('extended'));
-
-        const languageClientWrapper = wrapper.getLanguageClientWrapper();
-        expect(languageClientWrapper).toBeDefined();
-
-        console.log(window.MonacoEnvironment);
-        expect(async () => {
-            await languageClientWrapper!.start();
-        }).rejects.toEqual({
-            message: 'languageClientWrapper (undefined): Unable to start monaco-languageclient. No configuration was provided.',
-            error: 'No error was provided.'
+        // create a web worker to pass to the wrapper
+        const worker = createWorkerFromFunction(() => {
+            console.info('Hello');
         });
+        const languageClientConfig: LanguageClientConfig = {
+            languageId: 'javascript',
+            options: {
+                $type: 'WorkerDirect',
+                worker
+            }
+        };
+
+        const languageClientWrapper = new LanguageClientWrapper();
+        languageClientWrapper.init({
+            languageClientConfig
+        });
+        expect(languageClientWrapper).toBeDefined();
+        expect(languageClientWrapper?.haveLanguageClient).toBeTruthy();
+        expect(languageClientWrapper?.haveLanguageClientConfig).toBeTruthy();
     });
 
     test('Dispose: direct worker is cleaned up afterwards', async () => {
-
-        /**
-         * Helper to generate a quick worker from a function blob
-         */
-        function createWorkerFromFunction(fn: () => void): Worker {
-            return new Worker(URL.createObjectURL(
-                new Blob([`(${fn.toString()})()`], { type: 'application/javascript' })
-            ));
-        }
-
         // create a web worker to pass to the wrapper
         const worker = createWorkerFromFunction(() => {
             console.info('Hello');
@@ -53,12 +47,13 @@ describe('Test LanguageClientWrapper', () => {
         // setup the wrapper
         const config = createBaseConfig('extended');
         config.languageClientConfig = {
+            languageId: 'javascript',
             options: {
                 $type: 'WorkerDirect',
                 worker
             }
         };
-        const wrapper = await createWrapper(config);
+        const wrapper = await createAndInitWrapper(config);
 
         const languageClientWrapper = wrapper.getLanguageClientWrapper();
         expect(languageClientWrapper).toBeDefined();
@@ -76,12 +71,13 @@ describe('Test LanguageClientWrapper', () => {
     test('Constructor: config', async () => {
         const config = createBaseConfig('extended');
         config.languageClientConfig = {
+            languageId: 'javascript',
             options: {
                 $type: 'WebSocketUrl',
                 url: 'ws://localhost:12345/Tester'
             }
         };
-        const wrapper = await createWrapper(config);
+        const wrapper = await createAndInitWrapper(config);
 
         const languageClientWrapper = wrapper.getLanguageClientWrapper();
         expect(languageClientWrapper).toBeDefined();
@@ -92,18 +88,20 @@ describe('Test LanguageClientWrapper', () => {
     test('Start: unreachable url', async () => {
         const config = createBaseConfig('extended');
         config.languageClientConfig = {
+            languageId: 'javascript',
+            name: 'test-unreachable',
             options: {
                 $type: 'WebSocketUrl',
-                url: 'ws://localhost:12345/Tester',
-                name: 'test-unreachable'
+                url: 'ws://localhost:12345/Tester'
             }
         };
-        const wrapper = await createWrapper(config);
+        const wrapper = await createAndInitWrapper(config);
 
         const languageClientWrapper = wrapper.getLanguageClientWrapper();
         expect(languageClientWrapper).toBeDefined();
 
         expect(languageClientWrapper!.haveLanguageClientConfig()).toBeTruthy();
+        console.log('start');
         await expect(languageClientWrapper!.start()).rejects.toEqual({
             message: 'languageClientWrapper (test-unreachable): Websocket connection failed.',
             error: 'No error was provided.'
@@ -124,13 +122,14 @@ describe('Test LanguageClientWrapper', () => {
     test('Start: unreachable worker url', async () => {
         const config = createBaseConfig('extended');
         config.languageClientConfig = {
+            languageId: 'javascript',
             options: {
                 $type: 'WorkerConfig',
                 url: new URL('http://localhost:20101'),
                 type: 'classic'
             }
         };
-        const wrapper = await createWrapper(config);
+        const wrapper = await createAndInitWrapper(config);
 
         const languageClientWrapper = wrapper.getLanguageClientWrapper();
         expect(languageClientWrapper).toBeDefined();

--- a/packages/wrapper/test/wrapper.test.ts
+++ b/packages/wrapper/test/wrapper.test.ts
@@ -30,7 +30,6 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
 
         const appConfig = app.getConfig();
         expect(appConfig.overrideAutomaticLayout).toBeTruthy();
-        expect(appConfig.theme).toBe('vs-light');
     });
 
     test('No HTML in Userconfig', async () => {

--- a/packages/wrapper/test/wrapper.test.ts
+++ b/packages/wrapper/test/wrapper.test.ts
@@ -11,6 +11,7 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
 
     test('New wrapper has undefined editor', () => {
         const wrapper = new MonacoEditorLanguageClientWrapper();
+        expect(wrapper.haveLanguageClient()).toBeFalsy();
         expect(wrapper.getEditor()).toBeUndefined();
     });
 

--- a/packages/wrapper/test/wrapper.test.ts
+++ b/packages/wrapper/test/wrapper.test.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License. See LICENSE in the package root for license information.
  * ------------------------------------------------------------------------------------------ */
 
+import * as vscode from 'vscode';
+import { createModelReference } from 'vscode/monaco';
 import { describe, expect, test } from 'vitest';
 import { EditorAppClassic, MonacoEditorLanguageClientWrapper } from 'monaco-editor-wrapper';
 import { createBaseConfig, createMonacoEditorDiv } from './helper.js';
@@ -72,5 +74,85 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
         userConfigClassicNew.wrapperConfig.editorAppConfig.useDiffEditor = true;
 
         expect(wrapper.isReInitRequired(userConfigClassicNew, userConfigClassic)).toBeTruthy();
+    });
+
+    test('code resources main', async () => {
+        createMonacoEditorDiv();
+        const wrapper = new MonacoEditorLanguageClientWrapper();
+        const userConfig = createBaseConfig('classic');
+        await wrapper.initAndStart(userConfig, document.getElementById('monaco-editor-root'));
+        const app = wrapper.getMonacoEditorApp();
+
+        const modelRefs = app?.getModelRefs();
+        expect(modelRefs?.modelRef).toBeDefined();
+        expect(modelRefs?.modelRefOriginal).toBeUndefined();
+        app?.disposeApp();
+    });
+
+    test('code resources original', async () => {
+        createMonacoEditorDiv();
+        const wrapper = new MonacoEditorLanguageClientWrapper();
+        const userConfig = createBaseConfig('classic');
+        userConfig.wrapperConfig.editorAppConfig.codeResources.main = undefined;
+        userConfig.wrapperConfig.editorAppConfig.codeResources.original = {
+            text: 'original',
+            fileExt: 'js'
+        };
+        await wrapper.initAndStart(userConfig, document.getElementById('monaco-editor-root'));
+        const app = wrapper.getMonacoEditorApp();
+
+        const modelRefs = app?.getModelRefs();
+        expect(modelRefs?.modelRef).toBeUndefined();
+        expect(modelRefs?.modelRefOriginal).toBeDefined();
+        app?.disposeApp();
+    });
+
+    test('code resources main and original', async () => {
+        createMonacoEditorDiv();
+        const wrapper = new MonacoEditorLanguageClientWrapper();
+        const userConfig = createBaseConfig('classic');
+        userConfig.wrapperConfig.editorAppConfig.codeResources.original = {
+            text: 'original',
+            fileExt: 'js'
+        };
+        await wrapper.initAndStart(userConfig, document.getElementById('monaco-editor-root'));
+        const app = wrapper.getMonacoEditorApp();
+
+        const modelRefs = app?.getModelRefs();
+        expect(modelRefs?.modelRef).toBeDefined();
+        expect(modelRefs?.modelRefOriginal).toBeDefined();
+        app?.disposeApp();
+    });
+
+    test('code resources empty', async () => {
+        createMonacoEditorDiv();
+        const wrapper = new MonacoEditorLanguageClientWrapper();
+        const userConfig = createBaseConfig('classic');
+        userConfig.wrapperConfig.editorAppConfig.codeResources = {};
+        await wrapper.initAndStart(userConfig, document.getElementById('monaco-editor-root'));
+
+        const app = wrapper.getMonacoEditorApp();
+        const modelRefs = app?.getModelRefs();
+        expect(modelRefs?.modelRef).toBeUndefined();
+        expect(modelRefs?.modelRefOriginal).toBeUndefined();
+    });
+
+    test('code resources model direct', async () => {
+        createMonacoEditorDiv();
+        const wrapper = new MonacoEditorLanguageClientWrapper();
+        const userConfig = createBaseConfig('classic');
+        userConfig.wrapperConfig.editorAppConfig.codeResources = {};
+        await wrapper.initAndStart(userConfig, document.getElementById('monaco-editor-root'));
+
+        const app = wrapper.getMonacoEditorApp();
+
+        // here the modelReference is created manually and given to the updateEditorModels of the wrapper
+        const uri = vscode.Uri.parse('/workspace/statemachineUri.statemachine');
+        const modelRef = await createModelReference(uri, 'text');
+        wrapper.updateEditorModels(modelRef);
+
+        const modelRefs = app?.getModelRefs();
+        expect(modelRefs?.modelRef).toBeDefined();
+        expect(modelRefs?.modelRefOriginal).toBeUndefined();
     });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,80 +3,83 @@
  * Licensed under the MIT License. See LICENSE in the package root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { defineConfig } from 'vite';
+import { defineConfig as defineViteConfig, mergeConfig } from 'vite';
+import { defineConfig as defineVitestConfig } from 'vitest/config';
 import * as path from 'path';
 import importMetaUrlPlugin from '@codingame/esbuild-import-meta-url-plugin';
 import vsixPlugin from '@codingame/monaco-vscode-rollup-vsix-plugin';
-import plugin from '@codingame/monaco-vscode-rollup-vsix-plugin';
 
-export default defineConfig(() => {
-    const config = {
-        build: {
-            target: 'esnext',
-            rollupOptions: {
-                input: {
-                    index: path.resolve(__dirname, 'index.html'),
-                    bare: path.resolve(__dirname, 'packages/examples/bare.html'),
-                    wrapperWebSocket: path.resolve(__dirname, 'packages/examples/wrapper_ws.html'),
-                    // integrate locale from old example
-                    wrapperStatemachine: path.resolve(__dirname, 'packages/examples/wrapper_statemachine.html'),
-                    // share configuration with wrapperStatemachine
-                    reactStatemachine: path.resolve(__dirname, 'packages/examples/react_statemachine.html'),
-                    wrapperLangium: path.resolve(__dirname, 'packages/examples/wrapper_langium.html'),
-                    // python and reactPython share the same configuration
-                    python: path.resolve(__dirname, 'packages/examples/python.html'),
-                    reactPython: path.resolve(__dirname, 'packages/examples/react_python.html'),
-                    // converted to wrapper
-                    groovy: path.resolve(__dirname, 'packages/examples/groovy.html'),
+const viteConfig = defineViteConfig({
+    build: {
+        target: 'esnext',
+        rollupOptions: {
+            input: {
+                index: path.resolve(__dirname, 'index.html'),
+                bare: path.resolve(__dirname, 'packages/examples/bare.html'),
+                wrapperWebSocket: path.resolve(__dirname, 'packages/examples/wrapper_ws.html'),
+                // integrate locale from old example
+                wrapperStatemachine: path.resolve(__dirname, 'packages/examples/wrapper_statemachine.html'),
+                // share configuration with wrapperStatemachine
+                reactStatemachine: path.resolve(__dirname, 'packages/examples/react_statemachine.html'),
+                wrapperLangium: path.resolve(__dirname, 'packages/examples/wrapper_langium.html'),
+                // python and reactPython share the same configuration
+                python: path.resolve(__dirname, 'packages/examples/python.html'),
+                reactPython: path.resolve(__dirname, 'packages/examples/react_python.html'),
+                // converted to wrapper
+                groovy: path.resolve(__dirname, 'packages/examples/groovy.html'),
 
-                    // other examples
-                    wrapperTs: path.resolve(__dirname, 'packages/examples/wrapper_ts.html'),
-                    wrapperAdvanced: path.resolve(__dirname, 'packages/examples/wrapper_adv.html'),
-                    // what about the common code?
-                    browser: path.resolve(__dirname, 'packages/examples/browser.html'),
-                    // verification examples
-                    verifyWrapper: path.resolve(__dirname, 'packages/examples/verify_wrapper.html'),
-                    verifyAlt: path.resolve(__dirname, 'packages/examples/verify_alt.html')
-                }
-            }
-        },
-        resolve: {
-            // not needed here, see https://github.com/TypeFox/monaco-languageclient#vite-dev-server-troubleshooting
-            // dedupe: ['vscode']
-        },
-        server: {
-            origin: 'http://localhost:20001',
-            port: 20001
-        },
-        optimizeDeps: {
-            esbuildOptions: {
-                plugins: [
-                    importMetaUrlPlugin
-                ]
-            }
-        },
-        plugins: [
-            vsixPlugin()
-        ],
-        define: {
-            rootDirectory: JSON.stringify(__dirname)
-        },
-        test: {
-            pool: 'threads',
-            poolOptions: {
-                threads: {
-                    isolate: true
-                }
-            },
-            browser: {
-                enabled: true,
-                headless: true,
-                name: 'chrome',
-                api: {
-                    port: 20101
-                }
+                // other examples
+                wrapperTs: path.resolve(__dirname, 'packages/examples/wrapper_ts.html'),
+                wrapperAdvanced: path.resolve(__dirname, 'packages/examples/wrapper_adv.html'),
+                // what about the common code?
+                browser: path.resolve(__dirname, 'packages/examples/browser.html'),
+                // verification examples
+                verifyWrapper: path.resolve(__dirname, 'packages/examples/verify_wrapper.html'),
+                verifyAlt: path.resolve(__dirname, 'packages/examples/verify_alt.html')
             }
         }
-    };
-    return config;
+    },
+    resolve: {
+        // not needed here, see https://github.com/TypeFox/monaco-languageclient#vite-dev-server-troubleshooting
+        // dedupe: ['vscode']
+    },
+    server: {
+        origin: 'http://localhost:20001',
+        port: 20001
+    },
+    optimizeDeps: {
+        esbuildOptions: {
+            plugins: [
+                importMetaUrlPlugin
+            ]
+        }
+    },
+    plugins: [
+        vsixPlugin()
+    ],
+    define: {
+        rootDirectory: JSON.stringify(__dirname)
+    }
 });
+
+const vitestConfig = defineVitestConfig({
+    test: {
+        testTimeout: 10000,
+        pool: 'threads',
+        poolOptions: {
+            threads: {
+                isolate: true
+            }
+        },
+        browser: {
+            enabled: true,
+            headless: true,
+            name: 'chrome',
+            api: {
+                port: 20101
+            }
+        }
+    }
+});
+
+export default mergeConfig(viteConfig, vitestConfig);


### PR DESCRIPTION
Re-work how to configure code in `UserConfig` and make `languageId` no longer required and do not enforce it in the editor model.
This is now uri or file extension driven. `languageId` can be optionally enforced (WA for classical editor in the wrapper).

It is now possible to create an editor without any text or model and update the model or `codeResources` later. This is demonstrated here: https://github.com/TypeFox/monaco-languageclient/blob/issue-639/packages/examples/src/langium/statemachine/main.ts#L28-L42

Fixes #639 