### PR TITLE
Dispose extension files in EditorAppExtended

### DIFF
--- a/packages/wrapper/src/editorAppExtended.ts
+++ b/packages/wrapper/src/editorAppExtended.ts
@@ -10,7 +10,7 @@ import { registerExtension, IExtensionManifest, ExtensionHostKind } from 'vscode
 import { Logger } from 'monaco-languageclient/tools';
 import { UserConfig } from './userConfig.js';
 import { verifyUrlOrCreateDataUrl, ModelUpdateType, isEqual, isModelUpdateRequired } from './utils.js';
-import { DisposableCollection } from 'vscode-ws-jsonrpc';
+import { DisposableStore } from 'vscode/monaco';
 
 export type ExtensionConfig = {
     config: IExtensionManifest | object;
@@ -49,7 +49,7 @@ export class EditorAppExtended extends EditorAppBase {
 
     private config: EditorAppConfigExtended;
     private extensionRegisterResults: Map<string, RegisterLocalProcessExtensionResult | RegisterExtensionResult | undefined> = new Map();
-    private subscriptions: DisposableCollection = new DisposableCollection();
+    private subscriptions: DisposableStore = new DisposableStore();
 
     constructor(id: string, userConfig: UserConfig, logger?: Logger) {
         super(id);
@@ -93,7 +93,7 @@ export class EditorAppExtended extends EditorAppBase {
                 if (extensionConfig.filesOrContents && Object.hasOwn(extRegResult, 'registerFileUrl')) {
                     for (const entry of extensionConfig.filesOrContents) {
                         const registerFileUrlResult = (extRegResult as RegisterLocalExtensionResult).registerFileUrl(entry[0], verifyUrlOrCreateDataUrl(entry[1]));
-                        this.subscriptions.push(registerFileUrlResult);
+                        this.subscriptions.add(registerFileUrlResult);
                     }
                 }
                 allPromises.push(extRegResult.whenReady());

--- a/packages/wrapper/src/editorAppExtended.ts
+++ b/packages/wrapper/src/editorAppExtended.ts
@@ -10,6 +10,7 @@ import { registerExtension, IExtensionManifest, ExtensionHostKind } from 'vscode
 import { Logger } from 'monaco-languageclient/tools';
 import { UserConfig } from './userConfig.js';
 import { verifyUrlOrCreateDataUrl, ModelUpdateType, isEqual, isModelUpdateRequired } from './utils.js';
+import { DisposableCollection } from 'vscode-ws-jsonrpc';
 
 export type ExtensionConfig = {
     config: IExtensionManifest | object;
@@ -48,7 +49,7 @@ export class EditorAppExtended extends EditorAppBase {
 
     private config: EditorAppConfigExtended;
     private extensionRegisterResults: Map<string, RegisterLocalProcessExtensionResult | RegisterExtensionResult | undefined> = new Map();
-    private subscriptions: monaco.IDisposable[] = [];
+    private subscriptions: DisposableCollection = new DisposableCollection();
 
     constructor(id: string, userConfig: UserConfig, logger?: Logger) {
         super(id);
@@ -108,8 +109,7 @@ export class EditorAppExtended extends EditorAppBase {
     disposeApp(): void {
         this.disposeEditors();
         this.extensionRegisterResults.forEach((k) => k?.dispose());
-        this.subscriptions.forEach((k) => k.dispose());
-        this.subscriptions.length = 0;
+        this.subscriptions.dispose();
     }
 
     isAppConfigDifferent(orgConfig: EditorAppConfigExtended, config: EditorAppConfigExtended, includeModelData: boolean): boolean {

--- a/packages/wrapper/test/wrapper.test.ts
+++ b/packages/wrapper/test/wrapper.test.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import { createModelReference } from 'vscode/monaco';
 import { describe, expect, test } from 'vitest';
-import { EditorAppClassic, MonacoEditorLanguageClientWrapper } from 'monaco-editor-wrapper';
+import { EditorAppClassic, EditorAppConfigExtended, MonacoEditorLanguageClientWrapper } from 'monaco-editor-wrapper';
 import { createBaseConfig, createMonacoEditorDiv } from './helper.js';
 
 describe('Test MonacoEditorLanguageClientWrapper', () => {
@@ -164,5 +164,37 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
         const modelRefs = app?.getModelRefs();
         expect(modelRefs?.modelRef).toBeDefined();
         expect(modelRefs?.modelRefOriginal).toBeUndefined();
+    });
+
+    test('extended editor disposes extensions', async () => {
+        createMonacoEditorDiv();
+        const wrapper = new MonacoEditorLanguageClientWrapper();
+        const userConfig = createBaseConfig('extended');
+        (userConfig.wrapperConfig.editorAppConfig as EditorAppConfigExtended).extensions = [{
+            config: {
+                engines: {
+                    vscode: '*'
+                },
+                contributes: {
+                    languages: [{
+                        id: 'js',
+                        extensions: ['.js'],
+                        configuration: './language-configuration.json'
+                    }],
+                    grammars: [{
+                        language: 'js',
+                        scopeName: 'source.js',
+                        path: './javascript.tmLanguage.json'
+                    }]
+                }
+            },
+            filesOrContents: new Map([
+                ['/language-configuration.json', '{}'],
+                ['/javascript.tmLanguage.json', '{}']
+            ]),
+        }];
+        await wrapper.initAndStart(userConfig, document.getElementById('monaco-editor-root'));
+        await wrapper.dispose();
+        await wrapper.initAndStart(userConfig, document.getElementById('monaco-editor-root'));
     });
 });

--- a/packages/wrapper/test/wrapper.test.ts
+++ b/packages/wrapper/test/wrapper.test.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import { createModelReference } from 'vscode/monaco';
 import { describe, expect, test } from 'vitest';
-import { EditorAppClassic, EditorAppConfigExtended, MonacoEditorLanguageClientWrapper } from 'monaco-editor-wrapper';
+import { EditorAppClassic, MonacoEditorLanguageClientWrapper } from 'monaco-editor-wrapper';
 import { createBaseConfig, createMonacoEditorDiv } from './helper.js';
 
 describe('Test MonacoEditorLanguageClientWrapper', () => {
@@ -164,37 +164,5 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
         const modelRefs = app?.getModelRefs();
         expect(modelRefs?.modelRef).toBeDefined();
         expect(modelRefs?.modelRefOriginal).toBeUndefined();
-    });
-
-    test('extended editor disposes extensions', async () => {
-        createMonacoEditorDiv();
-        const wrapper = new MonacoEditorLanguageClientWrapper();
-        const userConfig = createBaseConfig('extended');
-        (userConfig.wrapperConfig.editorAppConfig as EditorAppConfigExtended).extensions = [{
-            config: {
-                engines: {
-                    vscode: '*'
-                },
-                contributes: {
-                    languages: [{
-                        id: 'js',
-                        extensions: ['.js'],
-                        configuration: './language-configuration.json'
-                    }],
-                    grammars: [{
-                        language: 'js',
-                        scopeName: 'source.js',
-                        path: './javascript.tmLanguage.json'
-                    }]
-                }
-            },
-            filesOrContents: new Map([
-                ['/language-configuration.json', '{}'],
-                ['/javascript.tmLanguage.json', '{}']
-            ]),
-        }];
-        await wrapper.initAndStart(userConfig, document.getElementById('monaco-editor-root'));
-        await wrapper.dispose();
-        await wrapper.initAndStart(userConfig, document.getElementById('monaco-editor-root'));
     });
 });


### PR DESCRIPTION
Fixes #679 

There was a bug where disposing and then reinitializing an `EditorAppExtended` where an extension has `filesOrContents` would result in an exception being thrown due to not disposing these files from the last time the extension was registered. This fixes that by disposing of the results of `registerFileUrl` in the `disposeApp` method.

I added a test to exercise this; the test introduced in the first commit exhibits the `Error: file 'extension-file://undefined.undefined/' already exists` error, and that error goes away in the second commit. Unfortunately, when I run this test suite, I also get a bunch of "Array buffer allocation failed" errors that seem to come from somewhere in VSCode's services. I tried using the `updateExtendedAppPrototyp` test helper to fix this, but that seems to remove so much functionality that the original "file already exists" error no longer happens in the first place. Open to suggestions on how to fix the test, or I can just remove the test so we can ship the fix.