### PR TITLE
Update onTextChanged in MonacoEditorReactComp

### DIFF
--- a/packages/wrapper-react/test/index.test.tsx
+++ b/packages/wrapper-react/test/index.test.tsx
@@ -27,4 +27,26 @@ describe('Test MonacoEditorReactComp', () => {
         await Promise.resolve();
         rerender(<MonacoEditorReactComp userConfig={userConfig} />);
     });
+
+    test('update onTextChanged', async () => {
+        const userConfig: UserConfig = {
+            wrapperConfig: {
+                editorAppConfig: {
+                    $type: 'extended',
+                    codeResources: {
+                        main: {
+                            text: '',
+                            fileExt: 'js'
+                        }
+                    }
+                }
+            },
+            loggerConfig: {
+                enabled: true,
+                debugEnabled: true,
+            }
+        };
+        const { rerender } = render(<MonacoEditorReactComp userConfig={userConfig} />);
+        await new Promise(resolve => rerender(<MonacoEditorReactComp userConfig={userConfig} onTextChanged={resolve} />));
+    });
 });


### PR DESCRIPTION
Fixes #683 

Updates `MonacoEditorReactComp` to correctly handle changes to the `onTextChanged` prop.

Note: since there isn't a test suite for the React component on `main`, this branch includes changes from both this PR and https://github.com/TypeFox/monaco-languageclient/issues/681 . See [here](https://github.com/vrama628/monaco-languageclient/compare/react-component-did-update...vrama628:monaco-languageclient:react-on-text-changed) for a diff of just the changes relevant to this PR.

The first commit adds a test case that reproduces the issue, and the second commit fixes it. When I run the test after the fix, Vite seems to get stuck and infinitely hang; I wasn't able to figure out why. I'm open to suggestions on how to fix the test case to run properly in `vitest`, or I can just remove the test case altogether.