### PR TITLE
Fix Diff Editor Model Refs

### DIFF
--- a/packages/wrapper/src/editorAppBase.ts
+++ b/packages/wrapper/src/editorAppBase.ts
@@ -172,8 +172,8 @@ export abstract class EditorAppBase {
     }
 
     async buildModelRefs(codeResources?: CodeResources): Promise<ModelRefs> {
-        const modelRef = await this.buildModelRef(codeResources?.main);
-        const modelRefOriginal = await this.buildModelRef(codeResources?.original);
+        const modelRef = await this.buildModelRef(codeResources?.main, false);
+        const modelRefOriginal = await this.buildModelRef(codeResources?.original, true);
 
         return {
             modelRef,
@@ -181,9 +181,9 @@ export abstract class EditorAppBase {
         };
     }
 
-    private async buildModelRef(code?: CodePlusUri | CodePlusFileExt): Promise<IReference<ITextFileEditorModel> | undefined> {
+    private async buildModelRef(code?: CodePlusUri | CodePlusFileExt, original?: boolean): Promise<IReference<ITextFileEditorModel> | undefined> {
         if (code) {
-            const uri = getEditorUri(this.id, false, code);
+            const uri = getEditorUri(this.id, original ?? false, code);
             const modelRef = await createModelReference(uri, code.text);
             this.checkEnforceLanguageId(modelRef, code.enforceLanguageId);
             return modelRef;

--- a/packages/wrapper/test/wrapper.test.ts
+++ b/packages/wrapper/test/wrapper.test.ts
@@ -129,6 +129,13 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
         const modelRefs = app?.getModelRefs();
         expect(modelRefs?.modelRef).toBeDefined();
         expect(modelRefs?.modelRefOriginal).toBeDefined();
+
+        const name = modelRefs?.modelRef?.object.name;
+        const nameOriginal = modelRefs?.modelRefOriginal?.object.name;
+        expect(name).toBeDefined();
+        expect(nameOriginal).toBeDefined();
+        expect(name).not.toEqual(nameOriginal);
+
         app?.disposeApp();
     });
 


### PR DESCRIPTION
# Summary

Fixes a bug that caused both diff editors to display the same model.

# Details

We ran into a bug with the diff editor where both the modified editor and original editor displayed the same content. When we inspected the editors in the browser, we found that they had the same `data-uri` value.

After tracing through the `editorAppBase.ts` file, we saw that the `getEditorUri` function accepts a boolean to determine whether to append 'Original'. But the `buildModelRef` function always passed `false` when building the model reference for both editors.

This pull request fixes the bug by passing a boolean parameter from `buildModelRef` to `getEditorUri` and ensuring that the URIs are different for both editors.

# Screenshots

Here is a screenshot before the change, showing how the modified editor and original editor displayed the same content.

<img width="929" alt="Screenshot 2024-07-01 at 7 51 16 PM" src="https://github.com/TypeFox/monaco-languageclient/assets/102343201/d759fb67-a446-4178-a5ef-215c40d08e1a">

Here is a screenshot after the change, showing how the modified editor and original editor now display different content.

<img width="928" alt="Screenshot 2024-07-01 at 7 52 32 PM" src="https://github.com/TypeFox/monaco-languageclient/assets/102343201/8693cf7d-0736-4d7e-b3f2-b70601db597b">
