### PR TITLE
Open default workspace

### DIFF
--- a/packages/client/src/vscode/services.ts
+++ b/packages/client/src/vscode/services.ts
@@ -117,7 +117,7 @@ export const importAllServices = async (instruction: InitServicesInstruction) =>
     reportServiceLoading(userServices, instruction.logger);
 
     if (instruction.performChecks === undefined || instruction.performChecks()) {
-        await initialize(userServices);
+        await initialize(userServices, undefined, lc.workspaceConfig);
         const logLevel = lc.workspaceConfig?.developmentOptions?.logLevel ?? LogLevel.Info;
         StandaloneServices.get(ILogService).setLevel(logLevel);
     }

--- a/packages/wrapper/src/vscode/services.ts
+++ b/packages/wrapper/src/vscode/services.ts
@@ -45,7 +45,7 @@ export const configureServices = async (config: VscodeServicesConfig): Promise<I
             workspaceProvider: {
                 trusted: true,
                 workspace: {
-                    workspaceUri: vscode.Uri.file('/workspace')
+                    workspaceUri: vscode.Uri.file('/workspace.code-workspace')
                 },
                 async open() {
                     window.open(window.location.href);


### PR DESCRIPTION
Currently, the `configureServices` function creates a default workspace config, but it is not passed to the `initialize` function. This PR passes the configuration to the `initialize` function. Moreover, to work properly, the `workspaceUri` must have the extension `.code-workspace`.

I previously reported a related issue here: https://github.com/CodinGame/monaco-vscode-api/issues/470