### PR TITLE
isRestarting is only checked and awaited at the beginning of handleReInit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@codingame/monaco-vscode-rollup-vsix-plugin": "~8.0.0",
         "@rollup/pluginutils": "~5.1.0",
         "@testing-library/react": "~16.0.0",
-        "@types/node": "^20",
+        "@types/node": "~20.14.14",
         "@types/react": "~18.3.3",
         "@types/react-dom": "~18.3.0",
         "@types/vscode": "~1.92.0",
@@ -2430,10 +2430,11 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
-      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "version": "20.14.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.14.tgz",
+      "integrity": "sha512-d64f00982fS9YoOgJkAMolK7MN8Iq3TDdVjchbYHdEmjth/DHowx82GnoA+tVUAN+7vxfYUgAzi+JXbKNd2SDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@codingame/monaco-vscode-rollup-vsix-plugin": "~8.0.0",
     "@rollup/pluginutils": "~5.1.0",
     "@testing-library/react": "~16.0.0",
-    "@types/node": "^20",
+    "@types/node": "~20.14.14",
     "@types/react": "~18.3.3",
     "@types/react-dom": "~18.3.0",
     "@types/vscode": "~1.92.0",

--- a/packages/wrapper/src/wrapper.ts
+++ b/packages/wrapper/src/wrapper.ts
@@ -222,9 +222,9 @@ export class MonacoEditorLanguageClientWrapper {
         if (prevConfig.$type !== config.$type) {
             mustReInit = true;
         } else if (prevConfig.$type === 'classic' && config.$type === 'classic') {
-            mustReInit = (this.getMonacoEditorApp() as EditorAppClassic).isAppConfigDifferent(prevConfig, config, false) === true;
+            mustReInit = this.getMonacoEditorApp() !== undefined && (this.getMonacoEditorApp() as EditorAppClassic).isAppConfigDifferent(prevConfig, config, false) === true;
         } else if (prevConfig.$type === 'extended' && config.$type === 'extended') {
-            mustReInit = (this.getMonacoEditorApp() as EditorAppExtended).isAppConfigDifferent(prevConfig, config, false) === true;
+            mustReInit = this.getMonacoEditorApp() !== undefined && (this.getMonacoEditorApp() as EditorAppExtended).isAppConfigDifferent(prevConfig, config, false) === true;
         }
 
         return mustReInit;

--- a/packages/wrapper/src/wrapper.ts
+++ b/packages/wrapper/src/wrapper.ts
@@ -177,6 +177,9 @@ export class MonacoEditorLanguageClientWrapper {
      * Disposes all application and editor resources, plus the languageclient (if used).
      */
     async dispose(): Promise<void> {
+        if (!this.initDone) {
+            return Promise.reject('Wrapper dispose is rejected as init was not yet completed.');
+        }
         this.editorApp?.disposeApp();
 
         if (this.languageClientWrapper?.haveLanguageClient() ?? false) {


### PR DESCRIPTION
This fixes #719 

`isRestarting` is no longer checked during destroy and only checked at  the beginning of `handleReInit`