### PR TITLE
fix(groovy): fix 'services.groovyls.build Additional property platfor…

### DIFF
--- a/packages/examples/resources/groovy/docker-compose.yml
+++ b/packages/examples/resources/groovy/docker-compose.yml
@@ -4,11 +4,6 @@ services:
     build:
       dockerfile: ./packages/examples/resources/groovy/Dockerfile
       context: ../../../..
-      # requires "Use containerd for pulling and storing images" in Docker Desktop
-      platforms:
-        - "linux/amd64"
-        # pre-built volta binaries are currently unavailable for linux/arm64, will change with v2.0.0
-        # - "linux/arm64"
     platform: linux/amd64
     command: [
       "bash", "-c", "npm run start:example:server:groovy"


### PR DESCRIPTION


the `docker compose -f ./packages/examples/resources/groovy/docker-compose.yml up -d` cmd gave me this error :
`services.groovyls.build Additional property platforms is not allowed`


tested on `Docker Desktop 4.4.2 (73305) is currently the newest version available.`

fix is related to https://github.com/TypeFox/monaco-languageclient/issues/758

thanks , 