### PR TITLE
Clangd example improvements: IndexedDB usage and possibility to load workspace from zip file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4605,10 +4605,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -7121,10 +7118,7 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -7794,10 +7788,7 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-      "dev": true,
       "license": "(MIT OR GPL-3.0-or-later)",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -7809,19 +7800,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jszip/node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -7836,10 +7821,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -8023,10 +8005,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "immediate": "~3.0.5"
       }
@@ -8857,10 +8836,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true,
-      "license": "(MIT AND Zlib)",
-      "optional": true,
-      "peer": true
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -9186,10 +9162,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -9778,7 +9751,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-regex-test": {
@@ -9966,10 +9938,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -11060,10 +11029,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -12093,6 +12059,7 @@
         "@typefox/monaco-editor-react": "~6.0.0-next.10",
         "cors": "^2.8.5",
         "express": "~4.21.2",
+        "jszip": "~3.10.1",
         "langium": "~3.3.0",
         "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~11.1.2",
         "monaco-editor-wrapper": "~6.0.0-next.10",

--- a/packages/examples/clangd.html
+++ b/packages/examples/clangd.html
@@ -13,8 +13,9 @@
     <div class="exampleHeadelineDiv">
         <b class="exampleHeadeline">Cpp Language Client & Clangd Language Server (Worker/Wasm)</b> - [<a href="../../index.html">Back to Index</a>]
         <br>
-        <b>Heads up:</b> This is a prototype and still evolving.<br>
-        The clangd language server worker has been derived from: <a href="https://github.com/guyutongxue/clangd-in-browser">clangd-in-browser</a><br>
+        <button type="button" id="button-start">Start</button>
+        <button type="button" id="button-start-fresh">Start (Reset DB)</button>
+        The clangd language server worker has been derived from: <a href="https://github.com/guyutongxue/clangd-in-browser">clangd-in-browser</a>
     </div>
     <script type="module">
         import { runClangdWrapper } from "./src/clangd/client/main.ts";

--- a/packages/examples/ghp_clangd.html
+++ b/packages/examples/ghp_clangd.html
@@ -14,8 +14,9 @@
     <div class="exampleHeadelineDiv">
         <b class="exampleHeadeline">Cpp Language Client & Clangd Language Server (Worker/Wasm)</b> - [<a href="./index.html">Back to Index</a>]
         <br>
-        <b>Heads up:</b> This is a prototype and still evolving.<br>
-        The clangd language server worker has been derived from: <a href="https://github.com/guyutongxue/clangd-in-browser">clangd-in-browser</a><br>
+        <button type="button" id="button-start">Start</button>
+        <button type="button" id="button-start-fresh">Start (Reset DB)</button>
+        The clangd language server worker has been derived from: <a href="https://github.com/guyutongxue/clangd-in-browser">clangd-in-browser</a>
     </div>
     <script type="module">
         import { runClangdWrapper } from "./src/clangd/client/main.ts";

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -81,6 +81,7 @@
     "@typefox/monaco-editor-react": "~6.0.0-next.10",
     "cors": "^2.8.5",
     "express": "~4.21.2",
+    "jszip": "~3.10.1",
     "langium": "~3.3.0",
     "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@~11.1.2",
     "monaco-editor-wrapper": "~6.0.0-next.10",

--- a/packages/examples/resources/clangd/build-docker.sh
+++ b/packages/examples/resources/clangd/build-docker.sh
@@ -18,9 +18,10 @@ cmake --build build-native --target llvm-tblgen clang-tblgen
 git apply $WORKSPACE_DIR/wait_stdin.patch
 
 ## Build clangd (1st time, just for compiler headers)
+## enable IndexedDB (-lidbfs.js)
 emcmake cmake -G Ninja -S llvm -B build \
     -DCMAKE_CXX_FLAGS="-pthread -Dwait4=__syscall_wait4" \
-    -DCMAKE_EXE_LINKER_FLAGS="-pthread -s ENVIRONMENT=worker -s NO_INVOKE_RUN" \
+    -DCMAKE_EXE_LINKER_FLAGS="-pthread -s ENVIRONMENT=worker -s NO_INVOKE_RUN -lidbfs.js" \
     -DCMAKE_BUILD_TYPE=MinSizeRel \
     -DLLVM_TARGET_ARCH=wasm32-emscripten \
     -DLLVM_DEFAULT_TARGET_TRIPLE=wasm32-wasi \
@@ -45,9 +46,10 @@ cmake --build build --target clangd
 cp -r build/lib/clang/$LLVM_VER_MAJOR/include/* $WORKSPACE_DIR/wasi-sysroot/include/
 
 ## Build clangd (2nd time, for the real thing)
+## enable IndexedDB (-lidbfs.js)
 emcmake cmake -G Ninja -S llvm -B build \
     -DCMAKE_CXX_FLAGS="-pthread -Dwait4=__syscall_wait4" \
-    -DCMAKE_EXE_LINKER_FLAGS="-pthread -s ENVIRONMENT=worker -s NO_INVOKE_RUN -s EXIT_RUNTIME -s INITIAL_MEMORY=2GB -s ALLOW_MEMORY_GROWTH -s MAXIMUM_MEMORY=4GB -s STACK_SIZE=256kB -s EXPORTED_RUNTIME_METHODS=FS,callMain -s MODULARIZE -s EXPORT_ES6 -s WASM_BIGINT -s ASSERTIONS -s ASYNCIFY -s PTHREAD_POOL_SIZE='Math.max(navigator.hardwareConcurrency, 8)' --embed-file=$WORKSPACE_DIR/wasi-sysroot/include@/usr/include" \
+    -DCMAKE_EXE_LINKER_FLAGS="-pthread -s ENVIRONMENT=worker -s NO_INVOKE_RUN -s EXIT_RUNTIME -s INITIAL_MEMORY=2GB -s ALLOW_MEMORY_GROWTH -s MAXIMUM_MEMORY=4GB -s STACK_SIZE=256kB -s EXPORTED_RUNTIME_METHODS=FS,callMain -s MODULARIZE -s EXPORT_ES6 -s WASM_BIGINT -s ASSERTIONS -s ASYNCIFY -s PTHREAD_POOL_SIZE='Math.max(navigator.hardwareConcurrency, 8)' --embed-file=$WORKSPACE_DIR/wasi-sysroot/include@/usr/include -lidbfs.js" \
     -DCMAKE_BUILD_TYPE=MinSizeRel \
     -DLLVM_TARGET_ARCH=wasm32-emscripten \
     -DLLVM_DEFAULT_TARGET_TRIPLE=wasm32-wasi \

--- a/packages/examples/resources/clangd/workspace/.clangd
+++ b/packages/examples/resources/clangd/workspace/.clangd
@@ -10,7 +10,7 @@
             '-isystem/usr/include/c++/v1',
             '-isystem/usr/include/wasm32-wasi/c++/v1',
             '-isystem/usr/include',
-            '-isystem/usr/include/wasm32-wasi',
+            '-isystem/usr/include/wasm32-wasi'
         ]
     }
 }

--- a/packages/examples/src/clangd/client/workerHandler.ts
+++ b/packages/examples/src/clangd/client/workerHandler.ts
@@ -5,7 +5,6 @@
 
 import { ComChannelEndpoint, ComRouter, RawPayload, WorkerMessage } from 'wtd-core';
 import clangdWorkerUrl from '../worker/clangd-server?worker&url';
-import { VolatileInput } from '../definitions.js';
 
 class ClangdInteractionMain implements ComRouter {
 
@@ -44,15 +43,17 @@ export class ClangdWorkerHandler {
     async init(config: {
         lsMessagePort: MessagePort,
         fsMessagePort: MessagePort,
-        loadWorkspace: boolean,
-        volatile?: VolatileInput
+        clearIndexedDb: boolean,
+        useCompressedWorkspace: boolean,
+        compressedWorkspaceUrl?: string
     }) {
         await this.endpointMain?.sentMessage({
             message: WorkerMessage.fromPayload(new RawPayload({
                 lsMessagePort: config.lsMessagePort,
                 fsMessagePort: config.fsMessagePort,
-                volatile: config.volatile,
-                loadWorkspace: config.loadWorkspace
+                clearIndexedDb: config.clearIndexedDb,
+                useCompressedWorkspace: config.useCompressedWorkspace,
+                compressedWorkspaceUrl: config.compressedWorkspaceUrl
             }), 'clangd_init'),
             transferables: [config.lsMessagePort, config.fsMessagePort],
             awaitAnswer: true,

--- a/packages/examples/src/clangd/definitions.ts
+++ b/packages/examples/src/clangd/definitions.ts
@@ -5,8 +5,3 @@
 
 export const HOME_DIR = '/home/web_user';
 export const WORKSPACE_PATH = `${HOME_DIR}/workspace`;
-
-export interface VolatileInput {
-    ignoreSubDirectories?: string[];
-    useDefaultGlob: boolean;
-}


### PR DESCRIPTION
This is the result of a collaboration between @montymxb and me.

The application behaves similar as before, but then worker now uses IndexedDB as file system. You can also re-configure the client to load a complex workspace from a zip file.

The worker logic has been logically restructured to and the async file system handling and clangd init is now working smoothly.