### PR TITLE
Bugfix: Wrapper; Text model content is not properly updated with updateCodeResource

### DIFF
--- a/packages/examples/src/browser/main.ts
+++ b/packages/examples/src/browser/main.ts
@@ -47,7 +47,7 @@ export const runBrowserEditor = async () => {
         },
         editorAppConfig: {
             codeResources: {
-                main: {
+                modified: {
                     text: code,
                     uri: codeUri
                 }
@@ -157,7 +157,7 @@ export const runBrowserEditor = async () => {
 
     await wrapper.start();
 
-    wrapper.getTextModels()?.text?.onDidChangeContent(() => {
+    wrapper.getTextModels()?.modified?.onDidChangeContent(() => {
         validate();
     });
 };

--- a/packages/examples/src/eclipse.jdt.ls/client/main.ts
+++ b/packages/examples/src/eclipse.jdt.ls/client/main.ts
@@ -39,7 +39,7 @@ export const runEclipseJdtLsClient = () => {
         },
         editorAppConfig: {
             codeResources: {
-                main: {
+                modified: {
                     text: helloJavaCode,
                     uri: `${eclipseJdtLsConfig.basePath}/workspace/hello.java`
                 }

--- a/packages/examples/src/groovy/client/main.ts
+++ b/packages/examples/src/groovy/client/main.ts
@@ -35,7 +35,7 @@ const userConfig: WrapperConfig = {
     },
     editorAppConfig: {
         codeResources: {
-            main: {
+            modified: {
                 text: code,
                 fileExt: 'groovy'
             }

--- a/packages/examples/src/json/client/wrapperWs.ts
+++ b/packages/examples/src/json/client/wrapperWs.ts
@@ -36,7 +36,7 @@ export const buildJsonClientUserConfig = (htmlContainer?: HTMLElement): WrapperC
         },
         editorAppConfig: {
             codeResources: {
-                main: {
+                modified: {
                     text,
                     fileExt: 'json'
                 }

--- a/packages/examples/src/langium/langium-dsl/config/classicConfig.ts
+++ b/packages/examples/src/langium/langium-dsl/config/classicConfig.ts
@@ -27,7 +27,7 @@ export const setupLangiumClientClassic = async (): Promise<WrapperConfig> => {
         },
         editorAppConfig: {
             codeResources: {
-                main: {
+                modified: {
                     text: code,
                     fileExt: 'langium',
                     enforceLanguageId: 'langium'

--- a/packages/examples/src/langium/langium-dsl/config/extendedConfig.ts
+++ b/packages/examples/src/langium/langium-dsl/config/extendedConfig.ts
@@ -69,7 +69,7 @@ export const setupLangiumClientExtended = async (): Promise<WrapperConfig> => {
         }],
         editorAppConfig: {
             codeResources: {
-                main: {
+                modified: {
                     text,
                     fileExt: 'langium'
                 }

--- a/packages/examples/src/langium/statemachine/config/wrapperStatemachineConfig.ts
+++ b/packages/examples/src/langium/statemachine/config/wrapperStatemachineConfig.ts
@@ -28,9 +28,9 @@ export const createLangiumGlobalConfig = async (params: {
     extensionFilesOrContents.set(`/${params.languageServerId}-statemachine-configuration.json`, statemachineLanguageConfig);
     extensionFilesOrContents.set(`/${params.languageServerId}-statemachine-grammar.json`, responseStatemachineTm);
 
-    let main;
+    let modified;
     if (params.text !== undefined) {
-        main = {
+        modified = {
             text: params.text,
             fileExt: 'statemachine'
         };
@@ -97,7 +97,7 @@ export const createLangiumGlobalConfig = async (params: {
         }],
         editorAppConfig: {
             codeResources: {
-                main
+                modified
             },
             monacoWorkerFactory: configureMonacoWorkers
         },

--- a/packages/examples/src/langium/statemachine/main.ts
+++ b/packages/examples/src/langium/statemachine/main.ts
@@ -52,9 +52,9 @@ const startEditor = async () => {
 
     // here the modelReference is created manually and given to the updateEditorModels of the wrapper
     const uri = vscode.Uri.parse('/workspace/statemachine-mod.statemachine');
-    const modelRef = await createModelReference(uri, text);
+    const modelRefModified = await createModelReference(uri, text);
     wrapper.updateEditorModels({
-        modelRef
+        modelRefModified
     });
 
     // start the second wrapper without any languageclient config

--- a/packages/examples/src/multi/twoLanguageClients.ts
+++ b/packages/examples/src/multi/twoLanguageClients.ts
@@ -58,7 +58,7 @@ print("Hello Moon!")
         },
         editorAppConfig: {
             codeResources: {
-                main: {
+                modified: {
                     text: currentText,
                     fileExt: currenFileExt
                 }
@@ -101,9 +101,9 @@ print("Hello Moon!")
             }
 
             await wrapper.initAndStart(wrapperConfig);
-            if (wrapperConfig.editorAppConfig?.codeResources?.main !== undefined) {
-                (wrapperConfig.editorAppConfig.codeResources.main as CodePlusFileExt).text = currentText;
-                (wrapperConfig.editorAppConfig.codeResources.main as CodePlusFileExt).fileExt = currenFileExt;
+            if (wrapperConfig.editorAppConfig?.codeResources?.modified !== undefined) {
+                (wrapperConfig.editorAppConfig.codeResources.modified as CodePlusFileExt).text = currentText;
+                (wrapperConfig.editorAppConfig.codeResources.modified as CodePlusFileExt).fileExt = currenFileExt;
             }
 
             disableButton('button-flip', false);
@@ -121,7 +121,7 @@ print("Hello Moon!")
             currentText = currentText === textJson ? textPython : textJson;
             currenFileExt = currenFileExt === 'json' ? 'py' : 'json';
             wrapper.updateCodeResources({
-                main: {
+                modified: {
                     text: currentText,
                     fileExt: currenFileExt
                 }

--- a/packages/examples/src/python/client/config.ts
+++ b/packages/examples/src/python/client/config.ts
@@ -79,7 +79,7 @@ export const createUserConfig = (workspaceRoot: string, code: string, codeUri: s
         },
         editorAppConfig: {
             codeResources: {
-                main: {
+                modified: {
                     text: code,
                     uri: codeUri
                 }

--- a/packages/examples/src/python/client/reactPython.tsx
+++ b/packages/examples/src/python/client/reactPython.tsx
@@ -19,7 +19,7 @@ export const runPythonReact = async () => {
     registerFileSystemOverlay(1, fileSystemProvider);
 
     const onTextChanged = (textChanges: TextChanges) => {
-        console.log(`Dirty? ${textChanges.isDirty}\ntext: ${textChanges.text}\ntextOriginal: ${textChanges.textOriginal}`);
+        console.log(`Dirty? ${textChanges.isDirty}\ntext: ${textChanges.modified}\ntextOriginal: ${textChanges.original}`);
     };
     const wrapperConfig = createUserConfig('/workspace', badPyCode, '/workspace/bad.py');
     const root = ReactDOM.createRoot(document.getElementById('react-root')!);

--- a/packages/examples/src/ts/wrapperTs.ts
+++ b/packages/examples/src/ts/wrapperTs.ts
@@ -46,7 +46,7 @@ export const runTsWrapper = async () => {
         },
         editorAppConfig: {
             codeResources: {
-                main: {
+                modified: {
                     text: code,
                     uri: codeUri
                 },
@@ -76,9 +76,9 @@ export const runTsWrapper = async () => {
         });
         document.querySelector('#button-swap-code')?.addEventListener('click', () => {
             const codeResources = wrapper.getMonacoEditorApp()?.getConfig().codeResources;
-            if ((codeResources?.main as CodePlusUri).uri === codeUri) {
+            if ((codeResources?.modified as CodePlusUri).uri === codeUri) {
                 wrapper.updateCodeResources({
-                    main: {
+                    modified: {
                         text: codeOriginal,
                         uri: codeOriginalUri
                     },
@@ -89,7 +89,7 @@ export const runTsWrapper = async () => {
                 });
             } else {
                 wrapper.updateCodeResources({
-                    main: {
+                    modified: {
                         text: code,
                         uri: codeUri
                     },

--- a/packages/wrapper-react/src/index.tsx
+++ b/packages/wrapper-react/src/index.tsx
@@ -76,17 +76,17 @@ export const MonacoEditorReactComp: React.FC<MonacoEditorProps> = (props) => {
             containerRef.current.className = className ?? '';
             try {
                 wrapperRef.current.registerModelUpdate((textModels: TextModels) => {
-                    if (textModels.text !== undefined || textModels.textOriginal !== undefined) {
+                    if (textModels.modified !== undefined || textModels.original !== undefined) {
                         const newSubscriptions: monaco.IDisposable[] = [];
 
-                        if (textModels.text !== undefined) {
-                            newSubscriptions.push(textModels.text.onDidChangeContent(() => {
+                        if (textModels.modified !== undefined) {
+                            newSubscriptions.push(textModels.modified.onDidChangeContent(() => {
                                 didModelContentChange(textModels, wrapperConfig.editorAppConfig?.codeResources, onTextChanged);
                             }));
                         }
 
-                        if (textModels.textOriginal !== undefined) {
-                            newSubscriptions.push(textModels.textOriginal.onDidChangeContent(() => {
+                        if (textModels.original !== undefined) {
+                            newSubscriptions.push(textModels.original.onDidChangeContent(() => {
                                 didModelContentChange(textModels, wrapperConfig.editorAppConfig?.codeResources, onTextChanged);
                             }));
                         }

--- a/packages/wrapper-react/test/index.test.tsx
+++ b/packages/wrapper-react/test/index.test.tsx
@@ -51,7 +51,7 @@ describe('Test MonacoEditorReactComp', () => {
             },
             editorAppConfig: {
                 codeResources: {
-                    main: {
+                    modified: {
                         text: 'hello world',
                         fileExt: 'js'
                     }
@@ -61,11 +61,11 @@ describe('Test MonacoEditorReactComp', () => {
         };
 
         const textReceiverHello = (textChanges: TextChanges) => {
-            expect(textChanges.text).toEqual('hello world');
+            expect(textChanges.modified).toEqual('hello world');
         };
 
         const handleOnLoad = async (wrapper: MonacoEditorLanguageClientWrapper) => {
-            expect(wrapper.getTextModels()?.text?.getValue()).toEqual('hello world');
+            expect(wrapper.getTextModels()?.modified?.getValue()).toEqual('hello world');
         };
         render(<MonacoEditorReactComp wrapperConfig={wrapperConfig} onTextChanged={(textReceiverHello)} onLoad={handleOnLoad} />);
     });
@@ -79,7 +79,7 @@ describe('Test MonacoEditorReactComp', () => {
             },
             editorAppConfig: {
                 codeResources: {
-                    main: {
+                    modified: {
                         text: 'hello world',
                         fileExt: 'js'
                     }
@@ -90,21 +90,23 @@ describe('Test MonacoEditorReactComp', () => {
 
         let count = 0;
         const textReceiver = (textChanges: TextChanges) => {
+            // initial call
             if (count === 0) {
-                expect(textChanges.text).toBe('hello world');
+                expect(textChanges.modified).toBe('hello world');
             } else {
-                expect(textChanges.text).toBe('goodbye world');
+                expect(textChanges.modified).toBe('goodbye world');
             }
         };
 
         const handleOnLoad = async (wrapper: MonacoEditorLanguageClientWrapper) => {
+            count++;
             await wrapper.updateCodeResources({
-                main: {
+                modified: {
                     text: 'goodbye world',
                     fileExt: 'js'
                 }
             });
-            count++;
+
         };
         render(<MonacoEditorReactComp wrapperConfig={wrapperConfig} onLoad={handleOnLoad} onTextChanged={textReceiver} />);
     });

--- a/packages/wrapper/src/wrapper.ts
+++ b/packages/wrapper/src/wrapper.ts
@@ -63,7 +63,7 @@ export class MonacoEditorLanguageClientWrapper {
 
         const editorAppConfig = wrapperConfig.editorAppConfig;
         if ((editorAppConfig?.useDiffEditor ?? false) && !editorAppConfig?.codeResources?.original) {
-            throw new Error(`Use diff editor was used without a valid config. code: ${editorAppConfig?.codeResources?.main} codeOriginal: ${editorAppConfig?.codeResources?.original}`);
+            throw new Error(`Use diff editor was used without a valid config. code: ${editorAppConfig?.codeResources?.modified} codeOriginal: ${editorAppConfig?.codeResources?.original}`);
         }
 
         const viewServiceType = wrapperConfig.vscodeApiConfig?.viewsConfig?.viewServiceType ?? 'EditorService';

--- a/packages/wrapper/test/editorApp.test.ts
+++ b/packages/wrapper/test/editorApp.test.ts
@@ -56,7 +56,7 @@ describe('Test EditorAppBase', () => {
     test('config defaults', () => {
         const wrapperConfig = createWrapperConfigClassicApp();
         const app = new EditorApp('config defaults', wrapperConfig.$type, wrapperConfig.editorAppConfig);
-        expect(app.getConfig().codeResources?.main?.text).toEqual('');
+        expect(app.getConfig().codeResources?.modified?.text).toEqual('');
         expect(app.getConfig().codeResources?.original).toBeUndefined();
         expect(app.getConfig().useDiffEditor ?? false).toBeFalsy();
         expect(app.getConfig().readOnly).toBeFalsy();
@@ -77,7 +77,7 @@ describe('Test EditorAppBase', () => {
     test('config defaults', () => {
         const wrapperConfig = createWrapperConfigExtendedApp();
         const app = new EditorApp('config defaults', wrapperConfig.$type, wrapperConfig.editorAppConfig);
-        expect(app.getConfig().codeResources?.main?.text).toEqual('');
+        expect(app.getConfig().codeResources?.modified?.text).toEqual('');
         expect(app.getConfig().codeResources?.original).toBeUndefined();
         expect(app.getConfig().useDiffEditor ?? false).toBeFalsy();
         expect(app.getConfig().readOnly).toBeFalsy();

--- a/packages/wrapper/test/helper.ts
+++ b/packages/wrapper/test/helper.ts
@@ -22,7 +22,7 @@ export const createWrapperConfigExtendedApp = (): WrapperConfig => {
         },
         editorAppConfig: {
             codeResources: {
-                main: {
+                modified: {
                     text: '',
                     fileExt: 'js'
                 }
@@ -41,7 +41,7 @@ export const createWrapperConfigClassicApp = (): WrapperConfig => {
         },
         editorAppConfig: {
             codeResources: {
-                main: {
+                modified: {
                     text: '',
                     fileExt: 'js'
                 }


### PR DESCRIPTION
Text model content was not updated properly when updating code resources
Added additional unit tests
Variable naming alignment. Terminology is always modified and original derived from DiffEditor.