### PR TITLE
Move text changes handling from react component to the wrapper

### DIFF
--- a/packages/examples/src/appPlayground/reactMain.tsx
+++ b/packages/examples/src/appPlayground/reactMain.tsx
@@ -5,7 +5,7 @@
 
 import React, { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
-import { MonacoEditorLanguageClientWrapper, type TextChanges } from 'monaco-editor-wrapper';
+import { MonacoEditorLanguageClientWrapper } from 'monaco-editor-wrapper';
 import { MonacoEditorReactComp } from '@typefox/monaco-editor-react';
 import { configure } from './config.js';
 import { configurePostStart } from './common.js';
@@ -13,9 +13,6 @@ import { disableElement } from '../common/client/utils.js';
 
 export const runApplicationPlaygroundReact = async () => {
 
-    const onTextChanged = (textChanges: TextChanges) => {
-        console.log(`Dirty? ${textChanges.isDirty}\ntext: ${textChanges.modified}\ntextOriginal: ${textChanges.original}`);
-    };
     const configResult = configure();
     const root = ReactDOM.createRoot(document.getElementById('react-root')!);
 
@@ -26,7 +23,6 @@ export const runApplicationPlaygroundReact = async () => {
                     <div style={{ 'backgroundColor': '#1f1f1f' }}>
                         <MonacoEditorReactComp
                             wrapperConfig={configResult.wrapperConfig}
-                            onTextChanged={onTextChanged}
                             onLoad={async (wrapper: MonacoEditorLanguageClientWrapper) => {
                                 await configurePostStart(wrapper, configResult);
                             }}

--- a/packages/examples/src/python/client/reactPython.tsx
+++ b/packages/examples/src/python/client/reactPython.tsx
@@ -8,7 +8,7 @@ import { RegisteredFileSystemProvider, registerFileSystemOverlay, RegisteredMemo
 import React, { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 import { MonacoEditorReactComp } from '@typefox/monaco-editor-react';
-import { MonacoEditorLanguageClientWrapper, type TextChanges } from 'monaco-editor-wrapper';
+import { MonacoEditorLanguageClientWrapper, type TextContents } from 'monaco-editor-wrapper';
 import { createWrapperConfig } from './config.js';
 import badPyCode from '../../../resources/python/bad.py?raw';
 import { disableElement } from '../../common/client/utils.js';
@@ -19,8 +19,8 @@ export const runPythonReact = async () => {
     fileSystemProvider.registerFile(new RegisteredMemoryFile(badPyUri, badPyCode));
     registerFileSystemOverlay(1, fileSystemProvider);
 
-    const onTextChanged = (textChanges: TextChanges) => {
-        console.log(`Dirty? ${textChanges.isDirty}\ntext: ${textChanges.modified}\ntextOriginal: ${textChanges.original}`);
+    const onTextChanged = (textChanges: TextContents) => {
+        console.log(`text: ${textChanges.modified}\ntextOriginal: ${textChanges.original}`);
     };
     const wrapperConfig = createWrapperConfig('/workspace', badPyCode, '/workspace/bad.py');
     const root = ReactDOM.createRoot(document.getElementById('react-root')!);

--- a/packages/wrapper-react/src/index.tsx
+++ b/packages/wrapper-react/src/index.tsx
@@ -3,15 +3,14 @@
 * Licensed under the MIT License. See LICENSE in the package root for license information.
 * ------------------------------------------------------------------------------------------ */
 
-import * as monaco from '@codingame/monaco-vscode-editor-api';
 import React, { type CSSProperties, useCallback, useEffect, useRef } from 'react';
-import { didModelContentChange, MonacoEditorLanguageClientWrapper, type TextChanges, type TextModels, type WrapperConfig } from 'monaco-editor-wrapper';
+import { MonacoEditorLanguageClientWrapper, type TextContents, type WrapperConfig } from 'monaco-editor-wrapper';
 
 export type MonacoEditorProps = {
     style?: CSSProperties;
     className?: string;
     wrapperConfig: WrapperConfig,
-    onTextChanged?: (textChanges: TextChanges) => void;
+    onTextChanged?: (textChanges: TextContents) => void;
     onLoad?: (wrapper: MonacoEditorLanguageClientWrapper) => void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onError?: (e: any) => void;
@@ -29,7 +28,6 @@ export const MonacoEditorReactComp: React.FC<MonacoEditorProps> = (props) => {
 
     const wrapperRef = useRef<MonacoEditorLanguageClientWrapper>(new MonacoEditorLanguageClientWrapper());
     const containerRef = useRef<HTMLDivElement>(null);
-    const onTextChangedSubscriptions = useRef<monaco.IDisposable[]>([]);
 
     useEffect(() => {
         return () => {
@@ -80,27 +78,7 @@ export const MonacoEditorReactComp: React.FC<MonacoEditorProps> = (props) => {
     const startMonaco = useCallback(async () => {
         if (containerRef.current) {
             try {
-                wrapperRef.current.registerModelUpdate((textModels: TextModels) => {
-                    if (textModels.modified !== undefined || textModels.original !== undefined) {
-                        const newSubscriptions: monaco.IDisposable[] = [];
-
-                        if (textModels.modified !== undefined) {
-                            newSubscriptions.push(textModels.modified.onDidChangeContent(() => {
-                                didModelContentChange(textModels, wrapperConfig.editorAppConfig?.codeResources, onTextChanged);
-                            }));
-                        }
-
-                        if (textModels.original !== undefined) {
-                            newSubscriptions.push(textModels.original.onDidChangeContent(() => {
-                                didModelContentChange(textModels, wrapperConfig.editorAppConfig?.codeResources, onTextChanged);
-                            }));
-                        }
-                        onTextChangedSubscriptions.current = newSubscriptions;
-                        // do it initially
-                        didModelContentChange(textModels, wrapperConfig.editorAppConfig?.codeResources, onTextChanged);
-                    }
-                });
-
+                wrapperRef.current.registerTextChangeCallback(onTextChanged);
                 await wrapperRef.current.start();
                 onLoad?.(wrapperRef.current);
                 handleOnTextChanged();
@@ -117,10 +95,7 @@ export const MonacoEditorReactComp: React.FC<MonacoEditorProps> = (props) => {
     }, [onError, onLoad, onTextChanged]);
 
     const handleOnTextChanged = useCallback(() => {
-        disposeOnTextChanged();
-
         if (!onTextChanged) return;
-
     }, [onTextChanged, wrapperConfig]);
 
     const destroyMonaco = useCallback(async () => {
@@ -130,14 +105,6 @@ export const MonacoEditorReactComp: React.FC<MonacoEditorProps> = (props) => {
             // The language client may throw an error during disposal.
             // This should not prevent us from continue working.
         }
-        disposeOnTextChanged();
-    }, []);
-
-    const disposeOnTextChanged = useCallback(() => {
-        for (const subscription of onTextChangedSubscriptions.current) {
-            subscription.dispose();
-        }
-        onTextChangedSubscriptions.current = [];
     }, []);
 
     return (

--- a/packages/wrapper-react/test/index.test.tsx
+++ b/packages/wrapper-react/test/index.test.tsx
@@ -7,7 +7,7 @@ import { describe, expect, test } from 'vitest';
 import { render, type RenderResult } from '@testing-library/react';
 import React from 'react';
 import { LogLevel } from '@codingame/monaco-vscode-api';
-import { MonacoEditorLanguageClientWrapper, type TextChanges, type WrapperConfig } from 'monaco-editor-wrapper';
+import { MonacoEditorLanguageClientWrapper, type TextContents, type WrapperConfig } from 'monaco-editor-wrapper';
 import { MonacoEditorReactComp } from '@typefox/monaco-editor-react';
 import { configureMonacoWorkers } from './helper.js';
 
@@ -60,7 +60,7 @@ describe('Test MonacoEditorReactComp', () => {
             }
         };
 
-        const textReceiverHello = (textChanges: TextChanges) => {
+        const textReceiverHello = (textChanges: TextContents) => {
             expect(textChanges.modified).toEqual('hello world');
         };
 
@@ -89,7 +89,7 @@ describe('Test MonacoEditorReactComp', () => {
         };
 
         let count = 0;
-        const textReceiver = (textChanges: TextChanges) => {
+        const textReceiver = (textChanges: TextContents) => {
             // initial call
             if (count === 0) {
                 expect(textChanges.modified).toBe('hello world');

--- a/packages/wrapper/src/editorApp.ts
+++ b/packages/wrapper/src/editorApp.ts
@@ -26,11 +26,6 @@ export interface TextContents {
     original?: string;
 }
 
-export type TextChanges = TextContents & {
-    isDirty: boolean;
-    isDirtyOriginal: boolean;
-}
-
 export interface CodeContent {
     text: string;
     enforceLanguageId?: string;
@@ -315,15 +310,11 @@ export const getEditorUri = (id: string, original: boolean, code: CodePlusUri | 
     }
 };
 
-export const didModelContentChange = (textModels: TextModels, codeResources?: CodeResources, onTextChanged?: (textChanges: TextChanges) => void) => {
+export const didModelContentChange = (textModels: TextModels, onTextChanged?: (textChanges: TextContents) => void) => {
     const modified = textModels.modified?.getValue() ?? '';
     const original = textModels.original?.getValue() ?? '';
-    const isDirty = modified !== codeResources?.modified?.text;
-    const isDirtyOriginal = original !== codeResources?.original?.text;
     onTextChanged?.({
         modified,
-        original,
-        isDirty,
-        isDirtyOriginal
+        original
     });
 };

--- a/packages/wrapper/src/wrapper.ts
+++ b/packages/wrapper/src/wrapper.ts
@@ -40,8 +40,8 @@ export class MonacoEditorLanguageClientWrapper {
     private id: string;
     private editorApp?: EditorApp;
     private extensionRegisterResults: Map<string, | RegisterExtensionResult> = new Map();
-    private disposableStore?: DisposableStore;
-    private disposableStoreTextUpdates?: DisposableStore;
+    private disposableStoreExtensions?: DisposableStore;
+    private disposableStoreMonaco?: DisposableStore;
     private languageClientWrappers: Map<string, LanguageClientWrapper> = new Map();
     private wrapperConfig?: WrapperConfig;
     private logger: Logger = new ConsoleLogger();
@@ -75,8 +75,8 @@ export class MonacoEditorLanguageClientWrapper {
         // Always dispose old instances before start and
         // ensure disposable store is available again after dispose
         this.dispose(false);
-        this.disposableStore = new DisposableStore();
-        this.disposableStoreTextUpdates = new DisposableStore();
+        this.disposableStoreExtensions = new DisposableStore();
+        this.disposableStoreMonaco = new DisposableStore();
 
         this.id = wrapperConfig.id ?? Math.floor(Math.random() * 101).toString();
 
@@ -135,7 +135,7 @@ export class MonacoEditorLanguageClientWrapper {
                 this.extensionRegisterResults.set(manifest.name, extRegResult);
                 if (extensionConfig.filesOrContents && Object.hasOwn(extRegResult, 'registerFileUrl')) {
                     for (const entry of extensionConfig.filesOrContents) {
-                        this.disposableStore?.add(extRegResult.registerFileUrl(entry[0], verifyUrlOrCreateDataUrl(entry[1])));
+                        this.disposableStoreExtensions?.add(extRegResult.registerFileUrl(entry[0], verifyUrlOrCreateDataUrl(entry[1])));
                     }
                 }
                 allPromises.push(extRegResult.whenReady());
@@ -281,18 +281,18 @@ export class MonacoEditorLanguageClientWrapper {
     registerTextChangeCallback(onTextChanged?: (textChanges: TextContents) => void) {
         this.editorApp?.registerModelUpdate((textModels: TextModels) => {
             // clear on new registration
-            this.disposableStoreTextUpdates?.clear();
+            this.disposableStoreMonaco?.clear();
 
             if (textModels.modified !== undefined || textModels.original !== undefined) {
 
                 if (textModels.modified !== undefined) {
-                    this.disposableStoreTextUpdates?.add(textModels.modified.onDidChangeContent(() => {
+                    this.disposableStoreMonaco?.add(textModels.modified.onDidChangeContent(() => {
                         didModelContentChange(textModels, onTextChanged);
                     }));
                 }
 
                 if (textModels.original !== undefined) {
-                    this.disposableStoreTextUpdates?.add(textModels.original.onDidChangeContent(() => {
+                    this.disposableStoreMonaco?.add(textModels.original.onDidChangeContent(() => {
                         didModelContentChange(textModels, onTextChanged);
                     }));
                 }
@@ -324,8 +324,8 @@ export class MonacoEditorLanguageClientWrapper {
         this.editorApp = undefined;
 
         this.extensionRegisterResults.forEach((k) => k.dispose());
-        this.disposableStore?.dispose();
-        this.disposableStoreTextUpdates?.dispose();
+        this.disposableStoreExtensions?.dispose();
+        this.disposableStoreMonaco?.dispose();
 
         if (doDisposeLanguageClients) {
             await disposeLanguageClients(this.languageClientWrappers.values(), false);


### PR DESCRIPTION
This was a bad design choice that is corrected. The react component should be thinnest possible layer around the wrapper.