### PR TITLE
Handle languageclient errors cases more robustly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11378,7 +11378,6 @@
       "license": "MIT",
       "dependencies": {
         "@codingame/monaco-vscode-api": "~14.0.2",
-        "@codingame/monaco-vscode-configuration-service-override": "~14.0.2",
         "@codingame/monaco-vscode-editor-api": "~14.0.2",
         "@codingame/monaco-vscode-editor-service-override": "~14.0.2",
         "@codingame/monaco-vscode-extension-api": "~14.0.2",

--- a/packages/client/src/commonTypes.ts
+++ b/packages/client/src/commonTypes.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License. See LICENSE in the package root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { MonacoLanguageClient } from './client.js';
+import type { MonacoLanguageClient } from './client.js';
 
 export type ConnectionConfigOptions = WebSocketConfigOptionsDirect | WebSocketConfigOptionsParams | WebSocketConfigOptionsUrl | WorkerConfigOptionsParams | WorkerConfigOptionsDirect;
 

--- a/packages/client/src/vscode/services.ts
+++ b/packages/client/src/vscode/services.ts
@@ -8,6 +8,7 @@ import 'vscode/localExtensionHost';
 import { initialize, type IWorkbenchConstructionOptions } from '@codingame/monaco-vscode-api';
 import type { OpenEditor } from '@codingame/monaco-vscode-editor-service-override';
 import type { WorkerConfig } from '@codingame/monaco-vscode-extensions-service-override';
+import getConfigurationServiceOverride, { initUserConfiguration } from '@codingame/monaco-vscode-configuration-service-override';
 import getExtensionServiceOverride from '@codingame/monaco-vscode-extensions-service-override';
 import getLanguagesServiceOverride from '@codingame/monaco-vscode-languages-service-override';
 import getModelServiceOverride from '@codingame/monaco-vscode-model-service-override';
@@ -17,7 +18,6 @@ import type { EnvironmentOverride } from '@codingame/monaco-vscode-api/workbench
 import type { Logger } from 'monaco-languageclient/tools';
 import { FakeWorker as Worker } from './fakeWorker.js';
 import { setUnexpectedErrorHandler } from '@codingame/monaco-vscode-api/monaco';
-import { initUserConfiguration } from '@codingame/monaco-vscode-configuration-service-override';
 
 export interface MonacoEnvironmentEnhanced extends monaco.Environment {
     vscodeInitialising?: boolean;
@@ -75,6 +75,7 @@ export const getMonacoEnvironmentEnhanced = () => {
 
 export const supplyRequiredServices = async () => {
     return {
+        ...getConfigurationServiceOverride(),
         ...getLanguagesServiceOverride(),
         ...getLogServiceOverride(),
         ...getModelServiceOverride()

--- a/packages/client/test/fs/endpoints/emptyEndpoint.test.ts
+++ b/packages/client/test/fs/endpoints/emptyEndpoint.test.ts
@@ -39,7 +39,7 @@ describe('EmptyFileSystemEndpoint Tests', () => {
     });
 
     test('getFileStats', async () => {
-        expect(async () => {
+        await expect(async () => {
             await endpoint.getFileStats({
                 type: 'file',
                 resourceUri: '/tmp/test.js'
@@ -48,7 +48,7 @@ describe('EmptyFileSystemEndpoint Tests', () => {
     });
 
     test('listFiles', async () => {
-        expect(async () => {
+        await expect(async () => {
             await endpoint.listFiles({
                 directoryUri: '/tmp'
             });

--- a/packages/client/test/vscode/services.test.ts
+++ b/packages/client/test/vscode/services.test.ts
@@ -5,15 +5,11 @@
 
 import { describe, expect, test } from 'vitest';
 import { initServices, type MonacoEnvironmentEnhanced } from 'monaco-languageclient/vscode/services';
-import getConfigurationServiceOverride from '@codingame/monaco-vscode-configuration-service-override';
 
 describe('VSCde services Tests', () => {
 
     test('initServices', async () => {
         const vscodeApiConfig = {
-            serviceOverrides: {
-                ...getConfigurationServiceOverride()
-            },
             userConfiguration: {
                 json: JSON.stringify({
                     'workbench.colorTheme': 'Default Dark Modern'

--- a/packages/examples/src/appPlayground/config.ts
+++ b/packages/examples/src/appPlayground/config.ts
@@ -6,7 +6,6 @@
 import * as vscode from 'vscode';
 import { LogLevel } from '@codingame/monaco-vscode-api';
 import { RegisteredFileSystemProvider, registerFileSystemOverlay, RegisteredMemoryFile } from '@codingame/monaco-vscode-files-service-override';
-import getConfigurationServiceOverride from '@codingame/monaco-vscode-configuration-service-override';
 import getKeybindingsServiceOverride from '@codingame/monaco-vscode-keybindings-service-override';
 import getLifecycleServiceOverride from '@codingame/monaco-vscode-lifecycle-service-override';
 import getLocalizationServiceOverride from '@codingame/monaco-vscode-localization-service-override';
@@ -51,7 +50,6 @@ export const configure = (htmlContainer?: HTMLElement): ConfigResult => {
         htmlContainer,
         vscodeApiConfig: {
             serviceOverrides: {
-                ...getConfigurationServiceOverride(),
                 ...getKeybindingsServiceOverride(),
                 ...getLifecycleServiceOverride(),
                 ...getLocalizationServiceOverride(createDefaultLocaleConfiguration()),

--- a/packages/examples/src/bare/client.ts
+++ b/packages/examples/src/bare/client.ts
@@ -6,7 +6,6 @@
 import * as monaco from '@codingame/monaco-vscode-editor-api';
 import { initServices } from 'monaco-languageclient/vscode/services';
 import { LogLevel } from '@codingame/monaco-vscode-api';
-import getConfigurationServiceOverride from '@codingame/monaco-vscode-configuration-service-override';
 // monaco-editor does not supply json highlighting with the json worker,
 // that's why we use the textmate extension from VSCode
 import '@codingame/monaco-vscode-json-default-extension';
@@ -20,9 +19,6 @@ export const runClient = async () => {
     const logger = new ConsoleLogger(LogLevel.Debug);
     const htmlContainer = document.getElementById('monaco-editor-root')!;
     await initServices({
-        serviceOverrides: {
-            ...getConfigurationServiceOverride()
-        },
         userConfiguration: {
             json: JSON.stringify({
                 'editor.experimental.asyncTokenization': true

--- a/packages/examples/src/clangd/client/config.ts
+++ b/packages/examples/src/clangd/client/config.ts
@@ -4,7 +4,6 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { Uri } from 'vscode';
-import getConfigurationServiceOverride from '@codingame/monaco-vscode-configuration-service-override';
 import getKeybindingsServiceOverride from '@codingame/monaco-vscode-keybindings-service-override';
 import getLifecycleServiceOverride from '@codingame/monaco-vscode-lifecycle-service-override';
 import getBannerServiceOverride from '@codingame/monaco-vscode-view-banner-service-override';
@@ -58,7 +57,6 @@ export const createWrapperConfig = async (config: {
         },
         vscodeApiConfig: {
             serviceOverrides: {
-                ...getConfigurationServiceOverride(),
                 ...getKeybindingsServiceOverride(),
                 ...getLifecycleServiceOverride(),
                 ...getBannerServiceOverride(),

--- a/packages/examples/src/langium/langium-dsl/config/classicConfig.ts
+++ b/packages/examples/src/langium/langium-dsl/config/classicConfig.ts
@@ -3,7 +3,6 @@
  * Licensed under the MIT License. See LICENSE in the package root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import getConfigurationServiceOverride from '@codingame/monaco-vscode-configuration-service-override';
 import getKeybindingsServiceOverride from '@codingame/monaco-vscode-keybindings-service-override';
 import { LogLevel } from '@codingame/monaco-vscode-api';
 import type { Logger } from 'monaco-languageclient/tools';
@@ -22,7 +21,6 @@ export const setupLangiumClientClassic = async (langiumWorker: Worker): Promise<
         logLevel: LogLevel.Debug,
         vscodeApiConfig: {
             serviceOverrides: {
-                ...getConfigurationServiceOverride(),
                 ...getKeybindingsServiceOverride()
             }
         },

--- a/packages/examples/src/python/client/config.ts
+++ b/packages/examples/src/python/client/config.ts
@@ -4,7 +4,6 @@
  * ------------------------------------------------------------------------------------------ */
 
 import * as vscode from 'vscode';
-import getConfigurationServiceOverride from '@codingame/monaco-vscode-configuration-service-override';
 import getKeybindingsServiceOverride from '@codingame/monaco-vscode-keybindings-service-override';
 import getLifecycleServiceOverride from '@codingame/monaco-vscode-lifecycle-service-override';
 import getLocalizationServiceOverride from '@codingame/monaco-vscode-localization-service-override';
@@ -134,7 +133,6 @@ export const createWrapperConfig = (): PythonAppConfig => {
         },
         vscodeApiConfig: {
             serviceOverrides: {
-                ...getConfigurationServiceOverride(),
                 ...getKeybindingsServiceOverride(),
                 ...getLifecycleServiceOverride(),
                 ...getLocalizationServiceOverride(createDefaultLocaleConfiguration()),

--- a/packages/wrapper-react/test/helper.ts
+++ b/packages/wrapper-react/test/helper.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License. See LICENSE in the package root for license information.
  * ------------------------------------------------------------------------------------------ */
 
+import { LogLevel } from '@codingame/monaco-vscode-api';
+import type { WrapperConfig } from 'monaco-editor-wrapper';
 import { useWorkerFactory } from 'monaco-languageclient/workerFactory';
 
 export const configureMonacoWorkers = () => {
@@ -11,4 +13,23 @@ export const configureMonacoWorkers = () => {
             TextEditorWorker: () => new Worker(new URL('@codingame/monaco-vscode-editor-api/esm/vs/editor/editor.worker.js', import.meta.url), { type: 'module' }),
         }
     });
+};
+
+export const createDefaultWrapperConfig = (): WrapperConfig => {
+    return {
+        $type: 'extended',
+        logLevel: LogLevel.Debug,
+        vscodeApiConfig: {
+            loadThemes: false
+        },
+        editorAppConfig: {
+            codeResources: {
+                modified: {
+                    text: 'hello world',
+                    fileExt: 'js'
+                }
+            },
+            monacoWorkerFactory: configureMonacoWorkers
+        }
+    };
 };

--- a/packages/wrapper-react/test/index.test.tsx
+++ b/packages/wrapper-react/test/index.test.tsx
@@ -6,59 +6,38 @@
 import { describe, expect, test } from 'vitest';
 import { render, type RenderResult } from '@testing-library/react';
 import React from 'react';
-import { LogLevel } from '@codingame/monaco-vscode-api';
-import { MonacoEditorLanguageClientWrapper, type TextContents, type WrapperConfig } from 'monaco-editor-wrapper';
+import { MonacoEditorLanguageClientWrapper, type TextContents } from 'monaco-editor-wrapper';
 import { MonacoEditorReactComp } from '@typefox/monaco-editor-react';
-import { configureMonacoWorkers } from './helper.js';
+import { createDefaultWrapperConfig } from './helper.js';
 
 describe('Test MonacoEditorReactComp', () => {
     test('rerender', async () => {
-        const wrapperConfig: WrapperConfig = {
-            $type: 'extended',
-            logLevel: LogLevel.Debug,
-            vscodeApiConfig: {
-                loadThemes: false
-            },
-            editorAppConfig: {
-                monacoWorkerFactory: configureMonacoWorkers
-            }
-        };
+        const wrapperConfig = createDefaultWrapperConfig();
         const { rerender } = render(<MonacoEditorReactComp wrapperConfig={wrapperConfig} />);
         rerender(<MonacoEditorReactComp wrapperConfig={wrapperConfig} />);
-        await Promise.resolve();
         rerender(<MonacoEditorReactComp wrapperConfig={wrapperConfig} />);
+    });
+
+    test('onLoad', async () => {
+        const wrapperConfig = createDefaultWrapperConfig();
 
         let renderResult: RenderResult;
         // we have to await the full start of the editor with the onLoad callback, then it is save to contine
-        const p = await new Promise<void>(resolve => {
+        await expect(await new Promise<void>(resolve => {
             const handleOnLoad = async (_wrapper: MonacoEditorLanguageClientWrapper) => {
                 renderResult.rerender(<MonacoEditorReactComp wrapperConfig={wrapperConfig} />);
 
+                console.log('onLoad');
                 resolve();
             };
+            // render(<MonacoEditorReactComp wrapperConfig={wrapperConfig} onLoad={handleOnLoad} />);
             renderResult = render(<MonacoEditorReactComp wrapperConfig={wrapperConfig} onLoad={handleOnLoad} />);
-        });
         // void promise is undefined after it was awaited
-        expect(p).toBeUndefined();
+        })).toBeUndefined();
     });
 
     test('update onTextChanged', async () => {
-        const wrapperConfig: WrapperConfig = {
-            $type: 'extended',
-            logLevel: LogLevel.Debug,
-            vscodeApiConfig: {
-                loadThemes: false
-            },
-            editorAppConfig: {
-                codeResources: {
-                    modified: {
-                        text: 'hello world',
-                        fileExt: 'js'
-                    }
-                },
-                monacoWorkerFactory: configureMonacoWorkers
-            }
-        };
+        const wrapperConfig = createDefaultWrapperConfig();
 
         const textReceiverHello = (textChanges: TextContents) => {
             expect(textChanges.modified).toEqual('hello world');
@@ -71,22 +50,7 @@ describe('Test MonacoEditorReactComp', () => {
     });
 
     test('update codeResources', async () => {
-        const wrapperConfig: WrapperConfig = {
-            $type: 'extended',
-            logLevel: LogLevel.Debug,
-            vscodeApiConfig: {
-                loadThemes: false
-            },
-            editorAppConfig: {
-                codeResources: {
-                    modified: {
-                        text: 'hello world',
-                        fileExt: 'js'
-                    }
-                },
-                monacoWorkerFactory: configureMonacoWorkers
-            }
-        };
+        const wrapperConfig = createDefaultWrapperConfig();
 
         let count = 0;
         const textReceiver = (textChanges: TextContents) => {

--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -61,7 +61,6 @@
   },
   "dependencies": {
     "@codingame/monaco-vscode-api": "~14.0.2",
-    "@codingame/monaco-vscode-configuration-service-override": "~14.0.2",
     "@codingame/monaco-vscode-editor-api": "~14.0.2",
     "@codingame/monaco-vscode-editor-service-override": "~14.0.2",
     "@codingame/monaco-vscode-extension-api": "~14.0.2",

--- a/packages/wrapper/src/vscode/services.ts
+++ b/packages/wrapper/src/vscode/services.ts
@@ -25,14 +25,6 @@ export const augmentVscodeApiConfig = async ($type: OverallConfigType, config: V
     // set empty object if undefined
     const services: monaco.editor.IEditorOverrideServices = vscodeApiConfig.serviceOverrides ?? {};
 
-    // import configuration service if it is not available
-    if (services.configurationService === undefined) {
-        const getConfigurationServiceOverride = (await import('@codingame/monaco-vscode-configuration-service-override')).default;
-        mergeServices(services, {
-            ...getConfigurationServiceOverride()
-        });
-    }
-
     await augmentHighlightingServices($type, services);
     await augmentViewsServices(services, vscodeApiConfig.viewsConfig);
 

--- a/packages/wrapper/src/wrapper.ts
+++ b/packages/wrapper/src/wrapper.ts
@@ -186,16 +186,13 @@ export class MonacoEditorLanguageClientWrapper {
      */
     async initAndStart(wrapperConfig: WrapperConfig, includeLanguageClients: boolean = true) {
         await this.init(wrapperConfig, includeLanguageClients);
-        await this.start({ includeLanguageClients });
+        await this.start(includeLanguageClients);
     }
 
     /**
      * Does not perform any user configuration or other application init and just starts the application.
      */
-    async start(startConfig?: {
-        htmlContainer?: HTMLElement,
-        includeLanguageClients?: boolean
-    }) {
+    async start(includeLanguageClients: boolean = true, htmlContainer?: HTMLElement) {
         if (this.wrapperConfig === undefined) {
             throw new Error('No init was performed. Please call init() before start()');
         }
@@ -204,7 +201,7 @@ export class MonacoEditorLanguageClientWrapper {
             const viewServiceType = this.wrapperConfig.vscodeApiConfig?.viewsConfig?.viewServiceType;
             if (viewServiceType === 'EditorService' || viewServiceType === undefined) {
                 this.logger.info(`Starting monaco-editor (${this.id})`);
-                const html = startConfig?.htmlContainer === undefined ? this.wrapperConfig.htmlContainer : startConfig.htmlContainer;
+                const html = htmlContainer === undefined ? this.wrapperConfig.htmlContainer : htmlContainer;
                 if (html === undefined) {
                     throw new Error('No html container provided. Unable to start monaco-editor.');
                 } else {
@@ -214,7 +211,7 @@ export class MonacoEditorLanguageClientWrapper {
                 this.logger.info('No EditorService configured. monaco-editor will not be started.');
             }
 
-            if (startConfig?.includeLanguageClients === true) {
+            if (includeLanguageClients) {
                 await this.startLanguageClients();
             }
             // eslint-disable-next-line no-useless-catch

--- a/packages/wrapper/test/helper.ts
+++ b/packages/wrapper/test/helper.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { useWorkerFactory } from 'monaco-languageclient/workerFactory';
-import type { WrapperConfig } from 'monaco-editor-wrapper';
+import type { LanguageClientConfig, WrapperConfig } from 'monaco-editor-wrapper';
 
 export const createMonacoEditorDiv = () => {
     const div = document.createElement('div');
@@ -57,4 +57,38 @@ export const configureMonacoWorkers = () => {
             TextEditorWorker: () => new Worker(new URL('@codingame/monaco-vscode-editor-api/esm/vs/editor/editor.worker.js', import.meta.url), { type: 'module' }),
         }
     });
+};
+
+export const createDefaultLcWorkerConfig = (): LanguageClientConfig => {
+    return {
+        name: 'test-worker-direct',
+        clientOptions: {
+            documentSelector: ['javascript']
+        },
+        connection: {
+            options: {
+                $type: 'WorkerDirect',
+                // create a web worker to pass to the wrapper
+                worker: new Worker('./worker/langium-server.ts', {
+                    type: 'module',
+                    name: 'Langium LS'
+                })
+            }
+        }
+    };
+};
+
+export const createDefaultLcUnreachableUrlConfig = (): LanguageClientConfig => {
+    return {
+        name: 'test-ws-unreachable',
+        clientOptions: {
+            documentSelector: ['javascript']
+        },
+        connection: {
+            options: {
+                $type: 'WebSocketUrl',
+                url: 'ws://localhost:12345/Tester'
+            }
+        }
+    };
 };

--- a/packages/wrapper/test/languageClientWrapper.test.ts
+++ b/packages/wrapper/test/languageClientWrapper.test.ts
@@ -3,128 +3,53 @@
  * Licensed under the MIT License. See LICENSE in the package root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { describe, expect, test } from 'vitest';
-import { LanguageClientWrapper, MonacoEditorLanguageClientWrapper } from 'monaco-editor-wrapper';
-import { createWrapperConfigExtendedApp } from './helper.js';
+import { beforeAll, describe, expect, test } from 'vitest';
+import { LanguageClientWrapper, type LanguageClientConfig } from 'monaco-editor-wrapper';
+import { initServices } from 'monaco-languageclient/vscode/services';
+import { createDefaultLcUnreachableUrlConfig, createDefaultLcWorkerConfig } from './helper.js';
 
 describe('Test LanguageClientWrapper', () => {
 
-    test('Not defined after construction without configuration', async () => {
-        const wrapper = new MonacoEditorLanguageClientWrapper();
-        await wrapper.init(createWrapperConfigExtendedApp());
-
-        const languageClientWrapper = wrapper.getLanguageClientWrapper('unknown');
-        expect(languageClientWrapper).toBeUndefined();
+    beforeAll(async () => {
+        await initServices({});
     });
 
     test('Constructor: no config', async () => {
+        const languageClientConfig = createDefaultLcWorkerConfig();
         const languageClientWrapper = new LanguageClientWrapper({
-            languageClientConfig: {
-                clientOptions: {
-                    documentSelector: ['javascript']
-                },
-                connection: {
-                    options: {
-                        $type: 'WorkerDirect',
-                        // create a web worker to pass to the wrapper
-                        worker: new Worker('./worker/langium-server.ts', {
-                            type: 'module',
-                            name: 'Langium LS',
-                        })
-                    }
-                }
-            }
+            languageClientConfig
         });
-        expect(languageClientWrapper).toBeDefined();
         expect(languageClientWrapper.haveLanguageClient).toBeTruthy();
     });
 
     test('Dispose: direct worker is cleaned up afterwards', async () => {
-        // setup the wrapper
-        const config = createWrapperConfigExtendedApp();
-        config.languageClientConfigs = {
-            javascript: {
-                clientOptions: {
-                    documentSelector: ['javascript']
-                },
-                connection: {
-                    options: {
-                        $type: 'WorkerDirect',
-                        // create a web worker to pass to the wrapper
-                        worker: new Worker('./worker/langium-server.ts', {
-                            type: 'module',
-                            name: 'Langium LS',
-                        })
-                    }
-                }
-            }
-        };
-        const wrapper = new MonacoEditorLanguageClientWrapper();
-        await wrapper.init(config);
+        const languageClientConfig = createDefaultLcWorkerConfig();
+        const languageClientWrapper = new LanguageClientWrapper({
+            languageClientConfig
+        });
 
-        const languageClientWrapper = wrapper.getLanguageClientWrapper('javascript');
-        expect(languageClientWrapper).toBeDefined();
-
-        expect(languageClientWrapper?.getWorker()).toBeFalsy();
+        expect(languageClientWrapper.getWorker()).toBeFalsy();
 
         // WA: for whatever reasons "await" kills the test,
         // but the languageClientWrapper needs to be fully initialised as otherwise the follow up steps fail
-        languageClientWrapper?.start();
+        languageClientWrapper.start();
 
         setTimeout(async () => {
             // dispose & verify
-            await languageClientWrapper?.disposeLanguageClient(false);
-            expect(languageClientWrapper?.getWorker()).toBeUndefined();
+            await languageClientWrapper.disposeLanguageClient(false);
+            expect(languageClientWrapper.getWorker()).toBeUndefined();
         }, 250);
-        expect(languageClientWrapper?.getWorker()).toBeTruthy();
-    });
-
-    test('Constructor: config', async () => {
-        const config = createWrapperConfigExtendedApp();
-        config.languageClientConfigs = {
-            javascript: {
-                clientOptions: {
-                    documentSelector: ['javascript']
-                },
-                connection: {
-                    options: {
-                        $type: 'WebSocketUrl',
-                        url: 'ws://localhost:12345/Tester'
-                    }
-                }
-            }
-        };
-        const wrapper = new MonacoEditorLanguageClientWrapper();
-        await wrapper.init(config);
-
-        const languageClientWrapper = wrapper.getLanguageClientWrapper('javascript');
-        expect(languageClientWrapper).toBeDefined();
+        expect(languageClientWrapper.getWorker()).toBeTruthy();
     });
 
     test('Start: unreachable url', async () => {
-        const config = createWrapperConfigExtendedApp();
-        config.languageClientConfigs = {
-            javascript: {
-                clientOptions: {
-                    documentSelector: ['javascript']
-                },
-                name: 'test-unreachable',
-                connection: {
-                    options: {
-                        $type: 'WebSocketUrl',
-                        url: 'ws://localhost:12345/Tester'
-                    }
-                }
-            }
-        };
-        const wrapper = new MonacoEditorLanguageClientWrapper();
-        await wrapper.init(config);
+        const languageClientConfig: LanguageClientConfig = createDefaultLcUnreachableUrlConfig();
+        const languageClientWrapper = new LanguageClientWrapper({
+            languageClientConfig
+        });
 
-        const languageClientWrapper = wrapper.getLanguageClientWrapper('javascript');
-        expect(languageClientWrapper).toBeDefined();
-
-        await expect(languageClientWrapper?.start()).rejects.toEqual({
-            message: 'languageClientWrapper (test-unreachable): Websocket connection failed.',
+        await expect(languageClientWrapper.start()).rejects.toEqual({
+            message: 'languageClientWrapper (test-ws-unreachable): Websocket connection failed.',
             error: 'No error was provided.'
         });
     });
@@ -141,29 +66,26 @@ describe('Test LanguageClientWrapper', () => {
     });
 
     test('Start: unreachable worker url', async () => {
-        const config = createWrapperConfigExtendedApp();
-        config.languageClientConfigs = {
-            javascript: {
-                clientOptions: {
-                    documentSelector: ['javascript']
-                },
-                connection: {
-                    options: {
-                        $type: 'WorkerConfig',
-                        url: new URL(`${import.meta.url.split('@fs')[0]}/packages/wrapper/test/worker/langium-server.ts`),
-                        type: 'classic'
-                    }
+        const languageClientConfig: LanguageClientConfig = {
+            name: 'test-worker-unreachable',
+            clientOptions: {
+                documentSelector: ['javascript']
+            },
+            connection: {
+                options: {
+                    $type: 'WorkerConfig',
+                    url: new URL(`${import.meta.url.split('@fs')[0]}/packages/wrapper/test/worker/langium-server.ts`),
+                    type: 'classic'
                 }
             }
         };
-        const wrapper = new MonacoEditorLanguageClientWrapper();
-        await wrapper.init(config);
 
-        const languageClientWrapper = wrapper.getLanguageClientWrapper('javascript');
-        expect(languageClientWrapper).toBeDefined();
+        const languageClientWrapper = new LanguageClientWrapper({
+            languageClientConfig
+        });
 
-        await expect(languageClientWrapper?.start()).rejects.toEqual({
-            message: 'languageClientWrapper (unnamed): Illegal worker configuration detected.',
+        await expect(languageClientWrapper.start()).rejects.toEqual({
+            message: 'languageClientWrapper (test-worker-unreachable): Illegal worker configuration detected.',
             error: 'No error was provided.'
         });
     });

--- a/packages/wrapper/test/worker/langium-server.ts
+++ b/packages/wrapper/test/worker/langium-server.ts
@@ -9,6 +9,8 @@ import { type DefaultSharedModuleContext, startLanguageServer } from 'langium/ls
 import { createLangiumGrammarServices } from 'langium/grammar';
 import { BrowserMessageReader, BrowserMessageWriter, createConnection } from 'vscode-languageserver/browser.js';
 
+console.log('Langium Worker started for test');
+
 /* browser specific setup code */
 const messageReader = new BrowserMessageReader(self as DedicatedWorkerGlobalScope);
 const messageWriter = new BrowserMessageWriter(self as DedicatedWorkerGlobalScope);

--- a/packages/wrapper/test/wrapper.test.ts
+++ b/packages/wrapper/test/wrapper.test.ts
@@ -31,7 +31,7 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
     test('Check default values', async () => {
         createMonacoEditorDiv();
         const wrapper = new MonacoEditorLanguageClientWrapper();
-        await wrapper.initAndStart(createWrapperConfigClassicApp());
+        expect(await wrapper.initAndStart(createWrapperConfigClassicApp())).toBeUndefined();
 
         const app = wrapper.getMonacoEditorApp();
         expect(app).toBeDefined();
@@ -53,7 +53,7 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
         const wrapper = new MonacoEditorLanguageClientWrapper();
         await expect(async () => {
             const config = createWrapperConfigClassicApp();
-            await wrapper.init(config);
+            expect(await wrapper.init(config)).toBeUndefined();
             await wrapper.initAndStart(config);
         }).rejects.toThrowError('init was already performed. Please call dispose first if you want to re-start.');
     });
@@ -62,7 +62,7 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
         createMonacoEditorDiv();
         const wrapper = new MonacoEditorLanguageClientWrapper();
         const wrapperConfig = createWrapperConfigClassicApp();
-        await wrapper.initAndStart(wrapperConfig);
+        expect(await wrapper.initAndStart(wrapperConfig)).toBeUndefined();
         const app = wrapper.getMonacoEditorApp();
 
         const modelRefs = app?.getModelRefs();
@@ -81,7 +81,7 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
             text: 'original',
             fileExt: 'js'
         };
-        await wrapper.initAndStart(wrapperConfig);
+        expect(await wrapper.initAndStart(wrapperConfig)).toBeUndefined();
         const app = wrapper.getMonacoEditorApp();
 
         const modelRefs = app?.getModelRefs();
@@ -99,7 +99,7 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
             text: 'original',
             fileExt: 'js'
         };
-        await wrapper.initAndStart(wrapperConfig);
+        expect(await wrapper.initAndStart(wrapperConfig)).toBeUndefined();
         const app = wrapper.getMonacoEditorApp();
 
         const modelRefs = app?.getModelRefs();
@@ -120,7 +120,7 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
         const wrapper = new MonacoEditorLanguageClientWrapper();
         const wrapperConfig = createWrapperConfigClassicApp();
         wrapperConfig.editorAppConfig!.codeResources = {};
-        await wrapper.initAndStart(wrapperConfig);
+        expect(await wrapper.initAndStart(wrapperConfig)).toBeUndefined();
 
         const app = wrapper.getMonacoEditorApp();
         const modelRefs = app?.getModelRefs();
@@ -133,7 +133,7 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
         const wrapper = new MonacoEditorLanguageClientWrapper();
         const wrapperConfig = createWrapperConfigClassicApp();
         wrapperConfig.editorAppConfig!.codeResources = {};
-        await wrapper.initAndStart(wrapperConfig);
+        expect(await wrapper.initAndStart(wrapperConfig)).toBeUndefined();
 
         const app = wrapper.getMonacoEditorApp();
 
@@ -174,10 +174,9 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
                 ['/javascript.tmLanguage.json', '{}']
             ]),
         }];
-        await wrapper.initAndStart(wrapperConfig);
-        await wrapper.dispose();
-
-        await wrapper.initAndStart(wrapperConfig);
+        expect(await wrapper.initAndStart(wrapperConfig)).toBeUndefined();
+        expect(await wrapper.dispose()).toBeUndefined();
+        expect(await wrapper.initAndStart(wrapperConfig)).toBeUndefined();
     });
 
     test('Early code resources update on wrapper are ok', async () => {
@@ -186,15 +185,14 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
         const wrapperConfig = createWrapperConfigClassicApp();
         wrapperConfig.editorAppConfig!.codeResources = {};
 
-        await wrapper.init(wrapperConfig);
+        expect(await wrapper.init(wrapperConfig)).toBeUndefined();
         const app = wrapper.getMonacoEditorApp();
-        const promise = await wrapper.updateCodeResources({
+        expect(await wrapper.updateCodeResources({
             modified: {
                 text: 'blah',
                 fileExt: 'statemachine'
             }
-        });
-        expect(promise).toBeUndefined();
+        })).toBeUndefined();
         expect(wrapper.getEditor()).toBeUndefined();
         expect(wrapper.getDiffEditor()).toBeUndefined();
 
@@ -202,7 +200,7 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
         expect(modelRefs?.modelRefModified).toBeDefined();
         expect(modelRefs?.modelRefOriginal).toBeUndefined();
 
-        await wrapper.start();
+        expect(await wrapper.start()).toBeUndefined();
     });
 
     test('editorConfig semanticHighlighting.enabled workaround', async () => {
@@ -212,7 +210,7 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
         wrapperConfig.editorAppConfig!.editorOptions = {
             'semanticHighlighting.enabled': true,
         };
-        await wrapper.init(wrapperConfig);
+        expect(await wrapper.init(wrapperConfig)).toBeUndefined();
         expect(wrapper.getWrapperConfig()?.vscodeApiConfig?.workspaceConfig?.configurationDefaults?.['editor.semanticHighlighting.enabled']).toEqual(true);
 
         const semHigh = await new Promise<unknown>(resolve => {
@@ -235,16 +233,16 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
             }
         };
 
-        await wrapper.initAndStart(wrapperConfig);
+        expect(await wrapper.initAndStart(wrapperConfig)).toBeUndefined();
         expect(wrapper.isStarted()).toBeTruthy();
 
-        await wrapper.updateCodeResources({
+        expect(await wrapper.updateCodeResources({
             modified: {
                 text: 'console.log("Goodbye World");',
                 fileExt: 'js',
                 enforceLanguageId: 'javascript'
             }
-        });
+        })).toBeUndefined();
 
         const textContents = wrapper.getTextContents();
         expect(textContents?.modified).toEqual('console.log("Goodbye World");');
@@ -263,15 +261,15 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
             }
         };
 
-        await wrapper.initAndStart(wrapperConfig);
+        expect(await wrapper.initAndStart(wrapperConfig)).toBeUndefined();
         expect(wrapper.isStarted()).toBeTruthy();
 
-        await wrapper.updateCodeResources({
+        expect(await wrapper.updateCodeResources({
             modified: {
                 text: 'console.log("Goodbye World");',
                 uri: '/workspace/main.js'
             }
-        });
+        })).toBeUndefined();
 
         const textContents = wrapper.getTextContents();
         expect(textContents?.modified).toEqual('console.log("Goodbye World");');
@@ -288,7 +286,7 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
             console.log(`text: ${textChanges.modified}\ntextOriginal: ${textChanges.original}`);
         };
 
-        await wrapper.init(wrapperConfig);
+        expect(await wrapper.init(wrapperConfig)).toBeUndefined();
 
         // eslint-disable-next-line dot-notation
         const disposableStoreMonaco = wrapper['disposableStoreMonaco'];
@@ -300,7 +298,7 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
         const spyModelUpdateCallback = vi.spyOn(wrapper['editorApp'], 'modelUpdateCallback');
         const spyDisposableStoreMonaco = vi.spyOn(disposableStoreMonaco, 'clear');
 
-        await wrapper.start();
+        expect(await wrapper.start()).toBeUndefined();
 
         expect(spyModelUpdateCallback).toHaveBeenCalledTimes(1);
         expect(spyDisposableStoreMonaco).toHaveBeenCalledTimes(1);
@@ -315,7 +313,7 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
 
     test('LanguageClientWrapper Not defined after construction without configuration', async () => {
         const wrapper = new MonacoEditorLanguageClientWrapper();
-        await wrapper.init(createWrapperConfigExtendedApp());
+        expect(await wrapper.init(createWrapperConfigExtendedApp())).toBeUndefined();
 
         const languageClientWrapper = wrapper.getLanguageClientWrapper('unknown');
         expect(languageClientWrapper).toBeUndefined();
@@ -327,7 +325,7 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
             javascript: createDefaultLcUnreachableUrlConfig()
         };
         const wrapper = new MonacoEditorLanguageClientWrapper();
-        await wrapper.init(config);
+        expect(await wrapper.init(config)).toBeUndefined();
 
         const languageClientWrapper = wrapper.getLanguageClientWrapper('javascript');
         expect(languageClientWrapper).toBeDefined();
@@ -350,13 +348,24 @@ describe('Test MonacoEditorLanguageClientWrapper', () => {
         expect(wrapper.isStarting()).toBeFalsy();
         expect(wrapper.isStopping()).toBeFalsy();
 
-        await wrapper.dispose();
+        expect(await wrapper.dispose()).toBeUndefined();
 
         expect(wrapper.isInitializing()).toBeFalsy();
         expect(wrapper.isStarting()).toBeFalsy();
         expect(wrapper.isStopping()).toBeFalsy();
 
         const config2 = createWrapperConfigExtendedApp();
-        await wrapper.initAndStart(config2);
+        expect(await wrapper.initAndStart(config2)).toBeUndefined();
+    });
+
+    test('Test html parameter with start', async () => {
+        createMonacoEditorDiv();
+        const wrapper = new MonacoEditorLanguageClientWrapper();
+        const wrapperConfig = createWrapperConfigExtendedApp();
+        const htmlContainer = wrapperConfig.htmlContainer;
+        wrapperConfig.htmlContainer = undefined;
+
+        expect(await wrapper.init(wrapperConfig)).toBeUndefined();
+        expect(await wrapper.start(true, htmlContainer)).toBeUndefined();
     });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,8 +29,9 @@ export const vitestBaseConfig = {
                 }
             ]
         },
+        // keep an explicit list of tests to run, so they can be commented in case of problems
         include: [
-            '**/client/test/fs/emptyEndpoint.test.ts',
+            '**/client/test/fs/endpoints/emptyEndpoint.test.ts',
             '**/client/test/tools/index.test.ts',
             '**/client/test/tools/utils.test.ts',
             '**/client/test/vscode/services.test.ts',
@@ -39,7 +40,9 @@ export const vitestBaseConfig = {
             '**/wrapper/test/languageClientWrapper.test.ts',
             '**/wrapper/test/utils.test.ts',
             '**/wrapper/test/wrapper.test.ts',
-            '**/wrapper-react/test/index.test.tsx'
+            '**/wrapper-react/test/index.test.tsx',
+            // '**/*.ts',
+            // '**/*.tsx'
         ],
         dangerouslyIgnoreUnhandledErrors: true
     }


### PR DESCRIPTION
I moved some tests around (wrong places) as well.
Fixing the wrapper handling in case of error introduced required changes to the react component and to several tests.

After thinking about #855