### PR TITLE
Fix typo in wrapper README

### DIFF
--- a/packages/wrapper/README.md
+++ b/packages/wrapper/README.md
@@ -55,7 +55,7 @@ import { MonacoEditorLanguageClientWrapper, WrapperConfig } from 'monaco-editor-
 const run = async () => {
   const wrapper = new MonacoEditorLanguageClientWrapper();
   const wrapperConfig: WrapperConfig = {
-    $type: 'extendend',
+    $type: 'extended',
     htmlContainer: document.getElementById('monaco-editor-root')!,
     editorAppConfig: {
       codeResources: {


### PR DESCRIPTION
Replace `extendend` with `extended` in example setup.