### PR TITLE
Fix configuration wrapper readme

### DIFF
--- a/packages/wrapper-react/README.md
+++ b/packages/wrapper-react/README.md
@@ -28,9 +28,9 @@ const wrapperConfig: WrapperConfig = {
   htmlContainer: document.getElementById('monaco-editor-root')!,
   editorAppConfig: {
     codeResources: {
-      main: {
-        text: 'print("Hello, World!")',
-        uri: '/workspace/hello.py'
+      modified: {
+              uri: '/workspace/hello.py',
+              text: 'print("Hello, World!")'
       }
     }
   }

--- a/packages/wrapper/README.md
+++ b/packages/wrapper/README.md
@@ -45,7 +45,7 @@ Monarch grammars and themes can only be used in **classic** mode and textmate gr
 
 ## Usage
 
-Monaco Editor with TypeScript language support in web worker and relying on classic mode:
+Monaco Editor with Python language support in web worker and relying on extended mode:
 
 ```ts
 import '@codingame/monaco-vscode-python-default-extension';
@@ -59,9 +59,9 @@ const run = async () => {
     htmlContainer: document.getElementById('monaco-editor-root')!,
     editorAppConfig: {
       codeResources: {
-        main: {
-          text: 'print("Hello, World!")',
-          uri: '/workspace/hello.py'
+        modified: {
+                uri: '/workspace/hello.py',
+                text: 'print("Hello, World!")'
         }
       }
     }

--- a/packages/wrapper/README.md
+++ b/packages/wrapper/README.md
@@ -55,7 +55,7 @@ import { MonacoEditorLanguageClientWrapper, WrapperConfig } from 'monaco-editor-
 const run = async () => {
   const wrapper = new MonacoEditorLanguageClientWrapper();
   const wrapperConfig: WrapperConfig = {
-    $type: 'extendend',
+    $type: 'extended',
     htmlContainer: document.getElementById('monaco-editor-root')!,
     editorAppConfig: {
       codeResources: {


### PR DESCRIPTION
Updates the example usage in the wrapper README:

- `modified` instead of `main`
- `python` instead of `TypeScript`
- `extended` instead of `classic`