### PR TITLE
implement async task queue to synchronize react wrapper initialization useEffect

### DIFF
--- a/packages/wrapper-react/src/index.tsx
+++ b/packages/wrapper-react/src/index.tsx
@@ -5,6 +5,7 @@
 
 import React, { type CSSProperties, useEffect, useRef } from 'react';
 import { MonacoEditorLanguageClientWrapper, type TextContents, type WrapperConfig } from 'monaco-editor-wrapper';
+import { TaskQueue } from './task-queue.js';
 
 export type MonacoEditorProps = {
     style?: CSSProperties;
@@ -27,6 +28,7 @@ export const MonacoEditorReactComp: React.FC<MonacoEditorProps> = (props) => {
 
     const wrapperRef = useRef<MonacoEditorLanguageClientWrapper>(new MonacoEditorLanguageClientWrapper());
     const containerRef = useRef<HTMLDivElement>(null);
+    const taskQueueRef = useRef(new TaskQueue(1));
 
     useEffect(() => {
         const destroyMonaco = async () => {
@@ -65,13 +67,13 @@ export const MonacoEditorReactComp: React.FC<MonacoEditorProps> = (props) => {
             }
         };
 
-        (async () => {
+        taskQueueRef.current.push((async () => {
             await initMonaco();
             await startMonaco();
-        })();
+        }));
 
         return () => {
-            destroyMonaco();
+            taskQueueRef.current.push(destroyMonaco);
         };
 
     }, [wrapperConfig]);

--- a/packages/wrapper-react/src/task-queue.ts
+++ b/packages/wrapper-react/src/task-queue.ts
@@ -1,0 +1,73 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2024 TypeFox and others.
+ * Licensed under the MIT License. See LICENSE in the package root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+type Task<T = unknown> = () => Promise<T> | T;
+type Resolve<T> = (value: T | PromiseLike<T>) => void;
+type Reject<T> = (reason?: T) => void;
+type TaskQueueItem<T = unknown> = {
+    task: Task<T>;
+    resolve: Resolve<T>;
+    reject: Reject<T>;
+};
+
+export class TaskQueue {
+    private queue: Array<TaskQueueItem<unknown>>;
+    private readonly concurrency: number;
+    private running: number;
+    constructor(concurrency: number = 1) {
+        this.queue = [];
+        this.concurrency = concurrency;
+        this.running = 0;
+    }
+
+    push<T>(task: Task<T>): Promise<T> {
+        return new Promise<T>((resolve, reject) => {
+            void (this.running < this.concurrency
+                ? this.runTask(task, resolve, reject)
+                : this.enqueueTask(task, resolve, reject));
+        });
+    }
+
+    private increment() {
+        this.running++;
+    }
+    private decrement() {
+        this.running--;
+    }
+
+    private async runTask<T>(
+        task: Task<T>,
+        resolve: Resolve<T>,
+        reject: Reject<T>
+    ) {
+        this.increment();
+        try {
+            const result = await task();
+            resolve(result);
+        } catch (e: unknown) {
+            reject(e as T);
+        } finally {
+            this.decrement();
+            if (this.queue.length > 0) {
+                const nextTask = this.queue.shift();
+                if (nextTask) {
+                    await this.runTask(
+                        nextTask.task,
+                        nextTask.resolve,
+                        nextTask.reject
+                    );
+                }
+            }
+        }
+    }
+
+    private enqueueTask<T>(
+        task: Task<T>,
+        resolve: Resolve<T>,
+        reject: Reject<T>
+    ) {
+        this.queue.push({ task, resolve, reject } as never);
+    }
+}

--- a/packages/wrapper-react/test/index.test.tsx
+++ b/packages/wrapper-react/test/index.test.tsx
@@ -6,7 +6,10 @@
 import { describe, expect, test } from 'vitest';
 import { render, type RenderResult } from '@testing-library/react';
 import React from 'react';
-import { MonacoEditorLanguageClientWrapper, type TextContents } from 'monaco-editor-wrapper';
+import {
+    MonacoEditorLanguageClientWrapper,
+    type TextContents,
+} from 'monaco-editor-wrapper';
 import { MonacoEditorReactComp } from '@typefox/monaco-editor-react';
 import { createDefaultWrapperConfig } from './helper.js';
 
@@ -30,7 +33,7 @@ describe('Test MonacoEditorReactComp', () => {
                 console.log('onLoad');
                 resolve();
             };
-            // render(<MonacoEditorReactComp wrapperConfig={wrapperConfig} onLoad={handleOnLoad} />);
+
             renderResult = render(<MonacoEditorReactComp wrapperConfig={wrapperConfig} onLoad={handleOnLoad} />);
         // void promise is undefined after it was awaited
         })).toBeUndefined();
@@ -73,5 +76,35 @@ describe('Test MonacoEditorReactComp', () => {
 
         };
         render(<MonacoEditorReactComp wrapperConfig={wrapperConfig} onLoad={handleOnLoad} onTextChanged={textReceiver} />);
+    });
+
+    test('should rerender without error', async () => {
+        const wrapperConfig = createDefaultWrapperConfig();
+
+        let renderResult: RenderResult;
+        expect(await new Promise<void>(resolve => {
+            const handleOnLoad = async (_wrapper: MonacoEditorLanguageClientWrapper) => {
+                renderResult.rerender(<MonacoEditorReactComp wrapperConfig={wrapperConfig} />);
+
+                resolve();
+            };
+
+            renderResult = render(<MonacoEditorReactComp wrapperConfig={wrapperConfig} onLoad={handleOnLoad} />);
+        // void promise is undefined after it was awaited
+        })).toBeUndefined();
+
+        expect(await new Promise<void>(resolve => {
+            const handleOnLoad = async (_wrapper: MonacoEditorLanguageClientWrapper) => {
+                renderResult.rerender(<MonacoEditorReactComp wrapperConfig={wrapperConfig} />);
+
+                resolve();
+            };
+            const newWrapperConfig = createDefaultWrapperConfig();
+
+            renderResult!.rerender(
+                <MonacoEditorReactComp wrapperConfig={newWrapperConfig} onLoad={handleOnLoad} />
+            );
+        // void promise is undefined after it was awaited
+        })).toBeUndefined();
     });
 });


### PR DESCRIPTION
Fixes #871 

This will ensure that dispose is not invoked before the editor is fully started. This will slow down initialisation in development mode, as the editor will be fully started, then destroyed and started again; however, in production, it should work the same as in the main (unless some unexpected re-renders occur on the client side).