### PR TITLE
fix: old monaco editor instance is not destroyed before a new one init

### DIFF
--- a/packages/wrapper-react/src/index.tsx
+++ b/packages/wrapper-react/src/index.tsx
@@ -66,15 +66,25 @@ export const MonacoEditorReactComp: React.FC<MonacoEditorProps> = (props) => {
         };
 
         (async () => {
-            await initMonaco();
-            await startMonaco();
+            if (wrapperRef.current.isStopping() === false) {
+                await destroyMonaco();
+                await initMonaco();
+                await startMonaco();
+            }
         })();
 
-        return () => {
-            destroyMonaco();
-        };
+    }, [wrapperConfig, onTextChanged, onLoad, onError]);
 
-    }, [wrapperConfig]);
+    useEffect(()=>{
+        return ()=>{
+            try {
+                wrapperRef.current.dispose();
+            } catch {
+                // The language client may throw an error during disposal.
+                // This should not prevent us from continue working.
+            }
+        };
+    },[]);
 
     return (
         <div


### PR DESCRIPTION
### Summary: This PR addresses an issue with the Monaco Editor React Component Wrapper where an old instance was not being properly destroyed before a new one was initialized.

### Changes Made:

Added a call to `destroyMonaco()` before initializing a new instance with `initMonaco()` and `await` it.

Added `if (wrapperRef.current.isStopping() === false)` to make sure the editor is not stopping to prevent double editors in react strict mode because in strict mode react will execute `useEffect` hooks twice

This ensures that the previous instance is completely disposed of before starting a new one, improving performance and stability.

Removed the cleanup function from the main `useEffect` because it runs each time the wrapper config changes

Added a new `useEffect` with an empty dependencies array and a cleanup function to make sure that the Monaco instance is disposed before the component unmounts