### PR TITLE
Update monaco-editor-react README for WorkFactory Usage

### DIFF
--- a/packages/wrapper-react/README.md
+++ b/packages/wrapper-react/README.md
@@ -22,6 +22,7 @@ import ReactDOM from 'react-dom/client';
 import '@codingame/monaco-vscode-python-default-extension';
 import { WrapperConfig } from 'monaco-editor-wrapper';
 import { MonacoEditorReactComp } from '@typefox/monaco-editor-react';
+import { configureDefaultWorkerFactory } from 'monaco-editor-wrapper/workers/workerLoaders';
 
 const wrapperConfig: WrapperConfig = {
   $type: 'extended',
@@ -32,7 +33,8 @@ const wrapperConfig: WrapperConfig = {
               uri: '/workspace/hello.py',
               text: 'print("Hello, World!")'
       }
-    }
+    },
+    monacoWorkerFactory: configureDefaultWorkerFactory
   }
 };
 

--- a/packages/wrapper/README.md
+++ b/packages/wrapper/README.md
@@ -50,6 +50,7 @@ Monaco Editor with Python language support in web worker and relying on extended
 ```ts
 import '@codingame/monaco-vscode-python-default-extension';
 import { MonacoEditorLanguageClientWrapper, WrapperConfig } from 'monaco-editor-wrapper';
+import { configureDefaultWorkerFactory } from 'monaco-editor-wrapper/workers/workerLoaders';
 
 // no top-level await
 const run = async () => {
@@ -63,7 +64,8 @@ const run = async () => {
                 uri: '/workspace/hello.py',
                 text: 'print("Hello, World!")'
         }
-      }
+      },
+      monacoWorkerFactory: configureDefaultWorkerFactory
     }
   };
 


### PR DESCRIPTION
Related to #913 , adds associated usage & import to setup the monacoWorkerFactory w/ the default work factory.