### PR TITLE
Fix data URL crash for Unicode characters

### DIFF
--- a/packages/wrapper/src/editorApp.ts
+++ b/packages/wrapper/src/editorApp.ts
@@ -279,7 +279,14 @@ export class EditorApp {
 }
 
 export const verifyUrlOrCreateDataUrl = (input: string | URL) => {
-    return (input instanceof URL) ? input.href : new URL(`data:text/plain;base64,${btoa(input)}`).href;
+    if (input instanceof URL) {
+        return input.href;
+    } else {
+        const bytes = new TextEncoder().encode(input);
+        const binString = Array.from(bytes, (b) => String.fromCodePoint(b)).join('');
+        const base64 = btoa(binString);
+        return new URL(`data:text/plain;base64,${base64}`).href;
+    }
 };
 
 export const didModelContentChange = (textModels: TextModels, onTextChanged?: (textChanges: TextContents) => void) => {

--- a/packages/wrapper/test/editorApp.test.ts
+++ b/packages/wrapper/test/editorApp.test.ts
@@ -22,7 +22,10 @@ describe('Test EditorApp', () => {
     test('verifyUrlorCreateDataUrl: url', async () => {
         const url = new URL('../../../node_modules/langium-statemachine-dsl/syntaxes/statemachine.tmLanguage.json', window.location.href);
         const text = await (await fetch(url)).text();
-        expect(verifyUrlOrCreateDataUrl(text)).toBe(`data:text/plain;base64,${btoa(text)}`);
+        const bytes = new TextEncoder().encode(text);
+        const binString = Array.from(bytes, (b) => String.fromCodePoint(b)).join('');
+        const base64 = btoa(binString);
+        expect(verifyUrlOrCreateDataUrl(text)).toBe(`data:text/plain;base64,${base64}`);
     });
 
     test('config defaults', () => {

--- a/packages/wrapper/test/editorApp.test.ts
+++ b/packages/wrapper/test/editorApp.test.ts
@@ -28,6 +28,14 @@ describe('Test EditorApp', () => {
         expect(verifyUrlOrCreateDataUrl(text)).toBe(`data:text/plain;base64,${base64}`);
     });
 
+    test('verifyUrlorCreateDataUrl: url', () => {
+        const text = '✓✓';
+        const bytes = new TextEncoder().encode(text);
+        const binString = Array.from(bytes, (b) => String.fromCodePoint(b)).join('');
+        const base64 = btoa(binString);
+        expect(verifyUrlOrCreateDataUrl(text)).toBe(`data:text/plain;base64,${base64}`);
+    });
+
     test('config defaults', () => {
         const wrapperConfig = createWrapperConfigExtendedApp();
         const app = new EditorApp(wrapperConfig.$type, wrapperConfig.editorAppConfig);


### PR DESCRIPTION
Fixes `DOMException: String contains an invalid character` in `verifyUrlOrCreateDataUrl` when a data url is created of a string that contains a Unicode character larger than one byte.

See https://developer.mozilla.org/en-US/docs/Web/API/Window/btoa#unicode_strings for a detailed explanation.

I had a special Unicode character in my language configuration which caused this error. Looks like the receiving side can deal with the UTF8 encoded string as it works as expected for me now.