### PR TITLE
Use public exports from vscode-jsonrpc instead of deep internal imports

### DIFF
--- a/packages/vscode-ws-jsonrpc/src/socket/reader.ts
+++ b/packages/vscode-ws-jsonrpc/src/socket/reader.ts
@@ -4,6 +4,8 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { Disposable } from 'vscode-jsonrpc';
+// TODO: Use environment-specific imports (vscode-jsonrpc/browser or vscode-jsonrpc/node)
+// when upgrading to vscode-jsonrpc@9.x.x-next.X which supports proper export maps
 import { type DataCallback, AbstractMessageReader, MessageReader } from 'vscode-jsonrpc';
 import type { IWebSocket } from './socket.js';
 

--- a/packages/vscode-ws-jsonrpc/src/socket/reader.ts
+++ b/packages/vscode-ws-jsonrpc/src/socket/reader.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { Disposable } from 'vscode-jsonrpc';
-import { type DataCallback, AbstractMessageReader, MessageReader } from 'vscode-jsonrpc/lib/common/messageReader.js';
+import { type DataCallback, AbstractMessageReader, MessageReader } from 'vscode-jsonrpc';
 import type { IWebSocket } from './socket.js';
 
 export class WebSocketMessageReader extends AbstractMessageReader implements MessageReader {

--- a/packages/vscode-ws-jsonrpc/src/socket/writer.ts
+++ b/packages/vscode-ws-jsonrpc/src/socket/writer.ts
@@ -3,8 +3,8 @@
  * Licensed under the MIT License. See LICENSE in the package root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import { Message } from 'vscode-jsonrpc/lib/common/messages.js';
-import { AbstractMessageWriter, MessageWriter } from 'vscode-jsonrpc/lib/common/messageWriter.js';
+import { Message } from 'vscode-jsonrpc';
+import { AbstractMessageWriter, MessageWriter } from 'vscode-jsonrpc';
 import type { IWebSocket } from './socket.js';
 
 export class WebSocketMessageWriter extends AbstractMessageWriter implements MessageWriter {

--- a/packages/vscode-ws-jsonrpc/tsconfig.src.json
+++ b/packages/vscode-ws-jsonrpc/tsconfig.src.json
@@ -3,10 +3,13 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "lib",
+    "declaration": true,
     "declarationDir": "lib",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
   },
-  "include": [
-    "src/**/*.ts",
-  ]
+  "include": ["src/**/*.ts"]
 }

--- a/packages/vscode-ws-jsonrpc/tsconfig.src.json
+++ b/packages/vscode-ws-jsonrpc/tsconfig.src.json
@@ -3,13 +3,10 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "lib",
-    "declaration": true,
     "declarationDir": "lib",
-    "skipLibCheck": true,
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext",
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true
+    "skipLibCheck": true
   },
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts",
+  ]
 }

--- a/verify/next/package-lock.json
+++ b/verify/next/package-lock.json
@@ -5,8 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "@typefox/monaco-editor-react": "~6.6.0",
-        "monaco-languageclient-examples": "~2025.3.6",
+        "@typefox/monaco-editor-react": "~6.9.0",
+        "monaco-languageclient-examples": "~2025.6.2",
         "next": "~15.2.2",
         "react": "~19.0.0",
         "react-dom": "~19.0.0"
@@ -58,1888 +58,2139 @@
       "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
       "license": "Apache-2.0"
     },
-    "node_modules/@codingame/monaco-vscode-039b5553-0838-562a-97c2-30d6e54a7b42-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-039b5553-0838-562a-97c2-30d6e54a7b42-common/-/monaco-vscode-039b5553-0838-562a-97c2-30d6e54a7b42-common-15.0.2.tgz",
-      "integrity": "sha512-R4UijfvKYNS6QvjALl7MdSmYAD43C4zCIzR+BxduCCnpOiajpP6zGbJCtXENJQTEW5omKBPRxZlNWHO1i/cymg==",
-      "license": "MIT"
-    },
-    "node_modules/@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common/-/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common-15.0.2.tgz",
-      "integrity": "sha512-Gh4IS1cpzu98ifRU2sMPZgoOXlp6YuS4tZZBU4rygcnCiJVlzSg1IGF3/qWvGsYb4XdCiF/88qP++hEuOBVftg==",
+    "node_modules/@codingame/monaco-vscode-0094ae09-a688-53e7-bacc-93e26f7f49db-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-0094ae09-a688-53e7-bacc-93e26f7f49db-common/-/monaco-vscode-0094ae09-a688-53e7-bacc-93e26f7f49db-common-18.1.3.tgz",
+      "integrity": "sha512-HJvIQWbe7SOCypt6sgWqmeKeCcQ6S6vDwSwLn4yEjAb6hosfFj6pxXi5oRR9BOyp5JTvadzw/xtkj4/t0BC+Hw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-1bb39316-6fbf-572e-ab6a-818a2496c14f-common": "15.0.2",
-        "@codingame/monaco-vscode-7bbc9e7d-eeae-55fc-8bf9-dc2f66e0dc73-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-07eaa805-9dea-5ec6-a422-a4f04872424d-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-07eaa805-9dea-5ec6-a422-a4f04872424d-common/-/monaco-vscode-07eaa805-9dea-5ec6-a422-a4f04872424d-common-18.1.3.tgz",
+      "integrity": "sha512-F7Ha6vxDJpVgWR6xZIghVTeQmemPlcM8TW7zpio4GgpZa8VAuZXUELcQH8Eh54E9dVGUNsllNpYIITfdj/fvdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-6c0f93b9-169c-58c3-a9cb-7d60698eb52c-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-c465110a-57c0-59d7-a6b2-be0a4db7e517-common": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common/-/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common-18.1.3.tgz",
+      "integrity": "sha512-GHOb3InFWTFpVAzd+O73giA2Ru6xciTmkuNYbLl776jgqMmzlHuTNtWEXURzjDDsfKQVbGm0nTqe4Je7v9E7kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-7bbc9e7d-eeae-55fc-8bf9-dc2f66e0dc73-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-0c06bfba-d24d-5c4d-90cd-b40cefb7f811-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-0c06bfba-d24d-5c4d-90cd-b40cefb7f811-common/-/monaco-vscode-0c06bfba-d24d-5c4d-90cd-b40cefb7f811-common-15.0.2.tgz",
-      "integrity": "sha512-xKAMWUmNibtc0Ae2Js0045JmamqpecGxGQOJzxz6fdwDocEb7vhjoaRnDINeoGvtd7kiXXCCUiE2WRhpiSRG4A==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-0c06bfba-d24d-5c4d-90cd-b40cefb7f811-common/-/monaco-vscode-0c06bfba-d24d-5c4d-90cd-b40cefb7f811-common-18.1.3.tgz",
+      "integrity": "sha512-P7deCRc6kwox2xs/7ktxfOw/9JD5lWKINaA6ISiiLdIsMf44NaBvjXunWBM7Z8pd3SFrrAyxqKBWlNu1hmjI3A==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-2e67e044-0db9-5fa6-8bd1-3737a7d586d4-common": "15.0.2",
-        "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "15.0.2",
-        "@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-a4683c2b-a0d2-5112-96ba-eedc605346d2-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common/-/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common-15.0.2.tgz",
-      "integrity": "sha512-AAdh+y22C36NUNOyU5bRP2iNEzyGE6HXOy/5fuiCpFerV/rwMFtr0yeAq9haCPdFaYNspnkt3Fj8zSZzr+bU/w==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common/-/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common-18.1.3.tgz",
+      "integrity": "sha512-/a8uYSyiFLwmTKva6/JA1tEyacxldULl0e+XLEiMprec34+V6JlQxJ+pOfqk0O1jU2G+FJIomBiLdsDrdRZlhw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-d8236b3b-b91a-522d-89f4-94d70a546f6a-common": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-f22e7e55-aee8-5b52-a6bc-950efd9f5890-common": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-0f5ced28-abde-558b-8652-db8e7d4d64aa-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-0f5ced28-abde-558b-8652-db8e7d4d64aa-common/-/monaco-vscode-0f5ced28-abde-558b-8652-db8e7d4d64aa-common-15.0.2.tgz",
-      "integrity": "sha512-rK/EYD70iQ6XF4Lx7P4FSIbAe1X6BVFFu85mZSrJnWJdWlHZ8XU3HkxnY0dSZJc+4bBh3EvvbYVkoISSDjcuAg==",
+    "node_modules/@codingame/monaco-vscode-0cd5242b-7b61-5f66-ac25-ffa40baf8e8f-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-0cd5242b-7b61-5f66-ac25-ffa40baf8e8f-common/-/monaco-vscode-0cd5242b-7b61-5f66-ac25-ffa40baf8e8f-common-18.1.3.tgz",
+      "integrity": "sha512-zqw3Eaq7K6v8tNVfgMU30WJEIJULVt5OcKjplwvmy47AAwfL8daPZnDX/pKgrfOl4nJj2Zd9hEUsl2q9M70wBA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-1021b67c-93e5-5c78-a270-cbdb2574d980-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-1021b67c-93e5-5c78-a270-cbdb2574d980-common/-/monaco-vscode-1021b67c-93e5-5c78-a270-cbdb2574d980-common-15.0.2.tgz",
-      "integrity": "sha512-u9dGcfjGCSPE2zy4k1LqstH/oydUBJ5o91K/OewJkMVj27JFlP1p5ynWrGQgLvLEEjcRXOaI8r43qAu6lZOK1w==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-1021b67c-93e5-5c78-a270-cbdb2574d980-common/-/monaco-vscode-1021b67c-93e5-5c78-a270-cbdb2574d980-common-18.1.3.tgz",
+      "integrity": "sha512-83eK4k7F64+ZURZv0rsBbARZa3nSs5UHvwlo7G+087EBAKZRgvSgvBTLFC5CT0fN4bpxW93QTR819pHDRREP1Q==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
-      }
-    },
-    "node_modules/@codingame/monaco-vscode-10418ae3-ee63-5700-a757-89cbe6564ee4-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-10418ae3-ee63-5700-a757-89cbe6564ee4-common/-/monaco-vscode-10418ae3-ee63-5700-a757-89cbe6564ee4-common-15.0.2.tgz",
-      "integrity": "sha512-ID0M2FbCsFdu3bR2id/GC8LxWR6gR0KDTFB9rMkmI/yNboGgO71G46R9LWnQ5iaw0MLS99zcTRn165hN5YT/gg==",
-      "license": "MIT",
-      "dependencies": {
-        "@codingame/monaco-vscode-1bb39316-6fbf-572e-ab6a-818a2496c14f-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
-      }
-    },
-    "node_modules/@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common/-/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common-15.0.2.tgz",
-      "integrity": "sha512-XBECAkPyaHKfIoNAPH6HHKRGZ9Rl8j/k+gxbsr3vYeAEEWUkEXCKgzA3mnQuqOA8krsU7vFwsjN/ywQU3LkbPA==",
-      "license": "MIT",
-      "dependencies": {
-        "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-fdf643f9-94dd-5510-b97a-408abf26ad92-common": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-15626ec7-b165-51e1-8caf-7bcc2ae9b95a-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-15626ec7-b165-51e1-8caf-7bcc2ae9b95a-common/-/monaco-vscode-15626ec7-b165-51e1-8caf-7bcc2ae9b95a-common-15.0.2.tgz",
-      "integrity": "sha512-nfjgdgxGKjn9HfMUPa8lA/yNMwj9DoqeATBW8r+Ew8MBJTDJguXfehBXX8ul3x8I7QknwKwPnHx+yT2jvUiGsQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-15626ec7-b165-51e1-8caf-7bcc2ae9b95a-common/-/monaco-vscode-15626ec7-b165-51e1-8caf-7bcc2ae9b95a-common-18.1.3.tgz",
+      "integrity": "sha512-CblbOEgtnQSeeQoecVTV3vYL3yKE01ag2k3EeegzyiVh+KXiuPV0OHPl85GTDHjghD4FRoSGPr2j0U93UnIcyA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-2e67e044-0db9-5fa6-8bd1-3737a7d586d4-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-168b98e5-dc20-5807-b1f9-798f1f92b37f-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-168b98e5-dc20-5807-b1f9-798f1f92b37f-common/-/monaco-vscode-168b98e5-dc20-5807-b1f9-798f1f92b37f-common-15.0.2.tgz",
-      "integrity": "sha512-8eQ+qKVfgh9cojK+fsRrSRFLFHjfV4rwNPhAYp6fyB5JFJUdTyp8SDO2NJHcTJOsTIJDW3J+xRFgrcMEwB/N/g==",
+    "node_modules/@codingame/monaco-vscode-158b9837-fc78-5d9c-86f5-9134e4358643-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-158b9837-fc78-5d9c-86f5-9134e4358643-common/-/monaco-vscode-158b9837-fc78-5d9c-86f5-9134e4358643-common-18.1.3.tgz",
+      "integrity": "sha512-LuPoeUq7u8xaSJeHKA55KirzCZbiLAUzYHD3Lu1ZbIUsEPuoVgE6jIKpPDAapGzsjz8yFI86CzW9sFi0hL42fQ==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-1bb39316-6fbf-572e-ab6a-818a2496c14f-common": "15.0.2",
-        "@codingame/monaco-vscode-2e69e120-617a-5258-95e0-3b8902f4e014-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
-      }
-    },
-    "node_modules/@codingame/monaco-vscode-1ae7d696-d960-5ac6-97a3-9fe7c8c3a793-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-1ae7d696-d960-5ac6-97a3-9fe7c8c3a793-common/-/monaco-vscode-1ae7d696-d960-5ac6-97a3-9fe7c8c3a793-common-15.0.2.tgz",
-      "integrity": "sha512-W3m13XvLSTXH/o1Dm0o552QFZ92u4NtcGX8rFoATecUkLQPxnBKtUxqlhBMVXp/eBjzNPDLBIvfG9azu4dq35w==",
-      "license": "MIT",
-      "dependencies": {
-        "@codingame/monaco-vscode-52bb4d5b-ba1a-57fd-9bee-b28824214eac-common": "15.0.2",
-        "@codingame/monaco-vscode-7ba0af96-90c2-5e11-ad7f-befdbbf246c8-common": "15.0.2",
-        "@codingame/monaco-vscode-9a6d8b6c-ad4c-5ea3-9558-f43d6dc4c0ad-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-1b4486de-4fe4-59c4-9e6d-34f265ff6625-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-1b4486de-4fe4-59c4-9e6d-34f265ff6625-common/-/monaco-vscode-1b4486de-4fe4-59c4-9e6d-34f265ff6625-common-15.0.2.tgz",
-      "integrity": "sha512-cZAfrwox+dWL0cs2W+V9i0q/96ZmhsqT0LdBNEyj3NGE/DTdhlQEC3hF3P9s/LFRwgKsECUfWCAnlhnUI2bfRw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-1b4486de-4fe4-59c4-9e6d-34f265ff6625-common/-/monaco-vscode-1b4486de-4fe4-59c4-9e6d-34f265ff6625-common-18.1.3.tgz",
+      "integrity": "sha512-v8ZPShK8Ie6k499K43A7KiQNrKTMvfXAca93xye7dxc7q0LLl3NCIckSb0sbCpSFXK4FKRAwvmgQ4QiofyuY/Q==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-422642f2-7e3a-5c1c-9e1e-1d3ef1817346-common": "15.0.2",
-        "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "15.0.2",
-        "@codingame/monaco-vscode-9a1a5840-af83-5d07-a156-ba32a36c5c4b-common": "15.0.2",
-        "@codingame/monaco-vscode-a7c9ae3c-16d2-5d17-86b2-981be7094566-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-bd6ad8b7-9db3-51a8-9895-0046508c029d-common": "15.0.2"
+        "@codingame/monaco-vscode-2a94c04a-b85b-5669-b06b-89c1bfa11cb9-common": "18.1.3",
+        "@codingame/monaco-vscode-422642f2-7e3a-5c1c-9e1e-1d3ef1817346-common": "18.1.3",
+        "@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": "18.1.3",
+        "@codingame/monaco-vscode-937ecbdf-94c7-5b16-aefa-ad78ae557a93-common": "18.1.3",
+        "@codingame/monaco-vscode-9a1a5840-af83-5d07-a156-ba32a36c5c4b-common": "18.1.3",
+        "@codingame/monaco-vscode-a8d3bd74-e63e-5327-96e8-4f931661e329-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-1bb39316-6fbf-572e-ab6a-818a2496c14f-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-1bb39316-6fbf-572e-ab6a-818a2496c14f-common/-/monaco-vscode-1bb39316-6fbf-572e-ab6a-818a2496c14f-common-15.0.2.tgz",
-      "integrity": "sha512-WCcpvOSAmPT/nDilAsqYx6U+x1Yj48YZQ+gB+XQ5WJFW1QIl2HZkkTk2vLXCva6T5ESAsfMGGivDKAcPBs/yCw==",
+    "node_modules/@codingame/monaco-vscode-1ba786a5-b7d7-5d26-8a85-ae48ee2a74a4-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-1ba786a5-b7d7-5d26-8a85-ae48ee2a74a4-common/-/monaco-vscode-1ba786a5-b7d7-5d26-8a85-ae48ee2a74a4-common-18.1.3.tgz",
+      "integrity": "sha512-6CtI8Y2PpqQpOnY9C9HVxCpsj9KmWar96dD8Fnr3zGXaeyiAMAPad2NSC8grOZ+ISkt/OgRW73OQlZJSLxd3Hg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-93784a59-b4cf-520c-8339-f8104d3a4f3e-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-1cb11a73-359e-5a2f-9e95-6989cc9858ee-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-1cb11a73-359e-5a2f-9e95-6989cc9858ee-common/-/monaco-vscode-1cb11a73-359e-5a2f-9e95-6989cc9858ee-common-18.1.3.tgz",
+      "integrity": "sha512-QC6s1KtwSlFTOCYkgMhau3bFL/0mmjWTHyyH7s888ehVxTjQ4tZEejN8ibkDsYfcwor+vEdpnAoDOJiCWIM8pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-4372ad43-a220-5e78-83e6-95a9cfd64384-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-c87fff3a-2aa9-52ab-ba4d-17e8d1e5e185-common": "18.1.3",
+        "@codingame/monaco-vscode-f5d4b045-44e8-55a8-b683-308656a412fa-common": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-1cc4ea0a-c5b6-54ed-bb60-078a99119b55-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-1cc4ea0a-c5b6-54ed-bb60-078a99119b55-common/-/monaco-vscode-1cc4ea0a-c5b6-54ed-bb60-078a99119b55-common-18.1.3.tgz",
+      "integrity": "sha512-/PaKLciS5XeyJ+RnSXRtpSm4nvZvBW9ItY5PZ4UIy06VGPY4lqVdR0a0goIv1njgygjAPKm3w2BIQTOF4HzREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-210e86a9-a91b-5273-b05d-390c776dde1f-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-210e86a9-a91b-5273-b05d-390c776dde1f-common/-/monaco-vscode-210e86a9-a91b-5273-b05d-390c776dde1f-common-15.0.2.tgz",
-      "integrity": "sha512-RXlx72SlAe7mI/8g5J5zgAARFzL5fCtlBo1suCEmiM5f9S4Zn+HVcEjkkchduq+0JNS5WVO5oH+24NQ/t/Lz7Q==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-210e86a9-a91b-5273-b05d-390c776dde1f-common/-/monaco-vscode-210e86a9-a91b-5273-b05d-390c776dde1f-common-18.1.3.tgz",
+      "integrity": "sha512-Kbot4Rb19wBW2mLks2GbNerHG1VPtsGZaZJIeUm++EW4BQEQ1M7EiAPZ6eoOaW6NvNl2ZK5j4ioOc5mr+xeXVw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-249dc928-1da3-51c1-82d0-45e0ba9d08a1-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-249dc928-1da3-51c1-82d0-45e0ba9d08a1-common/-/monaco-vscode-249dc928-1da3-51c1-82d0-45e0ba9d08a1-common-18.1.3.tgz",
+      "integrity": "sha512-6FguOn0F88gO6UDcZqlBG6jsJAHXFRUKf0aJGngUJVT08YkTKh8ycAPlntU3zBKaG80k7mM/OvNJzgXO5Y7kKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-256d5b78-0649-50e9-8354-2807f95f68f4-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-256d5b78-0649-50e9-8354-2807f95f68f4-common/-/monaco-vscode-256d5b78-0649-50e9-8354-2807f95f68f4-common-15.0.2.tgz",
-      "integrity": "sha512-JV1rxYGOSsv2Hps1XpdeobUmI0wt4xcOKT0qFY1pzSt4PrJAwC6g1g+AU5W4Kh+Ya1CjqBJKkXxJ9Je/gecpOA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-256d5b78-0649-50e9-8354-2807f95f68f4-common/-/monaco-vscode-256d5b78-0649-50e9-8354-2807f95f68f4-common-18.1.3.tgz",
+      "integrity": "sha512-NhM1Z0oeyLylu8qT4vZhDlOEYt6mRdr/s3UKYRW5VSFF8yyCFwZumVNxloGuTVInWLkG5mvWHA53BrfvDDxjIQ==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
-      }
-    },
-    "node_modules/@codingame/monaco-vscode-29bc1406-2925-5b8f-b25e-d04a7772d896-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-29bc1406-2925-5b8f-b25e-d04a7772d896-common/-/monaco-vscode-29bc1406-2925-5b8f-b25e-d04a7772d896-common-15.0.2.tgz",
-      "integrity": "sha512-LnXzby9mbOgtn239CdyAgRoPJFqhEBujyX7tUb+1QxfQGBZXrnbPAoXtDkIJhx76rjWHnGR7fRBArgBa4SRt2A==",
-      "license": "MIT",
-      "dependencies": {
-        "@codingame/monaco-vscode-210e86a9-a91b-5273-b05d-390c776dde1f-common": "15.0.2",
-        "@codingame/monaco-vscode-9a6d8b6c-ad4c-5ea3-9558-f43d6dc4c0ad-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-c4e2825a-b5b1-5f0e-b547-068c32e06d50-common": "15.0.2"
+        "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-2a22c7b4-b906-5914-8cd1-3ed912fb738f-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-2a22c7b4-b906-5914-8cd1-3ed912fb738f-common/-/monaco-vscode-2a22c7b4-b906-5914-8cd1-3ed912fb738f-common-15.0.2.tgz",
-      "integrity": "sha512-FKtBIj8IeTBIb/pvFEFJxrMFltP/7ZUyOmkrbCvhoa3+0KVYrNhlL3vnldi+WOSTlRBWC7KHXXehtZ6oRB7ERA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-2a22c7b4-b906-5914-8cd1-3ed912fb738f-common/-/monaco-vscode-2a22c7b4-b906-5914-8cd1-3ed912fb738f-common-18.1.3.tgz",
+      "integrity": "sha512-nV0IIt4PaVXEe+dX3YP94C2bRAeXz9MMsad7Q8+amNXz+mV2JM5gFtF89Q012NvRq8DaqiHi5Ttkj+VCUDqwug==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-2e67e044-0db9-5fa6-8bd1-3737a7d586d4-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-2e67e044-0db9-5fa6-8bd1-3737a7d586d4-common/-/monaco-vscode-2e67e044-0db9-5fa6-8bd1-3737a7d586d4-common-15.0.2.tgz",
-      "integrity": "sha512-tM5GUYVKrgoqeY1eJ5yXxYPybiDwKWBzRZoOcrJcmlrUWXz8h3AoWRJ4Udt7FO2CjOCcyX0QzpWWypLhzEchAw==",
+    "node_modules/@codingame/monaco-vscode-2a94c04a-b85b-5669-b06b-89c1bfa11cb9-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-2a94c04a-b85b-5669-b06b-89c1bfa11cb9-common/-/monaco-vscode-2a94c04a-b85b-5669-b06b-89c1bfa11cb9-common-18.1.3.tgz",
+      "integrity": "sha512-QnIntEFOqNn4tttiUwfcZgzz+hfEB2tvUd0P1NRAeBD16riXaaVzkN1s7gxBxv3cFL4mrq7Xd1h8BAPElAXcFQ==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@vscode/iconv-lite-umd": "0.7.0",
-        "jschardet": "3.1.4"
-      }
-    },
-    "node_modules/@codingame/monaco-vscode-2e69e120-617a-5258-95e0-3b8902f4e014-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-2e69e120-617a-5258-95e0-3b8902f4e014-common/-/monaco-vscode-2e69e120-617a-5258-95e0-3b8902f4e014-common-15.0.2.tgz",
-      "integrity": "sha512-tljZkApxt/PCWFSWIZ1wfilXi/Du1PxQXkvZGRZSLkEaNyJQ3XEfJtjelebpXW7ZRnYmyLWfMC+eP4UwVcqAiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-38f25ab8-ea30-5ba9-8a08-ae3308c297c0-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-fdf643f9-94dd-5510-b97a-408abf26ad92-common": "15.0.2"
+        "@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common": "18.1.3",
+        "@codingame/monaco-vscode-4a3ac544-9a61-534c-88df-756262793ef7-common": "18.1.3",
+        "@codingame/monaco-vscode-a8d3bd74-e63e-5327-96e8-4f931661e329-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-2f06fe84-148e-5e6b-a7ca-c7989c5f128a-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-2f06fe84-148e-5e6b-a7ca-c7989c5f128a-common/-/monaco-vscode-2f06fe84-148e-5e6b-a7ca-c7989c5f128a-common-15.0.2.tgz",
-      "integrity": "sha512-kE0eB/sKEPljMj7LmbeQSs4NG0jxzmQ/luFWMEErnw7GqiyfTp8wl2XrPerLoQ51k2y496WzcO+KRAy+hUQm5w==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-2f06fe84-148e-5e6b-a7ca-c7989c5f128a-common/-/monaco-vscode-2f06fe84-148e-5e6b-a7ca-c7989c5f128a-common-18.1.3.tgz",
+      "integrity": "sha512-6/e71/feyFf0gEm6R07hzc7JepOQeAMRSe/KhqJCQEZ3hHXGr0+CaKLLWQtGUnDD/KNm0WwKFeQFpPWcnK0dhg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-3109a756-1f83-5d09-945b-9f0fcad928f0-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-3109a756-1f83-5d09-945b-9f0fcad928f0-common/-/monaco-vscode-3109a756-1f83-5d09-945b-9f0fcad928f0-common-18.1.3.tgz",
+      "integrity": "sha512-Q/pOirRWinAoorDD3616rvyrMV/IkjkvDPsaNjQR0tjcPO2llIqObA8gVtN2coDjfLqHASYU+eptwOqeoAonJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-95ea5c7c-15cf-50aa-8e24-38039b06b4a6-common": "18.1.3",
+        "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-b1e8558d-1726-5299-bc75-e43ee6d1a124-common": "18.1.3",
+        "@codingame/monaco-vscode-f5d4b045-44e8-55a8-b683-308656a412fa-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-33833ac7-3af3-5e9d-8fb9-11838d852c59-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-33833ac7-3af3-5e9d-8fb9-11838d852c59-common/-/monaco-vscode-33833ac7-3af3-5e9d-8fb9-11838d852c59-common-15.0.2.tgz",
-      "integrity": "sha512-GPgJ0/gt1EV8OXpFKGD/DozVfQS/2nCJA9Q1f1fzM7Dr6Dv4anZaSvHGtd0nscVu3baEz73tGfBP8fOcn+Qtfw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-33833ac7-3af3-5e9d-8fb9-11838d852c59-common/-/monaco-vscode-33833ac7-3af3-5e9d-8fb9-11838d852c59-common-18.1.3.tgz",
+      "integrity": "sha512-MTrVphdn4Xc3ZtOFe8SsKE5Xfh7ClcwIHf+GdXrT1wwlA3yozjNJJ+hsWUG59mH56hsXLeHOPE+gs1VbHENTow==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-3607c442-ae7a-594b-b840-038378c24fef-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-3607c442-ae7a-594b-b840-038378c24fef-common/-/monaco-vscode-3607c442-ae7a-594b-b840-038378c24fef-common-15.0.2.tgz",
-      "integrity": "sha512-1PgXgl0LdCWM/mqOR7A9slWuTQpf7y9kivSxBIu6c0bJy3LxJeegNZ2EMZUenqR0imDRQTOh99FMY3L/M++65g==",
+    "node_modules/@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common/-/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common-18.1.3.tgz",
+      "integrity": "sha512-inHcfBzEaOw7SAFXxwNIxeh2D61Aa2xZknnMBD6JTAnt0qRmrSoNPR6Tu4e6GeLyoxx5ligvqg2SZhZOSOwrpg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-38f25ab8-ea30-5ba9-8a08-ae3308c297c0-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-38f25ab8-ea30-5ba9-8a08-ae3308c297c0-common/-/monaco-vscode-38f25ab8-ea30-5ba9-8a08-ae3308c297c0-common-15.0.2.tgz",
-      "integrity": "sha512-j2l3zM65AsJFIsTyOxzAX1XY20IOPsWGHLRUmoem9eDnaPhwfhHQ7ia/j6UQMveBH8xEOm4IIovedFhAIaGI+Q==",
+    "node_modules/@codingame/monaco-vscode-3a35f433-1297-5707-ab58-c261b8180e6d-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-3a35f433-1297-5707-ab58-c261b8180e6d-common/-/monaco-vscode-3a35f433-1297-5707-ab58-c261b8180e6d-common-18.1.3.tgz",
+      "integrity": "sha512-F+n2jH08UEFVf8ZQEH9xiZroOlO8mvOEaBmTfZkAVW499Yq8ooBVZxVKXio4y9cp/ebdvywcJPsllVWdF8m8+Q==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-fdf643f9-94dd-5510-b97a-408abf26ad92-common": "15.0.2"
+        "@codingame/monaco-vscode-69cd7d65-4465-53e8-9718-bc4f6df50f7d-common": "18.1.3",
+        "@codingame/monaco-vscode-7adbeffb-8051-54a9-8c9b-b62ce9e5836f-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common": "18.1.3",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-3cf6a388-482f-5484-a806-0525ad9ad8af-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-3cf6a388-482f-5484-a806-0525ad9ad8af-common/-/monaco-vscode-3cf6a388-482f-5484-a806-0525ad9ad8af-common-18.1.3.tgz",
+      "integrity": "sha512-D2dv5d1kkdzg23YSxm0Ml/tkWBh6Wu9eWK7ZydqLPC7NvZzHEFL819a5yRWEO1vtH3/M63rb11XLv5g0dGavJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-a4683c2b-a0d2-5112-96ba-eedc605346d2-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-c3c61c00-c254-5856-9dc9-d7929c1f9062-common": "18.1.3",
+        "@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common": "18.1.3",
+        "@codingame/monaco-vscode-f48982c4-9e82-55e2-b800-20e6d1e6096f-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-40cada32-7e9c-528a-81fc-766e4da54147-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-40cada32-7e9c-528a-81fc-766e4da54147-common/-/monaco-vscode-40cada32-7e9c-528a-81fc-766e4da54147-common-15.0.2.tgz",
-      "integrity": "sha512-6QMu8OiCoucyKCVNwue53TYGJsTpB+0lOe3W1CRON4rJyoP+jZVkU3i7Qj5q9OxpNY4cOiFT13sa60lWjyLtjQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-40cada32-7e9c-528a-81fc-766e4da54147-common/-/monaco-vscode-40cada32-7e9c-528a-81fc-766e4da54147-common-18.1.3.tgz",
+      "integrity": "sha512-v/I+LwzCtYbJiWhYRswpKoSt79RgD710X4H5Q7YgBK3xsisq3hmvdy5CdBXjcOMOU4gMnVUeeVD3P+i+Hva+JA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common": "15.0.2",
-        "@codingame/monaco-vscode-7559b0be-bfa5-5fe6-b731-1973fe9fffa1-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
-      }
-    },
-    "node_modules/@codingame/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common/-/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common-15.0.2.tgz",
-      "integrity": "sha512-Fp1q86xW/RsvoFI3FDK2oTzjjH3L0ybwUpHpojvdXs7qSe9xIABRdC2H+j6wqA48RWGvNfnzopw5x/AsAf3IWA==",
-      "license": "MIT",
-      "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-158b9837-fc78-5d9c-86f5-9134e4358643-common": "18.1.3",
+        "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-422642f2-7e3a-5c1c-9e1e-1d3ef1817346-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-422642f2-7e3a-5c1c-9e1e-1d3ef1817346-common/-/monaco-vscode-422642f2-7e3a-5c1c-9e1e-1d3ef1817346-common-15.0.2.tgz",
-      "integrity": "sha512-897LD2JzqZ2mE5D1Z4gb9QIqeK1QdOkANFeXNfrcVBW3I/+Fl0Vx/JnKpDUKAd4L9B+aa7pztUkv1N5cjchItg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-422642f2-7e3a-5c1c-9e1e-1d3ef1817346-common/-/monaco-vscode-422642f2-7e3a-5c1c-9e1e-1d3ef1817346-common-18.1.3.tgz",
+      "integrity": "sha512-5os2MqReKx9BJlHMbGJmJsXPnkYtiOlTZr2vjLFSQ907xULFiaqbnM0Qdmz+TOrAMX4MX/9GIX43z+lOCAUfnA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-42931eb9-e564-530c-bafc-fa23ab43a070-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-42931eb9-e564-530c-bafc-fa23ab43a070-common/-/monaco-vscode-42931eb9-e564-530c-bafc-fa23ab43a070-common-15.0.2.tgz",
-      "integrity": "sha512-+o0ivOGA5SShRp22CcbmW+qHoiUan/VN5joo4lgJ8bdCsEgTa59hWCddzx0KHgTjQxLuDlV9CmwulrsEvhJK0g==",
+    "node_modules/@codingame/monaco-vscode-4372ad43-a220-5e78-83e6-95a9cfd64384-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-4372ad43-a220-5e78-83e6-95a9cfd64384-common/-/monaco-vscode-4372ad43-a220-5e78-83e6-95a9cfd64384-common-18.1.3.tgz",
+      "integrity": "sha512-6LUnsErqhAhMmUl2gy/ygwX3L1HSsZ3X61ax4fvFpGwX+c+kZTyXNsuqginCpDwWIShB+5eTdEjA9RkxnIG3ig==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common": "15.0.2",
-        "@codingame/monaco-vscode-29bc1406-2925-5b8f-b25e-d04a7772d896-common": "15.0.2",
-        "@codingame/monaco-vscode-2e69e120-617a-5258-95e0-3b8902f4e014-common": "15.0.2",
-        "@codingame/monaco-vscode-9a6d8b6c-ad4c-5ea3-9558-f43d6dc4c0ad-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
-      }
-    },
-    "node_modules/@codingame/monaco-vscode-44b92f80-48ea-5562-a8d0-18a015f8d845-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-44b92f80-48ea-5562-a8d0-18a015f8d845-common/-/monaco-vscode-44b92f80-48ea-5562-a8d0-18a015f8d845-common-15.0.2.tgz",
-      "integrity": "sha512-aZTg+g286eUZfsu/Jxo70QOr8J4y6Jpwij/vu4Mh/i8nNiSF91TL67cWC3Cwbx2IERVyUSZxRiBYjWd25sRepQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-4ee27008-17b4-593f-9c09-19e8e3077f51-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-45a408c6-90ed-5d8b-801d-f3f69c7a97f2-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-45a408c6-90ed-5d8b-801d-f3f69c7a97f2-common/-/monaco-vscode-45a408c6-90ed-5d8b-801d-f3f69c7a97f2-common-15.0.2.tgz",
-      "integrity": "sha512-f8dl3Cza5K5kjoCR3rwnxHCj8FNRRCW2eGxr8/MsFx2OQ6rvBKsV2JatBeJv6DpanBcG9LNh7EfyJCQr772GDg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-45a408c6-90ed-5d8b-801d-f3f69c7a97f2-common/-/monaco-vscode-45a408c6-90ed-5d8b-801d-f3f69c7a97f2-common-18.1.3.tgz",
+      "integrity": "sha512-eDkRjXFfWkFJ96L1CUQHa87eX4w05o0d94btQXcVHHFLq3MROpBYhBqG947j1pp3FH7fyO//A3NHn122WuABtA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-42931eb9-e564-530c-bafc-fa23ab43a070-common": "15.0.2",
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-c4e2825a-b5b1-5f0e-b547-068c32e06d50-common": "15.0.2"
+        "@codingame/monaco-vscode-47472025-cc45-5680-86cd-09ceaba921a1-common": "18.1.3",
+        "@codingame/monaco-vscode-85f7fb0f-70f5-5a5e-831b-15c743a8bd11-common": "18.1.3",
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-f5d4b045-44e8-55a8-b683-308656a412fa-common": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-47472025-cc45-5680-86cd-09ceaba921a1-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-47472025-cc45-5680-86cd-09ceaba921a1-common/-/monaco-vscode-47472025-cc45-5680-86cd-09ceaba921a1-common-18.1.3.tgz",
+      "integrity": "sha512-SvD4MF63G3jRrRxoV6JVd4RUfLA3cFB2zl1P1ezJUXGH6c9h5jlxZO+u2D6Fe3BqJuZAIRK4CDUcu6XBmaJR5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-3cf6a388-482f-5484-a806-0525ad9ad8af-common": "18.1.3",
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-a4683c2b-a0d2-5112-96ba-eedc605346d2-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-f48982c4-9e82-55e2-b800-20e6d1e6096f-common": "18.1.3",
+        "@codingame/monaco-vscode-f5d4b045-44e8-55a8-b683-308656a412fa-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-494be54c-bd37-5b3c-af70-02f086e28768-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-494be54c-bd37-5b3c-af70-02f086e28768-common/-/monaco-vscode-494be54c-bd37-5b3c-af70-02f086e28768-common-15.0.2.tgz",
-      "integrity": "sha512-uOilmDHGZXeO2y+RrgAFy1ZC6WERu4uF4fM6bl8nhfSeqeZ6ArlS3jsnaVCZp849nRqWGJbwlEro2PgUmJH5Bg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-494be54c-bd37-5b3c-af70-02f086e28768-common/-/monaco-vscode-494be54c-bd37-5b3c-af70-02f086e28768-common-18.1.3.tgz",
+      "integrity": "sha512-wnUBrqjH3w1buKFBj3aNrbfqIeGE4SjgIMk7/1eIEK5oSAI/trN29ijw5XumEQiZRDu//chfR134bCobEHi9Zg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-4a316137-39d1-5d77-8b53-112db3547c1e-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-4a316137-39d1-5d77-8b53-112db3547c1e-common/-/monaco-vscode-4a316137-39d1-5d77-8b53-112db3547c1e-common-15.0.2.tgz",
-      "integrity": "sha512-NFzdN+mduRpev3iWvTWtErNXDFunp43Scvl46xAD1b9unoi+orcDAdUUNWbBltXFqMcM83C/xEskoUmnyYnEAw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-4a316137-39d1-5d77-8b53-112db3547c1e-common/-/monaco-vscode-4a316137-39d1-5d77-8b53-112db3547c1e-common-18.1.3.tgz",
+      "integrity": "sha512-gh6r4+tUYvprIFEYzaXMaBbveOVtRcM0A0gbX7oAUYPblYXnIWoMSWQ1ngqS+ssNvSc88/1CRUDoQu3Qw3FX9g==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-38f25ab8-ea30-5ba9-8a08-ae3308c297c0-common": "15.0.2",
-        "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-a7c9ae3c-16d2-5d17-86b2-981be7094566-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-937ecbdf-94c7-5b16-aefa-ad78ae557a93-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common": "18.1.3",
+        "@codingame/monaco-vscode-f48982c4-9e82-55e2-b800-20e6d1e6096f-common": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-4ead9d5f-54da-5c5a-b093-32be4a84d711-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-4ead9d5f-54da-5c5a-b093-32be4a84d711-common/-/monaco-vscode-4ead9d5f-54da-5c5a-b093-32be4a84d711-common-15.0.2.tgz",
-      "integrity": "sha512-STEjQ+Wt3eK423yJGGY23v+FU2zoUXjZ1j9ktHMvoTfwWNyrCWE0Sae55bDSmintBrg+/O43X1kcck1uxkg5Rg==",
+    "node_modules/@codingame/monaco-vscode-4a3ac544-9a61-534c-88df-756262793ef7-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-4a3ac544-9a61-534c-88df-756262793ef7-common/-/monaco-vscode-4a3ac544-9a61-534c-88df-756262793ef7-common-18.1.3.tgz",
+      "integrity": "sha512-691nOngAaBZ/iesJ5FvznPsiqYU7LIYJCIPJnm3MLOEmbzUGiA+RFZzjQfCkd+xR5i7whDQakpShmhe7SqPbSQ==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-ea14e352-8f1c-5569-b79a-8a96a53e8abe-common": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-4ee27008-17b4-593f-9c09-19e8e3077f51-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-4ee27008-17b4-593f-9c09-19e8e3077f51-common/-/monaco-vscode-4ee27008-17b4-593f-9c09-19e8e3077f51-common-18.1.3.tgz",
+      "integrity": "sha512-wylddLLfzZs6XkYotn6weum0hfKHQ5/GqkNuxlHzPlqJaZFTuVXcOKoYahtGt8ADE2rUhLbpqdDPqjkPmtJnXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common/-/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common-18.1.3.tgz",
+      "integrity": "sha512-uhCNvXJbeLlLL6lGwqrImSKsdrc1VjwFUStXNB5NJXXkxpYMhcWVDnpF/a9Im7pPxTLLAQ7GDup7uZptWmL52A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-523730aa-81e6-55d7-9916-87ad537fe087-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-523730aa-81e6-55d7-9916-87ad537fe087-common/-/monaco-vscode-523730aa-81e6-55d7-9916-87ad537fe087-common-15.0.2.tgz",
-      "integrity": "sha512-vCoR/kVApfn3IgKQNt3JM9Pb3I2t7iDvLKA7emek3LRQCuE+i2aLHIiQlhefcu5hCrNHhH1nfLO1P7lwiQkGlg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-523730aa-81e6-55d7-9916-87ad537fe087-common/-/monaco-vscode-523730aa-81e6-55d7-9916-87ad537fe087-common-18.1.3.tgz",
+      "integrity": "sha512-nG1rwNLLuWujEpYQGg9+41xwS7tixHKiiTP0WHRyopdqz/LqxIFu16j4IqQDENq9kZUCvpGkbRno8zX30TOcQg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "15.0.2",
-        "@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-c4e2825a-b5b1-5f0e-b547-068c32e06d50-common": "15.0.2"
-      }
-    },
-    "node_modules/@codingame/monaco-vscode-52bb4d5b-ba1a-57fd-9bee-b28824214eac-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-52bb4d5b-ba1a-57fd-9bee-b28824214eac-common/-/monaco-vscode-52bb4d5b-ba1a-57fd-9bee-b28824214eac-common-15.0.2.tgz",
-      "integrity": "sha512-hCgaESRGEDQHskDlRg18POBprzoQhfV9QCTiC7O8mNHpDLLL+3Xi3Ffmk3jZAERvTP1dndp35Wnxsk5/WREgIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-4ee27008-17b4-593f-9c09-19e8e3077f51-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": "18.1.3",
+        "@codingame/monaco-vscode-f5d4b045-44e8-55a8-b683-308656a412fa-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-5452e2b7-9081-5f95-839b-4ab3544ce28f-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-5452e2b7-9081-5f95-839b-4ab3544ce28f-common/-/monaco-vscode-5452e2b7-9081-5f95-839b-4ab3544ce28f-common-15.0.2.tgz",
-      "integrity": "sha512-L66aIitO0gZxVskynJBjfSJ6Kk4vmDbgG/5/1RJ104TsL0a02A3ojC1j+chU4b/NBNXhuRY7jiZqgdlLQwesmg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-5452e2b7-9081-5f95-839b-4ab3544ce28f-common/-/monaco-vscode-5452e2b7-9081-5f95-839b-4ab3544ce28f-common-18.1.3.tgz",
+      "integrity": "sha512-Nd5Jz+j3AT4+hftiyb/7AXEC5qGuOxcVdM8gc30BHMLqtaEfOHwFK2SxqIFJUeIqhdIj8q4cculmmXOudNatAw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-168b98e5-dc20-5807-b1f9-798f1f92b37f-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-1cc4ea0a-c5b6-54ed-bb60-078a99119b55-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-55ed5668-e8ca-5335-a587-790bcf1200c0-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-55ed5668-e8ca-5335-a587-790bcf1200c0-common/-/monaco-vscode-55ed5668-e8ca-5335-a587-790bcf1200c0-common-15.0.2.tgz",
-      "integrity": "sha512-B9qbbn24k0zZTC10cltPD5+BlR14gEoG5Vp2crp2awxtd136L4O2Xxjdl7/4vN81zNMsXXkjRM3NK1EmPYLyzw==",
+    "node_modules/@codingame/monaco-vscode-571c8352-7953-5038-9f09-e03bb6219a0e-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-571c8352-7953-5038-9f09-e03bb6219a0e-common/-/monaco-vscode-571c8352-7953-5038-9f09-e03bb6219a0e-common-18.1.3.tgz",
+      "integrity": "sha512-PMHm6wXqiLrm0TXOFRcWAlzg1nAK/+4rHPfO5SEbbSpM1ASGZAr6OzdVcqsaOMMihctryjU2szolTMcpnxXnKw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-249dc928-1da3-51c1-82d0-45e0ba9d08a1-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-625898ab-0e33-5b7f-a3ae-29c10271dc1c-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-625898ab-0e33-5b7f-a3ae-29c10271dc1c-common/-/monaco-vscode-625898ab-0e33-5b7f-a3ae-29c10271dc1c-common-15.0.2.tgz",
-      "integrity": "sha512-KSVLZMY0oEu6tAddYZ3cpYM8JsbKZUE0RXEk6WW2rTUL4offHp/LV1qNvQzdBH1uXU4ReFcgA8abF7k4mi6uxA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-625898ab-0e33-5b7f-a3ae-29c10271dc1c-common/-/monaco-vscode-625898ab-0e33-5b7f-a3ae-29c10271dc1c-common-18.1.3.tgz",
+      "integrity": "sha512-QdfbAnGsKI3gvmcfivFqu/8CXc6J5yzInM86mAltPlwEBYKIGPMznRSdhkWAoJuhpiiuheAdV6uq40YMf24DNg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common": "15.0.2",
-        "@codingame/monaco-vscode-7bbc9e7d-eeae-55fc-8bf9-dc2f66e0dc73-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common": "18.1.3",
+        "@codingame/monaco-vscode-7bbc9e7d-eeae-55fc-8bf9-dc2f66e0dc73-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common/-/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common-15.0.2.tgz",
-      "integrity": "sha512-/LMFDaoD37l3hVZvbTSzljebcajUlQrqv/wea/sGsRYn40pxNYlbr1BS0A3U3wYdWk0iW6YxeWu6rx4YG40Zcw==",
+    "node_modules/@codingame/monaco-vscode-64322fa2-7385-5f46-935b-8f243d98004b-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-64322fa2-7385-5f46-935b-8f243d98004b-common/-/monaco-vscode-64322fa2-7385-5f46-935b-8f243d98004b-common-18.1.3.tgz",
+      "integrity": "sha512-u8vjIE6in1rVuV/ISZ0q9oKmBdk6iCkVZwKGBate1dCUJOihs9HXA8msT1qm83zEFBNup7ywSG1jvhDhaGHEaA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-158b9837-fc78-5d9c-86f5-9134e4358643-common": "18.1.3",
+        "@codingame/monaco-vscode-47472025-cc45-5680-86cd-09ceaba921a1-common": "18.1.3",
+        "@codingame/monaco-vscode-6c0f93b9-169c-58c3-a9cb-7d60698eb52c-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-bc8c28cd-7a80-54a9-af1a-e6b1e7a7f34a-common": "18.1.3",
+        "@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": "18.1.3",
+        "@codingame/monaco-vscode-ea14e352-8f1c-5569-b79a-8a96a53e8abe-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-6845754f-e617-5ed9-8aaa-6ca3653a9532-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-6845754f-e617-5ed9-8aaa-6ca3653a9532-common/-/monaco-vscode-6845754f-e617-5ed9-8aaa-6ca3653a9532-common-15.0.2.tgz",
-      "integrity": "sha512-RvVJDncM+AbsxqCNsJT7W5o6+A1wunlGkB8beIXemirxteBbQkoVhd9JkcH+Tm8BJvqtDil4SKX3zf3MP6IaXA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-6845754f-e617-5ed9-8aaa-6ca3653a9532-common/-/monaco-vscode-6845754f-e617-5ed9-8aaa-6ca3653a9532-common-18.1.3.tgz",
+      "integrity": "sha512-ju0/cwJ2VdFfjNtnn9+zm71p6B3Ka6dnGWB0n8j0ms3LZ0GEcVFF66xKoufyd5I3iJI9WD/NESUtRBJq8V0Xcw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
-      }
-    },
-    "node_modules/@codingame/monaco-vscode-695440c8-a687-5594-b476-bbc7b36bafe9-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-695440c8-a687-5594-b476-bbc7b36bafe9-common/-/monaco-vscode-695440c8-a687-5594-b476-bbc7b36bafe9-common-15.0.2.tgz",
-      "integrity": "sha512-yq0ELxTe31ivgH9hno0urKw369aCQL60GuOeTn8i8MkdMesYDHH1t7f8vFZBVTFmDyDBSVcoE1oeQfts0/aCqg==",
-      "license": "MIT",
-      "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-6980eeab-47bb-5a48-8e15-32caf0785565-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-6980eeab-47bb-5a48-8e15-32caf0785565-common/-/monaco-vscode-6980eeab-47bb-5a48-8e15-32caf0785565-common-15.0.2.tgz",
-      "integrity": "sha512-Lbwz1oVdLpn/cIU6/FeZSMM9zXDFL6fYQa1uP2rJRzQuehrZtHjHmKGLu4kW9XrvIAFrvxKTqmZIAaB5n+mNZQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-6980eeab-47bb-5a48-8e15-32caf0785565-common/-/monaco-vscode-6980eeab-47bb-5a48-8e15-32caf0785565-common-18.1.3.tgz",
+      "integrity": "sha512-9x0Wckw7YzWaIWAKTbZ9xsosu02yz3apFCpLwB1YJobErDMmupD4ZqjeAb0seBDe2ON6Lr45qaY6nBarLzbMHw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common": "15.0.2",
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-40cada32-7e9c-528a-81fc-766e4da54147-common": "15.0.2",
-        "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common": "15.0.2",
-        "@codingame/monaco-vscode-ad89fae6-94f0-5ac2-a185-22dea4b68ee0-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-d8236b3b-b91a-522d-89f4-94d70a546f6a-common": "15.0.2"
+        "@codingame/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common": "18.1.3",
+        "@codingame/monaco-vscode-40cada32-7e9c-528a-81fc-766e4da54147-common": "18.1.3",
+        "@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": "18.1.3",
+        "@codingame/monaco-vscode-6bf85d7b-e6e3-54e9-9bc1-7e08d663f0f6-common": "18.1.3",
+        "@codingame/monaco-vscode-85886bdb-61c5-52f1-8eb7-d1d32f6f8cbd-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common": "18.1.3",
+        "@codingame/monaco-vscode-a8d3bd74-e63e-5327-96e8-4f931661e329-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-c3c61c00-c254-5856-9dc9-d7929c1f9062-common": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-6f9bc782-77e0-5716-93bd-b05210c768c5-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-6f9bc782-77e0-5716-93bd-b05210c768c5-common/-/monaco-vscode-6f9bc782-77e0-5716-93bd-b05210c768c5-common-15.0.2.tgz",
-      "integrity": "sha512-WKGCm94vwwc3tzDkBcljWVvb0FwHoQdiY3MoOidAolihork9I1kADJxI25/xdijEKVFDSy/td2sqYjqVtONlHA==",
+    "node_modules/@codingame/monaco-vscode-69cd7d65-4465-53e8-9718-bc4f6df50f7d-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-69cd7d65-4465-53e8-9718-bc4f6df50f7d-common/-/monaco-vscode-69cd7d65-4465-53e8-9718-bc4f6df50f7d-common-18.1.3.tgz",
+      "integrity": "sha512-8/beoPg81mSYVLK5h80/0Fx8wPr2QTEE3Z9SMPrcEVqY0sMEB2WrJDqnJVhTENOcOUaln/BgwnBKroJWeCq6vw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-805e9c2f-56b6-5a43-8b5b-d2dc2d3805fc-common": "15.0.2",
-        "@codingame/monaco-vscode-9a6d8b6c-ad4c-5ea3-9558-f43d6dc4c0ad-common": "15.0.2",
-        "@codingame/monaco-vscode-9b5a5e82-d649-5455-b4bf-ef90d6afd294-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-7559b0be-bfa5-5fe6-b731-1973fe9fffa1-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-7559b0be-bfa5-5fe6-b731-1973fe9fffa1-common/-/monaco-vscode-7559b0be-bfa5-5fe6-b731-1973fe9fffa1-common-15.0.2.tgz",
-      "integrity": "sha512-d3oGEVxucAudJ/tSl1JteduABCKXii27ekbEm/t8Xo8A9ximAoTRJ5tX6ne04cbXLisWdTcTeSzxirR9BdNVqA==",
+    "node_modules/@codingame/monaco-vscode-6bf85d7b-e6e3-54e9-9bc1-7e08d663f0f6-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-6bf85d7b-e6e3-54e9-9bc1-7e08d663f0f6-common/-/monaco-vscode-6bf85d7b-e6e3-54e9-9bc1-7e08d663f0f6-common-18.1.3.tgz",
+      "integrity": "sha512-aRLR9+cABqQYPix1V3zTb42EC9MR4fwbf5MjZprdEBscqb9ogDNuLddMArfXbNoCxsLr40X6cyH7nfbNMkrnlA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common": "18.1.3",
+        "@codingame/monaco-vscode-85886bdb-61c5-52f1-8eb7-d1d32f6f8cbd-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-96e83782-7f38-572e-8787-02e981f1c54f-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-f22e7e55-aee8-5b52-a6bc-950efd9f5890-common": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-7ba0af96-90c2-5e11-ad7f-befdbbf246c8-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-7ba0af96-90c2-5e11-ad7f-befdbbf246c8-common/-/monaco-vscode-7ba0af96-90c2-5e11-ad7f-befdbbf246c8-common-15.0.2.tgz",
-      "integrity": "sha512-cb7YE+yQVMNGOh1KI7E0VPm6M1bUVz3magAnwDXiSNXfTSjg8yLKBbJFUoAE/g18q+FY1PXg6DOS4wajWVCmAg==",
+    "node_modules/@codingame/monaco-vscode-6c0f93b9-169c-58c3-a9cb-7d60698eb52c-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-6c0f93b9-169c-58c3-a9cb-7d60698eb52c-common/-/monaco-vscode-6c0f93b9-169c-58c3-a9cb-7d60698eb52c-common-18.1.3.tgz",
+      "integrity": "sha512-3EuK3nkpNTqAgtlwBbJU1UkWGEdkgJYeGmCfoDnBCR/alwk6cQfmDD32zYIgwScLPskGA3Fj65TwwDr7ANhXVg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-1cb11a73-359e-5a2f-9e95-6989cc9858ee-common": "18.1.3",
+        "@codingame/monaco-vscode-210e86a9-a91b-5273-b05d-390c776dde1f-common": "18.1.3",
+        "@codingame/monaco-vscode-3a35f433-1297-5707-ab58-c261b8180e6d-common": "18.1.3",
+        "@codingame/monaco-vscode-7adbeffb-8051-54a9-8c9b-b62ce9e5836f-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-c465110a-57c0-59d7-a6b2-be0a4db7e517-common": "18.1.3",
+        "@codingame/monaco-vscode-f5d4b045-44e8-55a8-b683-308656a412fa-common": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-7869cfe8-f42c-5721-9f2b-7d04a6a41f16-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-7869cfe8-f42c-5721-9f2b-7d04a6a41f16-common/-/monaco-vscode-7869cfe8-f42c-5721-9f2b-7d04a6a41f16-common-18.1.3.tgz",
+      "integrity": "sha512-heeuABE9EP5p4beTkMb/ujE41ASo+mgPaPZn9Dk/4dztWLovFYPul2sdc5dBjBf1VsYfOQAivnkG9aFavgRhOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-7adbeffb-8051-54a9-8c9b-b62ce9e5836f-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-7adbeffb-8051-54a9-8c9b-b62ce9e5836f-common/-/monaco-vscode-7adbeffb-8051-54a9-8c9b-b62ce9e5836f-common-18.1.3.tgz",
+      "integrity": "sha512-isKwOTY0KphGfI8wXDlZwNttci99aW7RwvilZZftvNNvk+xowQcySHwqrHkUOZYfWG5m3nMi6mH8uG8jOX/b1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-7bbc9e7d-eeae-55fc-8bf9-dc2f66e0dc73-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-7bbc9e7d-eeae-55fc-8bf9-dc2f66e0dc73-common/-/monaco-vscode-7bbc9e7d-eeae-55fc-8bf9-dc2f66e0dc73-common-15.0.2.tgz",
-      "integrity": "sha512-W0580lGhTml4h/QbxGMM5zMTpaamUdZ/I/EF7t0Z/XCI31QIHzrVdw+8oRStHvnjCrz1587EyeKoUOC4jo4vEA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-7bbc9e7d-eeae-55fc-8bf9-dc2f66e0dc73-common/-/monaco-vscode-7bbc9e7d-eeae-55fc-8bf9-dc2f66e0dc73-common-18.1.3.tgz",
+      "integrity": "sha512-bRZdYqY/1kI5WSvR7pv1a7D3hLcuoSA9/TBN+F0QZ4h4IkaD4Snwu+uGKOX0XOsbWaIbNKJdUfAGBYUBMN3RiQ==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-7f39b6f1-3542-5430-8760-0f404d7a7cee-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-7f39b6f1-3542-5430-8760-0f404d7a7cee-common/-/monaco-vscode-7f39b6f1-3542-5430-8760-0f404d7a7cee-common-15.0.2.tgz",
-      "integrity": "sha512-WaqYkXMFauFHesL2bCqE7os8rY4MxQYzjILZRpspFcwJCf0ohujrkAVwYoCLLt7HOnG/xKmruF8I5mJIPAvm8w==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-7f39b6f1-3542-5430-8760-0f404d7a7cee-common/-/monaco-vscode-7f39b6f1-3542-5430-8760-0f404d7a7cee-common-18.1.3.tgz",
+      "integrity": "sha512-psXDcF13Z8+QFt0Uk+Dk1yuVxKUBHNDMAfDd4hDMZzIITzBus/ZveSXogRoryPUU2KcUNa0zx5jlbMINFgdDmQ==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-9b5a5e82-d649-5455-b4bf-ef90d6afd294-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-fdf643f9-94dd-5510-b97a-408abf26ad92-common": "15.0.2"
+        "@codingame/monaco-vscode-4372ad43-a220-5e78-83e6-95a9cfd64384-common": "18.1.3",
+        "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-805e9c2f-56b6-5a43-8b5b-d2dc2d3805fc-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-805e9c2f-56b6-5a43-8b5b-d2dc2d3805fc-common/-/monaco-vscode-805e9c2f-56b6-5a43-8b5b-d2dc2d3805fc-common-15.0.2.tgz",
-      "integrity": "sha512-Eua39mWE3K+kKLXm9uSsg6fvBJgVr7BPxWXRVPc17Rm2GjJ+/4WMIyue88KkFuBUCp/Y9sqaVhT5AiR+6DS/sg==",
+    "node_modules/@codingame/monaco-vscode-85886bdb-61c5-52f1-8eb7-d1d32f6f8cbd-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-85886bdb-61c5-52f1-8eb7-d1d32f6f8cbd-common/-/monaco-vscode-85886bdb-61c5-52f1-8eb7-d1d32f6f8cbd-common-18.1.3.tgz",
+      "integrity": "sha512-Io7qXcmU44AILpS9shVnW1LSz6hgEuuR9AF5gw+N9SyN//AHAjK78Y8IC8OO/ZP+itfS06r+IKMBOqIT9sF1Hw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-7559b0be-bfa5-5fe6-b731-1973fe9fffa1-common": "15.0.2",
-        "@codingame/monaco-vscode-7ba0af96-90c2-5e11-ad7f-befdbbf246c8-common": "15.0.2",
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common/-/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common-15.0.2.tgz",
-      "integrity": "sha512-c7qujmYpvQ9AmAvQoGjQ5GysvokdV8R+aDiosHDVtOfq9x3MVRkzdTNtlGL27UaauBKMpFFY7ZOM7rq/dnwZRw==",
+    "node_modules/@codingame/monaco-vscode-85f7fb0f-70f5-5a5e-831b-15c743a8bd11-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-85f7fb0f-70f5-5a5e-831b-15c743a8bd11-common/-/monaco-vscode-85f7fb0f-70f5-5a5e-831b-15c743a8bd11-common-18.1.3.tgz",
+      "integrity": "sha512-KjbM1/3OYbeeFpBH2JQc5xNoKMcG1cOSVSzfz0gOMWgj3V3UQ58dPXR0AEnVu2Ro7OnVhLucGVWubKNIePlGfA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
-      }
-    },
-    "node_modules/@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common/-/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common-15.0.2.tgz",
-      "integrity": "sha512-rf25cJ0J5useUnN1WpRqK+JXRFa6/s9nZ4LxcX7mIPvCV9VArfL4Q6Mc/ulUHdDe7ComvfmCHi5/TZpBzqCdTg==",
-      "license": "MIT",
-      "dependencies": {
-        "@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-47472025-cc45-5680-86cd-09ceaba921a1-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-88aa9a78-75f5-5aaa-89e9-bbdd580b3b5c-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-88aa9a78-75f5-5aaa-89e9-bbdd580b3b5c-common/-/monaco-vscode-88aa9a78-75f5-5aaa-89e9-bbdd580b3b5c-common-15.0.2.tgz",
-      "integrity": "sha512-Ndc3v4zkGc6w1lsQ3W1a/WLt4tAcJkyR3Q9a+Un4o7v+JAtpBAHe+l3Vu8Iq6fvmwonn0n0gaiD+s91X9vFzfw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-88aa9a78-75f5-5aaa-89e9-bbdd580b3b5c-common/-/monaco-vscode-88aa9a78-75f5-5aaa-89e9-bbdd580b3b5c-common-18.1.3.tgz",
+      "integrity": "sha512-rFDFkAiTzohYzvVhc5rspk4onQDt5f77nTjdhpxxktCiUveXsGSqDq151aIECjwokWE5By5dF1A/H9cY3sHskQ==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common": "15.0.2",
-        "@codingame/monaco-vscode-1bb39316-6fbf-572e-ab6a-818a2496c14f-common": "15.0.2",
-        "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "15.0.2",
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common": "18.1.3",
+        "@codingame/monaco-vscode-158b9837-fc78-5d9c-86f5-9134e4358643-common": "18.1.3",
+        "@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": "18.1.3",
+        "@codingame/monaco-vscode-8d39d04c-3201-5bd6-be79-eed8d17a5ad0-common": "18.1.3",
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-fc42f049-7883-579d-bb0b-2aa1010a19a8-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-897bebad-39df-57cb-8a57-36a271d038be-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-897bebad-39df-57cb-8a57-36a271d038be-common/-/monaco-vscode-897bebad-39df-57cb-8a57-36a271d038be-common-15.0.2.tgz",
-      "integrity": "sha512-VDX/WY6oaD7/CukLt+4n7T6ZGMU9gu0MP4pSrnSWTml4psiPcM4e/MvOQdx0Gh9fRD3/GwsvgHIxg31LvVAixg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-897bebad-39df-57cb-8a57-36a271d038be-common/-/monaco-vscode-897bebad-39df-57cb-8a57-36a271d038be-common-18.1.3.tgz",
+      "integrity": "sha512-O7ruiIJEpspj2+lvFxtT6FDsBBB6S0ekr1PH2MNtMZsCFSy2kM6UeK6grLQhyDN66tUOk0V14y+mUmKAc4UeiA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-89a82baf-8ded-5b2f-b8af-e5fbd72dc5ad-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-89a82baf-8ded-5b2f-b8af-e5fbd72dc5ad-common/-/monaco-vscode-89a82baf-8ded-5b2f-b8af-e5fbd72dc5ad-common-15.0.2.tgz",
-      "integrity": "sha512-YzLGDNQThRPmo+EbxapqhKgP3j6yqk84GpCHh02bWR8Ya1wpsvlRWPBDpZAEI+JmsqKE5VIRgYyiXTp0c7jmsQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-89a82baf-8ded-5b2f-b8af-e5fbd72dc5ad-common/-/monaco-vscode-89a82baf-8ded-5b2f-b8af-e5fbd72dc5ad-common-18.1.3.tgz",
+      "integrity": "sha512-Am8FthHOOXaKoexNVaz64AIEQIoe3qiWQ9E/njBPKO8QscOr2c1aSWLfbirm4uoZ0XRoBL65hb7aVat6m4q9Xw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-256d5b78-0649-50e9-8354-2807f95f68f4-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-256d5b78-0649-50e9-8354-2807f95f68f4-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-8a9062f2-d169-567b-848e-a2530c97ea18-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-8a9062f2-d169-567b-848e-a2530c97ea18-common/-/monaco-vscode-8a9062f2-d169-567b-848e-a2530c97ea18-common-18.1.3.tgz",
+      "integrity": "sha512-Px2BvDnz4EA1buW1HygUDVfhiMberd+7WjXxz/ZWzYbFj1lWZHniLIAunJh2ErDmYruZiw8K1qaNZ28UXf2uyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-8bcd87e5-7461-57cf-b4e4-a7b00d2b33df-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-8bcd87e5-7461-57cf-b4e4-a7b00d2b33df-common/-/monaco-vscode-8bcd87e5-7461-57cf-b4e4-a7b00d2b33df-common-18.1.3.tgz",
+      "integrity": "sha512-UPTBE7JiP0y0qyf/2YUe6FgMeUP6OVV850x2LRtri7J691FMMH/POPjM6eIRSLcVEJs5QK79MsErU6iBC6s5Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-8d39d04c-3201-5bd6-be79-eed8d17a5ad0-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-8ccb7637-50ea-5359-97bf-00015d7fe567-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-8ccb7637-50ea-5359-97bf-00015d7fe567-common/-/monaco-vscode-8ccb7637-50ea-5359-97bf-00015d7fe567-common-15.0.2.tgz",
-      "integrity": "sha512-QSDFeX/hTk5c+3EOIjioG234EQikOCaKtqUVDf/CWu8kVjetxdAPRAR2c269R5WbrtDPDSBvxhquJk8yvOjQGw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-8ccb7637-50ea-5359-97bf-00015d7fe567-common/-/monaco-vscode-8ccb7637-50ea-5359-97bf-00015d7fe567-common-18.1.3.tgz",
+      "integrity": "sha512-sAgkkbuPSZ0rKX974k4n74U4vkg+PZnmoGBpBjRP/98cmBm/rETuE2BkLf4TvZJOLA5KXkRIErg8CuwZyx3cWA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-210e86a9-a91b-5273-b05d-390c776dde1f-common": "15.0.2",
-        "@codingame/monaco-vscode-2e69e120-617a-5258-95e0-3b8902f4e014-common": "15.0.2",
-        "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "15.0.2",
-        "@codingame/monaco-vscode-897bebad-39df-57cb-8a57-36a271d038be-common": "15.0.2",
-        "@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-210e86a9-a91b-5273-b05d-390c776dde1f-common": "18.1.3",
+        "@codingame/monaco-vscode-4ee27008-17b4-593f-9c09-19e8e3077f51-common": "18.1.3",
+        "@codingame/monaco-vscode-897bebad-39df-57cb-8a57-36a271d038be-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-8d39d04c-3201-5bd6-be79-eed8d17a5ad0-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-8d39d04c-3201-5bd6-be79-eed8d17a5ad0-common/-/monaco-vscode-8d39d04c-3201-5bd6-be79-eed8d17a5ad0-common-18.1.3.tgz",
+      "integrity": "sha512-e26pexUKPD5KJlr6DxGNlWtZxXMDDA0r1WMkyWYS2JSdt/ay/QGTDW9AV9OEsUZEHhitlDDuMZeGaf4yw68bFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common/-/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common-18.1.3.tgz",
+      "integrity": "sha512-iMuHHVnhzMxApBshHOMGYB2HOkGbfyqtSvfcTEwtk+HroJ4z7RXWY4UwWnsul2siDCS6R651rP2XXhmzRY7jLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-93784a59-b4cf-520c-8339-f8104d3a4f3e-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-93784a59-b4cf-520c-8339-f8104d3a4f3e-common/-/monaco-vscode-93784a59-b4cf-520c-8339-f8104d3a4f3e-common-18.1.3.tgz",
+      "integrity": "sha512-ssSWmBjR2+KiQqKE5ZKU1O8KcbFlPFBP6yY4Vv92zVF9DjRouH6/gSzdQGYeoM0mIV4EptSFziBJxN1wiUSDsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-937ecbdf-94c7-5b16-aefa-ad78ae557a93-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-937ecbdf-94c7-5b16-aefa-ad78ae557a93-common/-/monaco-vscode-937ecbdf-94c7-5b16-aefa-ad78ae557a93-common-18.1.3.tgz",
+      "integrity": "sha512-41ZdBeYk5Om7dzP8XnzN8PXE5IPfAxxbIE+wiaVl4LECM0SbTpXeE/KIpdOZlHCE02f91P35nYZXR2O0uw9hig==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-95ea5c7c-15cf-50aa-8e24-38039b06b4a6-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-95ea5c7c-15cf-50aa-8e24-38039b06b4a6-common/-/monaco-vscode-95ea5c7c-15cf-50aa-8e24-38039b06b4a6-common-18.1.3.tgz",
+      "integrity": "sha512-UIaGVrrx8SOPEG86tvg+OXnh7xbrmxpIU+yFNdY672cjrBbfoPg7YCH0t+iD30Ky7IB//H8OY7R7qfbk8N06Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-96e83782-7f38-572e-8787-02e981f1c54f-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-96e83782-7f38-572e-8787-02e981f1c54f-common/-/monaco-vscode-96e83782-7f38-572e-8787-02e981f1c54f-common-18.1.3.tgz",
+      "integrity": "sha512-H6WxwsKcshvL7SlSBZNWHLIchj1gWhMjJHeA+6SPuxHPOvuwtPLm+5olxBZImxje1m9cd9S9Nvw4rWFP0R9Cdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-158b9837-fc78-5d9c-86f5-9134e4358643-common": "18.1.3",
+        "@codingame/monaco-vscode-69cd7d65-4465-53e8-9718-bc4f6df50f7d-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-f22e7e55-aee8-5b52-a6bc-950efd9f5890-common": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common/-/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common-18.1.3.tgz",
+      "integrity": "sha512-Xg3zqztIlBuCsUjgkuUVy4/XUnfsa+zoG2P/xdMgW2U3WFaT7di/2o3Hywk312uw2aXl/G3mkz8te/aA24y8Ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-9a1a5840-af83-5d07-a156-ba32a36c5c4b-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-9a1a5840-af83-5d07-a156-ba32a36c5c4b-common/-/monaco-vscode-9a1a5840-af83-5d07-a156-ba32a36c5c4b-common-15.0.2.tgz",
-      "integrity": "sha512-zop7+H3CEirMXdtZtjDQ3/+udWVWTf6hjHxGlGCrLKHIM1UoMci55SY2n+UVLsx2UTswo670SIjYge48CdLZPA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-9a1a5840-af83-5d07-a156-ba32a36c5c4b-common/-/monaco-vscode-9a1a5840-af83-5d07-a156-ba32a36c5c4b-common-18.1.3.tgz",
+      "integrity": "sha512-7iR5nVXkk+u9vvSJ/5Vsfz0pGrjoxnG0gKh0MoIuDDOsr4BRiYHCP5aHOzV3eIxdYsyUXlTXWzjxfvUmSm/dgQ==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-9a6d8b6c-ad4c-5ea3-9558-f43d6dc4c0ad-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-9a6d8b6c-ad4c-5ea3-9558-f43d6dc4c0ad-common/-/monaco-vscode-9a6d8b6c-ad4c-5ea3-9558-f43d6dc4c0ad-common-15.0.2.tgz",
-      "integrity": "sha512-ka4sYGK3SQ9jVPXSUP+SoCp1bMTIc90TL87pu+VMI9yo2NKq5f85y51Aibq/Vo5DBovkHB/FNSZMGAkWKf/mUA==",
+    "node_modules/@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common/-/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common-18.1.3.tgz",
+      "integrity": "sha512-3HNLxqEoyv5DtbzR2No9/cW29wCkQu3Uw7W4C4Ow6wY3G33zpYnMWwL/GxqtJH9dnzcIKbvwg5F5hF87QJhZBA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-1bb39316-6fbf-572e-ab6a-818a2496c14f-common": "15.0.2",
-        "@codingame/monaco-vscode-2e69e120-617a-5258-95e0-3b8902f4e014-common": "15.0.2",
-        "@codingame/monaco-vscode-52bb4d5b-ba1a-57fd-9bee-b28824214eac-common": "15.0.2",
-        "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "15.0.2",
-        "@codingame/monaco-vscode-7ba0af96-90c2-5e11-ad7f-befdbbf246c8-common": "15.0.2",
-        "@codingame/monaco-vscode-805e9c2f-56b6-5a43-8b5b-d2dc2d3805fc-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-9b5a5e82-d649-5455-b4bf-ef90d6afd294-common": "15.0.2",
-        "@codingame/monaco-vscode-a3f28a41-ba19-5a7e-8f5a-d6c1403b507d-common": "15.0.2",
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-c4e2825a-b5b1-5f0e-b547-068c32e06d50-common": "15.0.2",
-        "@codingame/monaco-vscode-d56fc266-2991-5e70-8f69-134ad70e1700-common": "15.0.2",
-        "marked": "14.0.0"
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-9b5a5e82-d649-5455-b4bf-ef90d6afd294-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-9b5a5e82-d649-5455-b4bf-ef90d6afd294-common/-/monaco-vscode-9b5a5e82-d649-5455-b4bf-ef90d6afd294-common-15.0.2.tgz",
-      "integrity": "sha512-AVrF/77g2A/L38bJ2vxM4VnJsV+o24kMNOViWJoF8GT1VVDg3MjsWHLFPQOudGm64tWgx2X7CyVVGKBqXruuHg==",
+    "node_modules/@codingame/monaco-vscode-9c84f943-bcb5-5bcf-92a6-91f66a732f26-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-9c84f943-bcb5-5bcf-92a6-91f66a732f26-common/-/monaco-vscode-9c84f943-bcb5-5bcf-92a6-91f66a732f26-common-18.1.3.tgz",
+      "integrity": "sha512-+nEx0S/8A/Q6oPQLJe0oYcjw4HMxdLb0TRa3XKIsv0eYzF/pdg8kou2kEtpTP7H1nEBu3/HQ2c0n3gVyD2tfFw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-38f25ab8-ea30-5ba9-8a08-ae3308c297c0-common": "15.0.2",
-        "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "15.0.2",
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-c4e2825a-b5b1-5f0e-b547-068c32e06d50-common": "15.0.2",
-        "@codingame/monaco-vscode-d56fc266-2991-5e70-8f69-134ad70e1700-common": "15.0.2",
-        "@codingame/monaco-vscode-fdf643f9-94dd-5510-b97a-408abf26ad92-common": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-9d0168a3-519b-57f3-9bcc-89efc41f951a-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-9d0168a3-519b-57f3-9bcc-89efc41f951a-common/-/monaco-vscode-9d0168a3-519b-57f3-9bcc-89efc41f951a-common-15.0.2.tgz",
-      "integrity": "sha512-2UzdDFPya+d1LRrhyr+44/8IsIq5HvTfDOXQI6Yl3eGGAPQPTHbMd30tNl9uFftnG5Ha0AVYxwFDRJQ6Df14tA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-9d0168a3-519b-57f3-9bcc-89efc41f951a-common/-/monaco-vscode-9d0168a3-519b-57f3-9bcc-89efc41f951a-common-18.1.3.tgz",
+      "integrity": "sha512-TjiNqwhiXMQiPqeeJ3WJc9f2XTSVqk7cdsC2N32BjRliE2YmD/yu17KgK43iquMD/iMg1vFRqbQO3xRAGtBk0w==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-7ba0af96-90c2-5e11-ad7f-befdbbf246c8-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-93784a59-b4cf-520c-8339-f8104d3a4f3e-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-9ed6fe06-a052-57c2-a234-5d9b94d2e7e0-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-9ed6fe06-a052-57c2-a234-5d9b94d2e7e0-common/-/monaco-vscode-9ed6fe06-a052-57c2-a234-5d9b94d2e7e0-common-18.1.3.tgz",
+      "integrity": "sha512-8u1ZsCEk4/Yw4CFDlUiYYaEfzy52q5QfvhtFvc1C1Pq0F2nJqO8CYzWawb7ySmVv2kotypEbxjw+4Kz9XeT1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": "18.1.3",
+        "@codingame/monaco-vscode-93784a59-b4cf-520c-8339-f8104d3a4f3e-common": "18.1.3",
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-9ee79c1a-3f03-568b-8eac-b02513a98b68-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-9ee79c1a-3f03-568b-8eac-b02513a98b68-common/-/monaco-vscode-9ee79c1a-3f03-568b-8eac-b02513a98b68-common-18.1.3.tgz",
+      "integrity": "sha512-sdwU5CBy3yP7d0phYAR8LGoyKOgIyE1QRWbcPx5SepxaZKc+CbCXMzaUZCaqrp1JiavyOSOGG0YfE1fDZfXJ7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-8d39d04c-3201-5bd6-be79-eed8d17a5ad0-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common/-/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common-15.0.2.tgz",
-      "integrity": "sha512-BxdBZz6ScRuo7a4LIN98VRpXEJKEx9fUyJ0Kri1ze/QsrwnGBz2IGF7jFoTP3mTzUtKKQPBuvghbzvK8z0tvLQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common/-/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common-18.1.3.tgz",
+      "integrity": "sha512-aYzRZudyJaJ6OjZAH48ED132pOv+8vZywAlSZeN9F29L9f7VnC7ZKVRLFpkewohkNbW/klZxzduXgLas1Hfrbw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-2e69e120-617a-5258-95e0-3b8902f4e014-common": "15.0.2",
-        "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "15.0.2",
-        "@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-fdf643f9-94dd-5510-b97a-408abf26ad92-common": "15.0.2"
+        "@codingame/monaco-vscode-4ee27008-17b4-593f-9c09-19e8e3077f51-common": "18.1.3",
+        "@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": "18.1.3",
+        "@codingame/monaco-vscode-69cd7d65-4465-53e8-9718-bc4f6df50f7d-common": "18.1.3",
+        "@codingame/monaco-vscode-95ea5c7c-15cf-50aa-8e24-38039b06b4a6-common": "18.1.3",
+        "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "18.1.3",
+        "@codingame/monaco-vscode-a8d3bd74-e63e-5327-96e8-4f931661e329-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": "18.1.3",
+        "@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-a2719803-af40-5ae9-a29f-8a2231c33056-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-a2719803-af40-5ae9-a29f-8a2231c33056-common/-/monaco-vscode-a2719803-af40-5ae9-a29f-8a2231c33056-common-15.0.2.tgz",
-      "integrity": "sha512-D/Bos7Tx8sCsTFcnyDAO4ZlWIJuKnjY1mSKCb31bwcUDb0Izt+3Zsw+xN/4OOsHqZobskvA3kaJ3g22sCMwP9A==",
+    "node_modules/@codingame/monaco-vscode-a3eaa464-944c-5b8f-8886-213068ba4897-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-a3eaa464-944c-5b8f-8886-213068ba4897-common/-/monaco-vscode-a3eaa464-944c-5b8f-8886-213068ba4897-common-18.1.3.tgz",
+      "integrity": "sha512-6Bh/iNPAo9s5lxVjvuQnQDHhtxVTuSEc1IyfiHvgJS1s/guZieeJGwXYmCvwwelDjr4s0iuvcIx6nbmWb9huaQ==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-a3f28a41-ba19-5a7e-8f5a-d6c1403b507d-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-a3f28a41-ba19-5a7e-8f5a-d6c1403b507d-common/-/monaco-vscode-a3f28a41-ba19-5a7e-8f5a-d6c1403b507d-common-15.0.2.tgz",
-      "integrity": "sha512-QNUfOAH6utrekJoKIO9s+wLPLQK4VEQUxrFHD7Rrv2PHj8YIcOM9sKfSuICilLmDQz9tp3RRh9kO6BVjXMj5jQ==",
+    "node_modules/@codingame/monaco-vscode-a4683c2b-a0d2-5112-96ba-eedc605346d2-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-a4683c2b-a0d2-5112-96ba-eedc605346d2-common/-/monaco-vscode-a4683c2b-a0d2-5112-96ba-eedc605346d2-common-18.1.3.tgz",
+      "integrity": "sha512-wl+AR4PcKRG9CSuJsILBrtpCW83xmBqDYqRHo9pU4QB8frRpM59xh8oFW8+mdgSa1cyX6d+owrefXI2a70lOWA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-1bb39316-6fbf-572e-ab6a-818a2496c14f-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common/-/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common-15.0.2.tgz",
-      "integrity": "sha512-0mE/43ivJDlyCGrFavJml7GWJ5y5dM9Lwe75pRzCmeNXGKTUNrgDwX/wvAbZH5jo9OOLVqpHUmpsIqOfyG59RA==",
+    "node_modules/@codingame/monaco-vscode-a8d3bd74-e63e-5327-96e8-4f931661e329-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-a8d3bd74-e63e-5327-96e8-4f931661e329-common/-/monaco-vscode-a8d3bd74-e63e-5327-96e8-4f931661e329-common-18.1.3.tgz",
+      "integrity": "sha512-329x1rsU24qzKwHc5QtFnrfh8Nx1Gqjok7uVpAhgM/dOw75z7kQkDmmGf1/+PsHwwB1uYjqT5mHcNAgChuvaLw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
-      }
-    },
-    "node_modules/@codingame/monaco-vscode-a7c9ae3c-16d2-5d17-86b2-981be7094566-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-a7c9ae3c-16d2-5d17-86b2-981be7094566-common/-/monaco-vscode-a7c9ae3c-16d2-5d17-86b2-981be7094566-common-15.0.2.tgz",
-      "integrity": "sha512-mTMFpzR6ZY5eimtEbBUjlvnDgTnuU8SrYnmXQylXagoZ5ea/bDhZA/hh2WlgLrkwUJ+FgCrQUbyv4VQ40fEOcw==",
-      "license": "MIT",
-      "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-ab07af84-42e8-5a0f-8aef-b83fb90ede21-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-ab07af84-42e8-5a0f-8aef-b83fb90ede21-common/-/monaco-vscode-ab07af84-42e8-5a0f-8aef-b83fb90ede21-common-15.0.2.tgz",
-      "integrity": "sha512-wrFz50JBi7mdMCnmAQ5yQrl1W0ai7z84kKw2tqWlhTI8gAPqxfJqzXDG/ky4sRIns5kWQuU5yBYi3cYUbKefNg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-ab07af84-42e8-5a0f-8aef-b83fb90ede21-common/-/monaco-vscode-ab07af84-42e8-5a0f-8aef-b83fb90ede21-common-18.1.3.tgz",
+      "integrity": "sha512-04LsSz5gaOF8alNUjc53sJfKY3i8DzHhIOIppMiH7gCY3iHmOI7fCXY/GfIBrobWUipGISyg3oA80YT+wWosoA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-abed5a84-8a82-5f84-9412-88a736235bae-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-abed5a84-8a82-5f84-9412-88a736235bae-common/-/monaco-vscode-abed5a84-8a82-5f84-9412-88a736235bae-common-15.0.2.tgz",
-      "integrity": "sha512-o+IJzhVvpVcfAEF0mNg9iUHyzYIdfKTftC6aojVv/xZAPf2M80dURmhCyCcGjxztGDHZl7e84cm0CSUOQ26RNw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-abed5a84-8a82-5f84-9412-88a736235bae-common/-/monaco-vscode-abed5a84-8a82-5f84-9412-88a736235bae-common-18.1.3.tgz",
+      "integrity": "sha512-DnkZ7Ljx3bMNlzhbhLx7VElBBrQ1AWLhVHYIsJD5hyN4pgduEM96iSUiO92B5f6Z6iPKC3Zcxi0jgTWKIkEaMw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
-      }
-    },
-    "node_modules/@codingame/monaco-vscode-ad89fae6-94f0-5ac2-a185-22dea4b68ee0-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-ad89fae6-94f0-5ac2-a185-22dea4b68ee0-common/-/monaco-vscode-ad89fae6-94f0-5ac2-a185-22dea4b68ee0-common-15.0.2.tgz",
-      "integrity": "sha512-pmr0Vc+jmtZPP1tkyicMmTNclw7DQwdkkpSm0nN8JpnlRlmEyaw9nsuVODsjqcZhjOMUSDAACndgsqjN49EFYA==",
-      "license": "MIT",
-      "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-2e69e120-617a-5258-95e0-3b8902f4e014-common": "15.0.2",
-        "@codingame/monaco-vscode-38f25ab8-ea30-5ba9-8a08-ae3308c297c0-common": "15.0.2",
-        "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-fdf643f9-94dd-5510-b97a-408abf26ad92-common": "15.0.2"
-      }
-    },
-    "node_modules/@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common/-/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common-15.0.2.tgz",
-      "integrity": "sha512-RMubUplntAaj2hSj0PnPD3fkjspZ19dIFobkwtFMMZeVQqHQ74HcneiVfXr1yujhW8LlCYagp02teSjW6go9GA==",
-      "license": "MIT",
-      "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-fdf643f9-94dd-5510-b97a-408abf26ad92-common": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-api": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-15.0.2.tgz",
-      "integrity": "sha512-hoSiyyE1Jm+Gx7b4sQioE25CniuODomOqIsjkZwQcMb+N/FrTmSrSGDxx0GIZrvsLCmowI4S4vILDUKB4UAP7w==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-api/-/monaco-vscode-api-18.1.3.tgz",
+      "integrity": "sha512-ZVYh3Vd6Frvcfx/F0QjXontURXET7/J4CMxzn5SKAe6CfqDG0xVMV9VjQ3RHX7tutSV9vWBIZLtic0+X5r0iGA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-base-service-override": "15.0.2",
-        "@codingame/monaco-vscode-environment-service-override": "15.0.2",
-        "@codingame/monaco-vscode-extensions-service-override": "15.0.2",
-        "@codingame/monaco-vscode-files-service-override": "15.0.2",
-        "@codingame/monaco-vscode-host-service-override": "15.0.2",
-        "@codingame/monaco-vscode-layout-service-override": "15.0.2",
-        "@codingame/monaco-vscode-quickaccess-service-override": "15.0.2",
+        "@codingame/monaco-vscode-base-service-override": "18.1.3",
+        "@codingame/monaco-vscode-environment-service-override": "18.1.3",
+        "@codingame/monaco-vscode-extensions-service-override": "18.1.3",
+        "@codingame/monaco-vscode-files-service-override": "18.1.3",
+        "@codingame/monaco-vscode-host-service-override": "18.1.3",
+        "@codingame/monaco-vscode-layout-service-override": "18.1.3",
+        "@codingame/monaco-vscode-quickaccess-service-override": "18.1.3",
+        "@vscode/iconv-lite-umd": "0.7.0",
+        "dompurify": "3.2.6",
+        "jschardet": "3.1.4",
         "marked": "14.0.0"
       }
     },
-    "node_modules/@codingame/monaco-vscode-b1249c5b-1339-5278-b002-746f08105c6d-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-b1249c5b-1339-5278-b002-746f08105c6d-common/-/monaco-vscode-b1249c5b-1339-5278-b002-746f08105c6d-common-15.0.2.tgz",
-      "integrity": "sha512-k4t1jvaxq8+1GBlwR0TuCHCHsVe/WRJy50e4Aj55W1IRaYyo8q4mw6aNbxN/ZoqFcxLjKCDiff70yeGjfexIwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
-      }
-    },
     "node_modules/@codingame/monaco-vscode-b1e8558d-1726-5299-bc75-e43ee6d1a124-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-b1e8558d-1726-5299-bc75-e43ee6d1a124-common/-/monaco-vscode-b1e8558d-1726-5299-bc75-e43ee6d1a124-common-15.0.2.tgz",
-      "integrity": "sha512-JIwDNq6ta1ZO7ri3E1wjJvRsQtkY/ZhT4eCa1d8ipy5w9TsaJuLvPFPsjBGax2IA6GTCrxLxKOWsHfyBUQA0vw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-b1e8558d-1726-5299-bc75-e43ee6d1a124-common/-/monaco-vscode-b1e8558d-1726-5299-bc75-e43ee6d1a124-common-18.1.3.tgz",
+      "integrity": "sha512-JaJ1zc2XNSrCWJmczAcKuqVEq16jqNY5btY8KpKQcU72owpFHVZUlw30wpAaaUX/kMUFnNgilA46XuwvLLif1Q==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-2e67e044-0db9-5fa6-8bd1-3737a7d586d4-common": "15.0.2",
-        "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "15.0.2",
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-ad89fae6-94f0-5ac2-a185-22dea4b68ee0-common": "15.0.2",
-        "@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-c4e2825a-b5b1-5f0e-b547-068c32e06d50-common": "15.0.2",
-        "@codingame/monaco-vscode-fdf643f9-94dd-5510-b97a-408abf26ad92-common": "15.0.2"
+        "@codingame/monaco-vscode-4ee27008-17b4-593f-9c09-19e8e3077f51-common": "18.1.3",
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "18.1.3",
+        "@codingame/monaco-vscode-a4683c2b-a0d2-5112-96ba-eedc605346d2-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-c3c61c00-c254-5856-9dc9-d7929c1f9062-common": "18.1.3",
+        "@codingame/monaco-vscode-f5d4b045-44e8-55a8-b683-308656a412fa-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-b71b5434-ce96-5581-8993-e8da380bd63f-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-b71b5434-ce96-5581-8993-e8da380bd63f-common/-/monaco-vscode-b71b5434-ce96-5581-8993-e8da380bd63f-common-15.0.2.tgz",
-      "integrity": "sha512-6A11la9Qz30uYzfNwNKyoi5xaA7sq3mrzHLGfNJmkjCKyp+ntTBiULkNxchNOqTbNXR0VD8M2QSoFkBAvk0pIA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-b71b5434-ce96-5581-8993-e8da380bd63f-common/-/monaco-vscode-b71b5434-ce96-5581-8993-e8da380bd63f-common-18.1.3.tgz",
+      "integrity": "sha512-4coaCQQqeLrV8v3h2HRLtqjuzrRTly6V0SuvIU6vl1rhCBueoXsBGkX/8dOwGcee/FY2ER+MtbMTUvoGel9GhA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "15.0.2",
-        "@codingame/monaco-vscode-7559b0be-bfa5-5fe6-b731-1973fe9fffa1-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-d56fc266-2991-5e70-8f69-134ad70e1700-common": "15.0.2"
+        "@codingame/monaco-vscode-158b9837-fc78-5d9c-86f5-9134e4358643-common": "18.1.3",
+        "@codingame/monaco-vscode-3cf6a388-482f-5484-a806-0525ad9ad8af-common": "18.1.3",
+        "@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-a8d3bd74-e63e-5327-96e8-4f931661e329-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-b99aef83-0d60-5e8c-a62e-9908b6256f35-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-b99aef83-0d60-5e8c-a62e-9908b6256f35-common/-/monaco-vscode-b99aef83-0d60-5e8c-a62e-9908b6256f35-common-18.1.3.tgz",
+      "integrity": "sha512-xKvh61zf20PNEB48wt2BZXq2WwbZLwcD9qiOa/NSMXrP3WCZleRaE9Bg7/IO8TS0RgtwfM0iTri2FZXGHo+w7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-fc42f049-7883-579d-bb0b-2aa1010a19a8-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-base-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-15.0.2.tgz",
-      "integrity": "sha512-NApfW6rJUS/JmbGCcLpywRRUEhc2hXT3hbymjQGoJ/SfIAssV+rS0B+3vV2/PVc5It+lz+gK9s9w76CHCAsbgQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-base-service-override/-/monaco-vscode-base-service-override-18.1.3.tgz",
+      "integrity": "sha512-QFMJZEicuBVZjgSQZhCNgEejUJ2V4s55GuOVvEhonf8k32f+MUaAWkdMcjOTNQhPsga2BvQpgAW6Q0La+PZ4fw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-039b5553-0838-562a-97c2-30d6e54a7b42-common": "15.0.2",
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common": "15.0.2",
-        "@codingame/monaco-vscode-7559b0be-bfa5-5fe6-b731-1973fe9fffa1-common": "15.0.2",
-        "@codingame/monaco-vscode-9a1a5840-af83-5d07-a156-ba32a36c5c4b-common": "15.0.2",
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-d987325e-3e05-53aa-b9ff-6f97476f64db-common": "15.0.2"
+        "@codingame/monaco-vscode-158b9837-fc78-5d9c-86f5-9134e4358643-common": "18.1.3",
+        "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-93784a59-b4cf-520c-8339-f8104d3a4f3e-common": "18.1.3",
+        "@codingame/monaco-vscode-9a1a5840-af83-5d07-a156-ba32a36c5c4b-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-d987325e-3e05-53aa-b9ff-6f97476f64db-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-bba55be6-41a2-50cd-a3cc-8bafa35bfa89-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-bba55be6-41a2-50cd-a3cc-8bafa35bfa89-common/-/monaco-vscode-bba55be6-41a2-50cd-a3cc-8bafa35bfa89-common-15.0.2.tgz",
-      "integrity": "sha512-KlcPmFOl4wkv5MVxcZ1c+GJqbnXn5wxhhWTbq73cIaMTz58FV1g5XlRfb87+W9Lekr8jur+4uficzSFYf8Dusw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-bba55be6-41a2-50cd-a3cc-8bafa35bfa89-common/-/monaco-vscode-bba55be6-41a2-50cd-a3cc-8bafa35bfa89-common-18.1.3.tgz",
+      "integrity": "sha512-DEU7ILAcWzVXn0aD8pU5nY8+FvGEVMkefTF9e2pjioPljdYHbVLY/4tYalMzrt/ShFJiRYtZmknbCePap+CGLQ==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "15.0.2",
-        "@codingame/monaco-vscode-9b5a5e82-d649-5455-b4bf-ef90d6afd294-common": "15.0.2",
-        "@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-4372ad43-a220-5e78-83e6-95a9cfd64384-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-a4683c2b-a0d2-5112-96ba-eedc605346d2-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-bd6ad8b7-9db3-51a8-9895-0046508c029d-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-bd6ad8b7-9db3-51a8-9895-0046508c029d-common/-/monaco-vscode-bd6ad8b7-9db3-51a8-9895-0046508c029d-common-15.0.2.tgz",
-      "integrity": "sha512-aM1FtyF1FU0Lqm0l2jZIkhpLgh5yX+tUksKLFxVfSgOpSOaGkZFxQgzRmekJQhgFgrRdukf7IcNb/dpk4GU/lQ==",
+    "node_modules/@codingame/monaco-vscode-bc8c28cd-7a80-54a9-af1a-e6b1e7a7f34a-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-bc8c28cd-7a80-54a9-af1a-e6b1e7a7f34a-common/-/monaco-vscode-bc8c28cd-7a80-54a9-af1a-e6b1e7a7f34a-common-18.1.3.tgz",
+      "integrity": "sha512-+ul5WkfLxq8H7UNcrm6uKs7M0XSwGPqWBuGWgspltzcqF2N0gDEx9OCJTwqpaVS5URKL48bvCeM+padxotUlwg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
-      }
-    },
-    "node_modules/@codingame/monaco-vscode-be8ddbb5-094a-5657-b1cc-fe106c94c632-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-be8ddbb5-094a-5657-b1cc-fe106c94c632-common/-/monaco-vscode-be8ddbb5-094a-5657-b1cc-fe106c94c632-common-15.0.2.tgz",
-      "integrity": "sha512-ghZ5ejDZhlH1FJz5j4NnY+hhmMfGvFiV2aw9LyaqssrplO22jvxEHMA9lM0xHEM4WcDKarsv+VaQ9tVIHUGpHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-1cb11a73-359e-5a2f-9e95-6989cc9858ee-common": "18.1.3",
+        "@codingame/monaco-vscode-4372ad43-a220-5e78-83e6-95a9cfd64384-common": "18.1.3",
+        "@codingame/monaco-vscode-47472025-cc45-5680-86cd-09ceaba921a1-common": "18.1.3",
+        "@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": "18.1.3",
+        "@codingame/monaco-vscode-85f7fb0f-70f5-5a5e-831b-15c743a8bd11-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-9ed6fe06-a052-57c2-a234-5d9b94d2e7e0-common": "18.1.3",
+        "@codingame/monaco-vscode-a4683c2b-a0d2-5112-96ba-eedc605346d2-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": "18.1.3",
+        "@codingame/monaco-vscode-e28ac690-06d5-5ee9-92d1-02df70296354-common": "18.1.3",
+        "@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common": "18.1.3",
+        "@codingame/monaco-vscode-f338ac19-278c-5fe1-bec8-b588de04a788-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-bf94ddb5-e436-506a-9763-5ab86b642508-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-bf94ddb5-e436-506a-9763-5ab86b642508-common/-/monaco-vscode-bf94ddb5-e436-506a-9763-5ab86b642508-common-15.0.2.tgz",
-      "integrity": "sha512-ucOOfIxAFe5lFD2dwf7YMesclMzlsW+ilZSqqFmdcmb3EF4aQ+WuemBQl34bmmn5L6jiGOvaN5UfYdv5DoLU/Q==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-bf94ddb5-e436-506a-9763-5ab86b642508-common/-/monaco-vscode-bf94ddb5-e436-506a-9763-5ab86b642508-common-18.1.3.tgz",
+      "integrity": "sha512-gwhnNt7wb4+FtoH5OsVLn4qkjE0gfV2gGmMC5cPkUooDA/+jpo9Xz96AAP1qS5ZFuU9f1hHOKz1/2Y2BY8Pj3Q==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-bulk-edit-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-bulk-edit-service-override/-/monaco-vscode-bulk-edit-service-override-15.0.2.tgz",
-      "integrity": "sha512-QISWI6Q0BPPxatVPtI63dQHXP1VOHrO6JKD9aqdXZo7+SL7bpszsqOvbejpf0J2WUIjOdvle+7mx0R0OYHLLjg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-bulk-edit-service-override/-/monaco-vscode-bulk-edit-service-override-18.1.3.tgz",
+      "integrity": "sha512-GihiHmJBq2PRPZuHJvD7euVy58zR5LprkeHPwFE/oieML9KI09n1g2Jodp2/DSB8gU9R/rp/1cVfFYO37MPM9A==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "15.0.2",
-        "@codingame/monaco-vscode-9a6d8b6c-ad4c-5ea3-9558-f43d6dc4c0ad-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-4372ad43-a220-5e78-83e6-95a9cfd64384-common": "18.1.3",
+        "@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": "18.1.3",
+        "@codingame/monaco-vscode-a8d3bd74-e63e-5327-96e8-4f931661e329-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-c3b3387c-7bce-5b8f-9e14-bebeb636f1c8-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-c3b3387c-7bce-5b8f-9e14-bebeb636f1c8-common/-/monaco-vscode-c3b3387c-7bce-5b8f-9e14-bebeb636f1c8-common-15.0.2.tgz",
-      "integrity": "sha512-tgNGU+PorIwbxCWEHjEwZMDYKAtMp7vu9IDkZZrFXx68Ol9n6949+3w5j3To8tMg6w6e1Y9YmpdDHfDXMVAXsQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-c3b3387c-7bce-5b8f-9e14-bebeb636f1c8-common/-/monaco-vscode-c3b3387c-7bce-5b8f-9e14-bebeb636f1c8-common-18.1.3.tgz",
+      "integrity": "sha512-5XmO0ZG9zgoUN4NRt1juXzcdVzNTrK79F25kpgGsjtRe6T2gLUfvuhaUNICZfsJGYzoKtzQ1oJj0vKIK4vFAlg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-0f5ced28-abde-558b-8652-db8e7d4d64aa-common": "15.0.2",
-        "@codingame/monaco-vscode-422642f2-7e3a-5c1c-9e1e-1d3ef1817346-common": "15.0.2",
-        "@codingame/monaco-vscode-52bb4d5b-ba1a-57fd-9bee-b28824214eac-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-b1249c5b-1339-5278-b002-746f08105c6d-common": "15.0.2"
+        "@codingame/monaco-vscode-422642f2-7e3a-5c1c-9e1e-1d3ef1817346-common": "18.1.3",
+        "@codingame/monaco-vscode-7869cfe8-f42c-5721-9f2b-7d04a6a41f16-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-c87fff3a-2aa9-52ab-ba4d-17e8d1e5e185-common": "18.1.3",
+        "@codingame/monaco-vscode-ce7c734f-7712-563c-9335-d7acb43306af-common": "18.1.3"
       }
     },
-    "node_modules/@codingame/monaco-vscode-c4e2825a-b5b1-5f0e-b547-068c32e06d50-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-c4e2825a-b5b1-5f0e-b547-068c32e06d50-common/-/monaco-vscode-c4e2825a-b5b1-5f0e-b547-068c32e06d50-common-15.0.2.tgz",
-      "integrity": "sha512-EcN1gJVQTqZ+Hj6Ij/w2zveDrRZV25HS8y/ufJ5xabm7f7b+3I2wH9t7UoYK1cTLJHwV0Ek2QW5QR2WbkCLxww==",
+    "node_modules/@codingame/monaco-vscode-c3c61c00-c254-5856-9dc9-d7929c1f9062-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-c3c61c00-c254-5856-9dc9-d7929c1f9062-common/-/monaco-vscode-c3c61c00-c254-5856-9dc9-d7929c1f9062-common-18.1.3.tgz",
+      "integrity": "sha512-dXGyDxIkjnCp4dxvEXxe29BsAIb91fqmt6f+nrPzkTetjlquPm0yLNJVSVo4r0rAkVAK96lal53biSaBSBVe/w==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "15.0.2",
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-fdf643f9-94dd-5510-b97a-408abf26ad92-common": "15.0.2"
+        "@codingame/monaco-vscode-0094ae09-a688-53e7-bacc-93e26f7f49db-common": "18.1.3",
+        "@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "18.1.3",
+        "@codingame/monaco-vscode-a4683c2b-a0d2-5112-96ba-eedc605346d2-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": "18.1.3",
+        "@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common": "18.1.3",
+        "@codingame/monaco-vscode-f48982c4-9e82-55e2-b800-20e6d1e6096f-common": "18.1.3",
+        "@codingame/monaco-vscode-fc3b1755-9783-51f9-b3e6-45e7ef6fe6e3-common": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-c465110a-57c0-59d7-a6b2-be0a4db7e517-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-c465110a-57c0-59d7-a6b2-be0a4db7e517-common/-/monaco-vscode-c465110a-57c0-59d7-a6b2-be0a4db7e517-common-18.1.3.tgz",
+      "integrity": "sha512-1ToeIZdV6hIRx0GSyKWj+kx5GSShLwGlGprlKxzxPUmDdV0zKkAy13uVYJHL2v6+BvJEUI6c7z0h8An9Phfylw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-1ba786a5-b7d7-5d26-8a85-ae48ee2a74a4-common": "18.1.3",
+        "@codingame/monaco-vscode-3a35f433-1297-5707-ab58-c261b8180e6d-common": "18.1.3",
+        "@codingame/monaco-vscode-3cf6a388-482f-5484-a806-0525ad9ad8af-common": "18.1.3",
+        "@codingame/monaco-vscode-4372ad43-a220-5e78-83e6-95a9cfd64384-common": "18.1.3",
+        "@codingame/monaco-vscode-47472025-cc45-5680-86cd-09ceaba921a1-common": "18.1.3",
+        "@codingame/monaco-vscode-6c0f93b9-169c-58c3-a9cb-7d60698eb52c-common": "18.1.3",
+        "@codingame/monaco-vscode-7adbeffb-8051-54a9-8c9b-b62ce9e5836f-common": "18.1.3",
+        "@codingame/monaco-vscode-8d39d04c-3201-5bd6-be79-eed8d17a5ad0-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-93784a59-b4cf-520c-8339-f8104d3a4f3e-common": "18.1.3",
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-9ed6fe06-a052-57c2-a234-5d9b94d2e7e0-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-c87fff3a-2aa9-52ab-ba4d-17e8d1e5e185-common": "18.1.3",
+        "@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common": "18.1.3",
+        "@codingame/monaco-vscode-fab30422-b487-5f4e-8d30-8b4d266e3fcd-common": "18.1.3",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-c87fff3a-2aa9-52ab-ba4d-17e8d1e5e185-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-c87fff3a-2aa9-52ab-ba4d-17e8d1e5e185-common/-/monaco-vscode-c87fff3a-2aa9-52ab-ba4d-17e8d1e5e185-common-18.1.3.tgz",
+      "integrity": "sha512-6kevMdaj9zbGPcWoEQuy8///HY/wcbcX69hRMJzjb3vuDgrC1ezyGYkG2F5z87M3sHIAL6dPztjXkDsZGFMN2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-ce7c734f-7712-563c-9335-d7acb43306af-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-ce7c734f-7712-563c-9335-d7acb43306af-common/-/monaco-vscode-ce7c734f-7712-563c-9335-d7acb43306af-common-18.1.3.tgz",
+      "integrity": "sha512-XshqhvAlbi+8F91xzBIyJs/kCCyM9aMqw4vRKj6yK5yM3kIdzQw82LbJHch1E09sdnptFhnVftnjip0ylOtQBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-cea4d01f-6526-5c2f-8b09-b168fead499f-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-cea4d01f-6526-5c2f-8b09-b168fead499f-common/-/monaco-vscode-cea4d01f-6526-5c2f-8b09-b168fead499f-common-15.0.2.tgz",
-      "integrity": "sha512-XqZN0s440ipfNmztYZKZ5rexUydQCNNnw9UsVhsh2VZYSWdUjmojxz6dn5uphHgWdIZv9/TiuE1VNtdEEs4tZA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-cea4d01f-6526-5c2f-8b09-b168fead499f-common/-/monaco-vscode-cea4d01f-6526-5c2f-8b09-b168fead499f-common-18.1.3.tgz",
+      "integrity": "sha512-/wN1xYAdNpmLBYf0+fCZI3OG5rbSN9mfqj+o7bX9+CPAoE71pgIIJaQ06i/4hToTYhcuk2+ZAItIgE+6JzljiQ==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-cecd476b-6f89-54b7-b016-fe6fdaa6675e-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-cecd476b-6f89-54b7-b016-fe6fdaa6675e-common/-/monaco-vscode-cecd476b-6f89-54b7-b016-fe6fdaa6675e-common-18.1.3.tgz",
+      "integrity": "sha512-psV3eTXodCPMbxIjI3lfE2L2EdssidJyvKnDpKdr6BYaDJFqkzQSlaFWeGvDEHtI1sxdrsmvw6KlZ01lRxIaOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-configuration-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-configuration-service-override/-/monaco-vscode-configuration-service-override-15.0.2.tgz",
-      "integrity": "sha512-pC63gLhK4dszUSGWj1kjKL09K5GPkhX+IhshnZpbpzVIiLIdsKAOoKiRZylx3v6288SMWwvpX6ME7Of6Ol7V7A==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-configuration-service-override/-/monaco-vscode-configuration-service-override-18.1.3.tgz",
+      "integrity": "sha512-JSDE3CV5BF2zG6l+djuKjQG9/kEicd9ga46PJWmuI8/EoCJIRQqn9q+muYjzC7CFp5p75xTN4+6ofTABUOmY0Q==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-422642f2-7e3a-5c1c-9e1e-1d3ef1817346-common": "15.0.2",
-        "@codingame/monaco-vscode-7559b0be-bfa5-5fe6-b731-1973fe9fffa1-common": "15.0.2",
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-b1249c5b-1339-5278-b002-746f08105c6d-common": "15.0.2",
-        "@codingame/monaco-vscode-d987325e-3e05-53aa-b9ff-6f97476f64db-common": "15.0.2",
-        "@codingame/monaco-vscode-files-service-override": "15.0.2"
+        "@codingame/monaco-vscode-158b9837-fc78-5d9c-86f5-9134e4358643-common": "18.1.3",
+        "@codingame/monaco-vscode-422642f2-7e3a-5c1c-9e1e-1d3ef1817346-common": "18.1.3",
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-ce7c734f-7712-563c-9335-d7acb43306af-common": "18.1.3",
+        "@codingame/monaco-vscode-d987325e-3e05-53aa-b9ff-6f97476f64db-common": "18.1.3",
+        "@codingame/monaco-vscode-files-service-override": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-cpp-default-extension": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-cpp-default-extension/-/monaco-vscode-cpp-default-extension-15.0.2.tgz",
-      "integrity": "sha512-a/4uYe4gLVcFJyjeHXp/JQzFz1LB9v+eH3DJjRaWYP419EhIHbmfDdC6P8FvvdKy3UJ8hUgVzSfOZ6g2G2Hc+A==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-cpp-default-extension/-/monaco-vscode-cpp-default-extension-18.1.3.tgz",
+      "integrity": "sha512-eiNfnRnfxymn9Zsp5s8OuWaP9fjHPa2IkBXW2negLvb3Zj6dAlX/+3lFBAgGXJ46aU7bSN+/NeexeQuR7dwASA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-d26a96d3-122c-5a3d-a04d-deb5ff0f19c0-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-d26a96d3-122c-5a3d-a04d-deb5ff0f19c0-common/-/monaco-vscode-d26a96d3-122c-5a3d-a04d-deb5ff0f19c0-common-18.1.3.tgz",
+      "integrity": "sha512-Cuvc2nV/qZa4AoROJqnzdoC8FkITNOLIgDvrrC5PIXGWhw21RjobAOU12SobwBCrmdsOUjODmuyoG33m2gp/Cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-2a94c04a-b85b-5669-b06b-89c1bfa11cb9-common": "18.1.3",
+        "@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-d481a59e-259c-524e-bee1-76483d75d3a1-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-d481a59e-259c-524e-bee1-76483d75d3a1-common/-/monaco-vscode-d481a59e-259c-524e-bee1-76483d75d3a1-common-15.0.2.tgz",
-      "integrity": "sha512-nO+nKlZfoozH6WjGCnkS//8mQxrL4iI5P84vtmriYWiOz9Fj3CJVKFmu2ZBLV7ilD+QIXigXCa9vUtfH2JWNkw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-d481a59e-259c-524e-bee1-76483d75d3a1-common/-/monaco-vscode-d481a59e-259c-524e-bee1-76483d75d3a1-common-18.1.3.tgz",
+      "integrity": "sha512-5JfFl4/X3DG962uY4e/EfcNkmYi72D+v/H2GfhcJhEGr1hAroEeLo6x9zWLp4wz2wczuNqaN1qMqWHTbqXMoxA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-523730aa-81e6-55d7-9916-87ad537fe087-common": "15.0.2",
-        "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "15.0.2",
-        "@codingame/monaco-vscode-9b5a5e82-d649-5455-b4bf-ef90d6afd294-common": "15.0.2",
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-a7c9ae3c-16d2-5d17-86b2-981be7094566-common": "15.0.2",
-        "@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-b1e8558d-1726-5299-bc75-e43ee6d1a124-common": "15.0.2",
-        "@codingame/monaco-vscode-c4e2825a-b5b1-5f0e-b547-068c32e06d50-common": "15.0.2",
-        "@codingame/monaco-vscode-fdf643f9-94dd-5510-b97a-408abf26ad92-common": "15.0.2"
-      }
-    },
-    "node_modules/@codingame/monaco-vscode-d56fc266-2991-5e70-8f69-134ad70e1700-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-d56fc266-2991-5e70-8f69-134ad70e1700-common/-/monaco-vscode-d56fc266-2991-5e70-8f69-134ad70e1700-common-15.0.2.tgz",
-      "integrity": "sha512-AiYTjTrbpvbyNR9G95cUmBvevNZKapKQS0IvRzFvBsI9ciZTvbTjsGWrj72m+trttUhiQ2ioh1qWpBfid7pPwg==",
-      "license": "MIT",
-      "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-2e69e120-617a-5258-95e0-3b8902f4e014-common": "15.0.2",
-        "@codingame/monaco-vscode-38f25ab8-ea30-5ba9-8a08-ae3308c297c0-common": "15.0.2",
-        "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "15.0.2",
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-ad89fae6-94f0-5ac2-a185-22dea4b68ee0-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-c4e2825a-b5b1-5f0e-b547-068c32e06d50-common": "15.0.2"
+        "@codingame/monaco-vscode-523730aa-81e6-55d7-9916-87ad537fe087-common": "18.1.3",
+        "@codingame/monaco-vscode-937ecbdf-94c7-5b16-aefa-ad78ae557a93-common": "18.1.3",
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "18.1.3",
+        "@codingame/monaco-vscode-a4683c2b-a0d2-5112-96ba-eedc605346d2-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-b1e8558d-1726-5299-bc75-e43ee6d1a124-common": "18.1.3",
+        "@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": "18.1.3",
+        "@codingame/monaco-vscode-f5d4b045-44e8-55a8-b683-308656a412fa-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-d609a7d3-bf87-551a-884f-550a8b327ec5-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-d609a7d3-bf87-551a-884f-550a8b327ec5-common/-/monaco-vscode-d609a7d3-bf87-551a-884f-550a8b327ec5-common-15.0.2.tgz",
-      "integrity": "sha512-J5YNlKjwAm/nyESCm96GqezvOmMyRrfBGhvpAWAcln5awLFETTlr7x3XbNgHBLCqi3MnpdZTY+W+pR4zRmTCKA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-d609a7d3-bf87-551a-884f-550a8b327ec5-common/-/monaco-vscode-d609a7d3-bf87-551a-884f-550a8b327ec5-common-18.1.3.tgz",
+      "integrity": "sha512-lzIXfOzZfprFtH30jxUkFBMpFfENqhrhoPrdQvc4orq0QXi7gzHOxPxzUgl9CTuhjTAZNPxi+sphCJGhVCXsbg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
-      }
-    },
-    "node_modules/@codingame/monaco-vscode-d7f659f5-da33-5ea8-a3b8-9b94f2cf5f33-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-d7f659f5-da33-5ea8-a3b8-9b94f2cf5f33-common/-/monaco-vscode-d7f659f5-da33-5ea8-a3b8-9b94f2cf5f33-common-15.0.2.tgz",
-      "integrity": "sha512-PLfB4PGtrRACUPhFdN5PtMkli9mC/xScrPdapS7f2LrLoGfiiX1qi3jn/ovCBCNd/45CCBFFK6TvJoHYp2PImQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-7559b0be-bfa5-5fe6-b731-1973fe9fffa1-common": "15.0.2",
-        "@codingame/monaco-vscode-a2719803-af40-5ae9-a29f-8a2231c33056-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
-      }
-    },
-    "node_modules/@codingame/monaco-vscode-d8236b3b-b91a-522d-89f4-94d70a546f6a-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-d8236b3b-b91a-522d-89f4-94d70a546f6a-common/-/monaco-vscode-d8236b3b-b91a-522d-89f4-94d70a546f6a-common-15.0.2.tgz",
-      "integrity": "sha512-T13joFSRpmrmC7L0IvNb+xP1r061v0OMf8E/fbLbO7+LweuodX4nulkbBvSp0Rgx/75wcsT3jQ2LoHA8rZZHjg==",
-      "license": "MIT",
-      "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-2e69e120-617a-5258-95e0-3b8902f4e014-common": "15.0.2",
-        "@codingame/monaco-vscode-3607c442-ae7a-594b-b840-038378c24fef-common": "15.0.2",
-        "@codingame/monaco-vscode-7559b0be-bfa5-5fe6-b731-1973fe9fffa1-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-a7c9ae3c-16d2-5d17-86b2-981be7094566-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-d987325e-3e05-53aa-b9ff-6f97476f64db-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-d987325e-3e05-53aa-b9ff-6f97476f64db-common/-/monaco-vscode-d987325e-3e05-53aa-b9ff-6f97476f64db-common-15.0.2.tgz",
-      "integrity": "sha512-QZqXxOk85tHMQ1f+s+pI3vdl3XW4RMU+JWbifqfKbX/EaC7rbmlGC1qCrXMCt4IIDUkDfgANg6QcrnaXZpK/6Q==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-d987325e-3e05-53aa-b9ff-6f97476f64db-common/-/monaco-vscode-d987325e-3e05-53aa-b9ff-6f97476f64db-common-18.1.3.tgz",
+      "integrity": "sha512-YbBDEWxpmktYUiAD4jGuK4YOADdI42PblksFQev7nbTfyqQ30BZPMO4Z/MC2+kmgBJ2Z6P/CbIHPEZ4f2K9fmw==",
       "license": "MIT"
     },
-    "node_modules/@codingame/monaco-vscode-debug-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-debug-service-override/-/monaco-vscode-debug-service-override-15.0.2.tgz",
-      "integrity": "sha512-2f1IFPwLjnaDUFL0/HMg+hILzfHArTwcVOTw4LWG6KDFkhtAJLXpuEAkUk9g3/25/Flcd9fsN8EXFwLjEhUwRw==",
+    "node_modules/@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common/-/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common-18.1.3.tgz",
+      "integrity": "sha512-xoRKmTVJmdRtqOPIolNGYQp/ipfeFmfCImcplTK+B87i7PLhzYMH+JLgpNjBiBuJyLpArPS1NhHJsKzIDr3T1A==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common": "15.0.2",
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-1bb39316-6fbf-572e-ab6a-818a2496c14f-common": "15.0.2",
-        "@codingame/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common": "15.0.2",
-        "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-88aa9a78-75f5-5aaa-89e9-bbdd580b3b5c-common": "15.0.2",
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-a7c9ae3c-16d2-5d17-86b2-981be7094566-common": "15.0.2",
-        "@codingame/monaco-vscode-ab07af84-42e8-5a0f-8aef-b83fb90ede21-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-b1249c5b-1339-5278-b002-746f08105c6d-common": "15.0.2",
-        "@codingame/monaco-vscode-e59ecb8c-db32-5324-8fe4-cf9921fd92b8-common": "15.0.2"
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-debug-service-override": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-debug-service-override/-/monaco-vscode-debug-service-override-18.1.3.tgz",
+      "integrity": "sha512-VrSWvrQQst/cqqJi40e+iPvv4qZRcrwBCJQmJv2u6Db34UPyx7DMfFEmWiFHXPpLtiStRPv/go4T7g3rbfDaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "18.1.3",
+        "@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": "18.1.3",
+        "@codingame/monaco-vscode-6c0f93b9-169c-58c3-a9cb-7d60698eb52c-common": "18.1.3",
+        "@codingame/monaco-vscode-7adbeffb-8051-54a9-8c9b-b62ce9e5836f-common": "18.1.3",
+        "@codingame/monaco-vscode-88aa9a78-75f5-5aaa-89e9-bbdd580b3b5c-common": "18.1.3",
+        "@codingame/monaco-vscode-8d39d04c-3201-5bd6-be79-eed8d17a5ad0-common": "18.1.3",
+        "@codingame/monaco-vscode-937ecbdf-94c7-5b16-aefa-ad78ae557a93-common": "18.1.3",
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-a8d3bd74-e63e-5327-96e8-4f931661e329-common": "18.1.3",
+        "@codingame/monaco-vscode-ab07af84-42e8-5a0f-8aef-b83fb90ede21-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-b99aef83-0d60-5e8c-a62e-9908b6256f35-common": "18.1.3",
+        "@codingame/monaco-vscode-ce7c734f-7712-563c-9335-d7acb43306af-common": "18.1.3",
+        "@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": "18.1.3",
+        "@codingame/monaco-vscode-e59ecb8c-db32-5324-8fe4-cf9921fd92b8-common": "18.1.3",
+        "@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common": "18.1.3",
+        "@codingame/monaco-vscode-fc42f049-7883-579d-bb0b-2aa1010a19a8-common": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-e28ac690-06d5-5ee9-92d1-02df70296354-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-e28ac690-06d5-5ee9-92d1-02df70296354-common/-/monaco-vscode-e28ac690-06d5-5ee9-92d1-02df70296354-common-18.1.3.tgz",
+      "integrity": "sha512-zFjH7oQ/eGLx8ZSPSt4Ulb2THsaq5K3Y3nsjGnRsZHsTsmeSgWz+i3dYtQRVp73cjgFoVKRDuVxP6TcjWnpYzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-0094ae09-a688-53e7-bacc-93e26f7f49db-common": "18.1.3",
+        "@codingame/monaco-vscode-158b9837-fc78-5d9c-86f5-9134e4358643-common": "18.1.3",
+        "@codingame/monaco-vscode-1cb11a73-359e-5a2f-9e95-6989cc9858ee-common": "18.1.3",
+        "@codingame/monaco-vscode-3a35f433-1297-5707-ab58-c261b8180e6d-common": "18.1.3",
+        "@codingame/monaco-vscode-4372ad43-a220-5e78-83e6-95a9cfd64384-common": "18.1.3",
+        "@codingame/monaco-vscode-7adbeffb-8051-54a9-8c9b-b62ce9e5836f-common": "18.1.3",
+        "@codingame/monaco-vscode-93784a59-b4cf-520c-8339-f8104d3a4f3e-common": "18.1.3",
+        "@codingame/monaco-vscode-9ee79c1a-3f03-568b-8eac-b02513a98b68-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-c465110a-57c0-59d7-a6b2-be0a4db7e517-common": "18.1.3",
+        "@codingame/monaco-vscode-c87fff3a-2aa9-52ab-ba4d-17e8d1e5e185-common": "18.1.3",
+        "@codingame/monaco-vscode-fc42f049-7883-579d-bb0b-2aa1010a19a8-common": "18.1.3",
+        "marked": "14.0.0"
       }
     },
     "node_modules/@codingame/monaco-vscode-e59ecb8c-db32-5324-8fe4-cf9921fd92b8-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-e59ecb8c-db32-5324-8fe4-cf9921fd92b8-common/-/monaco-vscode-e59ecb8c-db32-5324-8fe4-cf9921fd92b8-common-15.0.2.tgz",
-      "integrity": "sha512-76p/DFTjmzcngmxnGxA3OybJhaTwcBX6j3tLObufLidzOURKrx+GfRZko7W5ZcteDToVs9EGQR1fALXkJYpOlg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-e59ecb8c-db32-5324-8fe4-cf9921fd92b8-common/-/monaco-vscode-e59ecb8c-db32-5324-8fe4-cf9921fd92b8-common-18.1.3.tgz",
+      "integrity": "sha512-8Y7X7VgC8rLgcphWYDA77Eps5tNbVb338+CbAUw5A8ihtLYbKTFPk/rT7YQxgw/JUL1djW0f/jkCJo9y2QNZVQ==",
       "license": "MIT"
     },
     "node_modules/@codingame/monaco-vscode-e72c94ca-257a-5b75-8b68-5a5fa3c18255-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-e72c94ca-257a-5b75-8b68-5a5fa3c18255-common/-/monaco-vscode-e72c94ca-257a-5b75-8b68-5a5fa3c18255-common-15.0.2.tgz",
-      "integrity": "sha512-W1CSlxHBEyCwhhc5Q7QUEb4YLebISFa8h4Ae/jEAMefxCaD0+DXArBh82IDlcNNesmnYBnm2pXW3NsLCpr1/Og==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-e72c94ca-257a-5b75-8b68-5a5fa3c18255-common/-/monaco-vscode-e72c94ca-257a-5b75-8b68-5a5fa3c18255-common-18.1.3.tgz",
+      "integrity": "sha512-+gGpFBkEHA31bmKp+drCEp5UnUtaBnfYHinr/SAwMruXZVmItA5L84RzzfrrhtfiB0nnB62hxDktP+pugiMYIA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-d609a7d3-bf87-551a-884f-550a8b327ec5-common": "15.0.2"
+        "@codingame/monaco-vscode-158b9837-fc78-5d9c-86f5-9134e4358643-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-d609a7d3-bf87-551a-884f-550a8b327ec5-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-ea14e352-8f1c-5569-b79a-8a96a53e8abe-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-ea14e352-8f1c-5569-b79a-8a96a53e8abe-common/-/monaco-vscode-ea14e352-8f1c-5569-b79a-8a96a53e8abe-common-15.0.2.tgz",
-      "integrity": "sha512-5fW7UH7G5UQZz3rgxu7f+ppNKi5bhCJKsyCh2ST/EHR+hls6lYXYvcsi41lJZivc4KGAEYLh1dx6pd6NDoo6Ig==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-ea14e352-8f1c-5569-b79a-8a96a53e8abe-common/-/monaco-vscode-ea14e352-8f1c-5569-b79a-8a96a53e8abe-common-18.1.3.tgz",
+      "integrity": "sha512-FMjL7KNENLT+5DMC4FCS7E2rjrKlv6hD/xzl9KKLUgPS8E62MPBlcQl04JZdyRKOCnf6acLXbiIiB36wDqRJeg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-2e69e120-617a-5258-95e0-3b8902f4e014-common": "15.0.2",
-        "@codingame/monaco-vscode-42931eb9-e564-530c-bafc-fa23ab43a070-common": "15.0.2",
-        "@codingame/monaco-vscode-7559b0be-bfa5-5fe6-b731-1973fe9fffa1-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-0094ae09-a688-53e7-bacc-93e26f7f49db-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-eb7d5efd-2e60-59f8-9ba4-9a8ae8cb2957-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-eb7d5efd-2e60-59f8-9ba4-9a8ae8cb2957-common/-/monaco-vscode-eb7d5efd-2e60-59f8-9ba4-9a8ae8cb2957-common-15.0.2.tgz",
-      "integrity": "sha512-L9+4QDctDTFUVGEOjyYuFRXvsuM1HU8ttPOEpBIFgkbNsi/0xqV2Lh/wKoECeWYPKZGfCXVaR8pg5d/63bOmEQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-eb7d5efd-2e60-59f8-9ba4-9a8ae8cb2957-common/-/monaco-vscode-eb7d5efd-2e60-59f8-9ba4-9a8ae8cb2957-common-18.1.3.tgz",
+      "integrity": "sha512-rcvbcg3wMJxFczZ9JR/83aJgf/DR/fDrrP4AcXeYmXpSfAMewHSCZotrDWaMXevzyMrTRFk71DCABxsiR9hY9w==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-1bb39316-6fbf-572e-ab6a-818a2496c14f-common": "15.0.2",
-        "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "15.0.2",
-        "@codingame/monaco-vscode-a3f28a41-ba19-5a7e-8f5a-d6c1403b507d-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": "18.1.3",
+        "@codingame/monaco-vscode-8d39d04c-3201-5bd6-be79-eed8d17a5ad0-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-9ee79c1a-3f03-568b-8eac-b02513a98b68-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-eba0b9b3-174c-5dae-9867-a37810ca1808-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-eba0b9b3-174c-5dae-9867-a37810ca1808-common/-/monaco-vscode-eba0b9b3-174c-5dae-9867-a37810ca1808-common-15.0.2.tgz",
-      "integrity": "sha512-rGIV6WdMp2LlpB6dA04TOiX48OpX/QFmevxL6V9RCz7eLOdWthIM8urq761xQI3wEUqQoZPNXPLotDRO0gTFFA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-eba0b9b3-174c-5dae-9867-a37810ca1808-common/-/monaco-vscode-eba0b9b3-174c-5dae-9867-a37810ca1808-common-18.1.3.tgz",
+      "integrity": "sha512-2gHjmDliIu42KCO1bVWVH4s1ckhZ/20r/LqMFL4Vfl9lS1hq8CyZdXLoQaziJN54Vq7VZg0Fqg3lxuyk75l0ew==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-9b5a5e82-d649-5455-b4bf-ef90d6afd294-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-4372ad43-a220-5e78-83e6-95a9cfd64384-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-editor-api": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-editor-api/-/monaco-vscode-editor-api-15.0.2.tgz",
-      "integrity": "sha512-to1b/4bqfMDUTYZzkDZUFxJr7xYWDZ1lRKPKCyqhxt8TRShAIsItEQ6rZ3HrhjKJR4T1prwDyG1N4eCObFX4/g==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-editor-api/-/monaco-vscode-editor-api-18.1.3.tgz",
+      "integrity": "sha512-VSLWmToMS5/CiaP8tRX+JvUqDA2iECX9MZqUkTkaNgK976OPigVjyEdqia+85xwLjYnNLYfbh2YijFAXR3F5eA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-5452e2b7-9081-5f95-839b-4ab3544ce28f-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-5452e2b7-9081-5f95-839b-4ab3544ce28f-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-editor-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-editor-service-override/-/monaco-vscode-editor-service-override-15.0.2.tgz",
-      "integrity": "sha512-utrHOJYb2++T1biVbDzSMbonuex6CMy8jZB1c74BYbl0TAHHazpKX3BRIg6u9A2QMGJ1smibsC+pe+XI3+AXAQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-editor-service-override/-/monaco-vscode-editor-service-override-18.1.3.tgz",
+      "integrity": "sha512-2YQ3rSohlycw56MtEQzRg6OjWHxYUBqOGmEAEafMXaIeul6RANzO+KNTB/ovXSm0kxjfnzuQxMJ+uT8UtAmzOw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-b1e8558d-1726-5299-bc75-e43ee6d1a124-common": "15.0.2",
-        "@codingame/monaco-vscode-c4e2825a-b5b1-5f0e-b547-068c32e06d50-common": "15.0.2"
+        "@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-b1e8558d-1726-5299-bc75-e43ee6d1a124-common": "18.1.3",
+        "@codingame/monaco-vscode-f5d4b045-44e8-55a8-b683-308656a412fa-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-environment-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-15.0.2.tgz",
-      "integrity": "sha512-cTZHfj0oPKzyKJu8Gjc4E2oh2M6vHsFbmdrwtQ1+yCkOkmLaSjza7G6v6OBrGGhvdSTVWb8Fv1fWJSiBL2rpBA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-environment-service-override/-/monaco-vscode-environment-service-override-18.1.3.tgz",
+      "integrity": "sha512-BTiNazufHF3FfP/ulw+vEFs2v2XT1hfcj7+JEFhpjUp2i7P1pvUTjAllZs22HCCyiief/6qhM8FgB1d6HtbCaA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-abed5a84-8a82-5f84-9412-88a736235bae-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-abed5a84-8a82-5f84-9412-88a736235bae-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-explorer-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-explorer-service-override/-/monaco-vscode-explorer-service-override-15.0.2.tgz",
-      "integrity": "sha512-ojv0N/w+3gwoBfhusIpkzQo7stjgJIfmSL0RNOghxNwiovl+1oB2IsclYWWqMro/yzDhvPQGjIVBIjJLrtEXpg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-explorer-service-override/-/monaco-vscode-explorer-service-override-18.1.3.tgz",
+      "integrity": "sha512-WC1mKzIxnT5ChWaX7fbhv24Jk1RbtIYcjVtcxE3Nv+TJAm2VUs36Fsd2NpMW+UhtW9p3OjPwdJb0kNsZNLDNAQ==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-15626ec7-b165-51e1-8caf-7bcc2ae9b95a-common": "15.0.2",
-        "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "15.0.2",
-        "@codingame/monaco-vscode-9b5a5e82-d649-5455-b4bf-ef90d6afd294-common": "15.0.2",
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-b1e8558d-1726-5299-bc75-e43ee6d1a124-common": "15.0.2",
-        "@codingame/monaco-vscode-b71b5434-ce96-5581-8993-e8da380bd63f-common": "15.0.2",
-        "@codingame/monaco-vscode-c4e2825a-b5b1-5f0e-b547-068c32e06d50-common": "15.0.2",
-        "@codingame/monaco-vscode-d481a59e-259c-524e-bee1-76483d75d3a1-common": "15.0.2"
+        "@codingame/monaco-vscode-15626ec7-b165-51e1-8caf-7bcc2ae9b95a-common": "18.1.3",
+        "@codingame/monaco-vscode-47472025-cc45-5680-86cd-09ceaba921a1-common": "18.1.3",
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-a4683c2b-a0d2-5112-96ba-eedc605346d2-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-b1e8558d-1726-5299-bc75-e43ee6d1a124-common": "18.1.3",
+        "@codingame/monaco-vscode-b71b5434-ce96-5581-8993-e8da380bd63f-common": "18.1.3",
+        "@codingame/monaco-vscode-d481a59e-259c-524e-bee1-76483d75d3a1-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-extension-api": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extension-api/-/monaco-vscode-extension-api-15.0.2.tgz",
-      "integrity": "sha512-qdt2VEKR6aI5Z7KAw5ex/dXD72k6lmKi4V+Po++De0YdSPPzqo4+KaNLiHqcM2FWXbgox4J+qE8ul9CZ131SMg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extension-api/-/monaco-vscode-extension-api-18.1.3.tgz",
+      "integrity": "sha512-jv1sRVVIE4MXBcUGgPiDOZQMYOYL277CuJUdzt8GwvirgiEVvWJyl2aql572SgdkKRkAr42Jq5KFlgns0NSMeg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-bd6ad8b7-9db3-51a8-9895-0046508c029d-common": "15.0.2",
-        "@codingame/monaco-vscode-extensions-service-override": "15.0.2"
+        "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "18.1.3",
+        "@codingame/monaco-vscode-4a3ac544-9a61-534c-88df-756262793ef7-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-extensions-service-override": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-extensions-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-15.0.2.tgz",
-      "integrity": "sha512-7UtMt7FwcWQ05vlaMNXsFWRP3nwktKiGNqf68Dg3cAmcKMNRP1ajR5I/CnRdotzOoXd7v1Jjb4yygHS9+evBWg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extensions-service-override/-/monaco-vscode-extensions-service-override-18.1.3.tgz",
+      "integrity": "sha512-GXrQ88rtcjrPmcwLWxO9qC7g6oWtiFeeGa65FvjlDUiu4qf/4vN6ObNHs+YfkmTc6dpx2m8rsIe9SDuU1NgCng==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common": "15.0.2",
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-168b98e5-dc20-5807-b1f9-798f1f92b37f-common": "15.0.2",
-        "@codingame/monaco-vscode-256d5b78-0649-50e9-8354-2807f95f68f4-common": "15.0.2",
-        "@codingame/monaco-vscode-3607c442-ae7a-594b-b840-038378c24fef-common": "15.0.2",
-        "@codingame/monaco-vscode-38f25ab8-ea30-5ba9-8a08-ae3308c297c0-common": "15.0.2",
-        "@codingame/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common": "15.0.2",
-        "@codingame/monaco-vscode-42931eb9-e564-530c-bafc-fa23ab43a070-common": "15.0.2",
-        "@codingame/monaco-vscode-6845754f-e617-5ed9-8aaa-6ca3653a9532-common": "15.0.2",
-        "@codingame/monaco-vscode-7ba0af96-90c2-5e11-ad7f-befdbbf246c8-common": "15.0.2",
-        "@codingame/monaco-vscode-7f39b6f1-3542-5430-8760-0f404d7a7cee-common": "15.0.2",
-        "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "15.0.2",
-        "@codingame/monaco-vscode-8ccb7637-50ea-5359-97bf-00015d7fe567-common": "15.0.2",
-        "@codingame/monaco-vscode-9a6d8b6c-ad4c-5ea3-9558-f43d6dc4c0ad-common": "15.0.2",
-        "@codingame/monaco-vscode-9b5a5e82-d649-5455-b4bf-ef90d6afd294-common": "15.0.2",
-        "@codingame/monaco-vscode-ad89fae6-94f0-5ac2-a185-22dea4b68ee0-common": "15.0.2",
-        "@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-bba55be6-41a2-50cd-a3cc-8bafa35bfa89-common": "15.0.2",
-        "@codingame/monaco-vscode-bd6ad8b7-9db3-51a8-9895-0046508c029d-common": "15.0.2",
-        "@codingame/monaco-vscode-be8ddbb5-094a-5657-b1cc-fe106c94c632-common": "15.0.2",
-        "@codingame/monaco-vscode-bf94ddb5-e436-506a-9763-5ab86b642508-common": "15.0.2",
-        "@codingame/monaco-vscode-d7f659f5-da33-5ea8-a3b8-9b94f2cf5f33-common": "15.0.2",
-        "@codingame/monaco-vscode-eb7d5efd-2e60-59f8-9ba4-9a8ae8cb2957-common": "15.0.2",
-        "@codingame/monaco-vscode-eba0b9b3-174c-5dae-9867-a37810ca1808-common": "15.0.2",
-        "@codingame/monaco-vscode-fdf643f9-94dd-5510-b97a-408abf26ad92-common": "15.0.2",
-        "@codingame/monaco-vscode-files-service-override": "15.0.2"
+        "@codingame/monaco-vscode-1cb11a73-359e-5a2f-9e95-6989cc9858ee-common": "18.1.3",
+        "@codingame/monaco-vscode-1cc4ea0a-c5b6-54ed-bb60-078a99119b55-common": "18.1.3",
+        "@codingame/monaco-vscode-256d5b78-0649-50e9-8354-2807f95f68f4-common": "18.1.3",
+        "@codingame/monaco-vscode-2a94c04a-b85b-5669-b06b-89c1bfa11cb9-common": "18.1.3",
+        "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "18.1.3",
+        "@codingame/monaco-vscode-3a35f433-1297-5707-ab58-c261b8180e6d-common": "18.1.3",
+        "@codingame/monaco-vscode-4372ad43-a220-5e78-83e6-95a9cfd64384-common": "18.1.3",
+        "@codingame/monaco-vscode-47472025-cc45-5680-86cd-09ceaba921a1-common": "18.1.3",
+        "@codingame/monaco-vscode-4a3ac544-9a61-534c-88df-756262793ef7-common": "18.1.3",
+        "@codingame/monaco-vscode-4ee27008-17b4-593f-9c09-19e8e3077f51-common": "18.1.3",
+        "@codingame/monaco-vscode-571c8352-7953-5038-9f09-e03bb6219a0e-common": "18.1.3",
+        "@codingame/monaco-vscode-6845754f-e617-5ed9-8aaa-6ca3653a9532-common": "18.1.3",
+        "@codingame/monaco-vscode-7adbeffb-8051-54a9-8c9b-b62ce9e5836f-common": "18.1.3",
+        "@codingame/monaco-vscode-7f39b6f1-3542-5430-8760-0f404d7a7cee-common": "18.1.3",
+        "@codingame/monaco-vscode-8ccb7637-50ea-5359-97bf-00015d7fe567-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "18.1.3",
+        "@codingame/monaco-vscode-a4683c2b-a0d2-5112-96ba-eedc605346d2-common": "18.1.3",
+        "@codingame/monaco-vscode-a8d3bd74-e63e-5327-96e8-4f931661e329-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-bba55be6-41a2-50cd-a3cc-8bafa35bfa89-common": "18.1.3",
+        "@codingame/monaco-vscode-bf94ddb5-e436-506a-9763-5ab86b642508-common": "18.1.3",
+        "@codingame/monaco-vscode-c3c61c00-c254-5856-9dc9-d7929c1f9062-common": "18.1.3",
+        "@codingame/monaco-vscode-eb7d5efd-2e60-59f8-9ba4-9a8ae8cb2957-common": "18.1.3",
+        "@codingame/monaco-vscode-eba0b9b3-174c-5dae-9867-a37810ca1808-common": "18.1.3",
+        "@codingame/monaco-vscode-f22e7e55-aee8-5b52-a6bc-950efd9f5890-common": "18.1.3",
+        "@codingame/monaco-vscode-f48982c4-9e82-55e2-b800-20e6d1e6096f-common": "18.1.3",
+        "@codingame/monaco-vscode-fab30422-b487-5f4e-8d30-8b4d266e3fcd-common": "18.1.3",
+        "@codingame/monaco-vscode-files-service-override": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-f1bbc6d3-6129-583c-a2ba-c80b832993d2-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-f1bbc6d3-6129-583c-a2ba-c80b832993d2-common/-/monaco-vscode-f1bbc6d3-6129-583c-a2ba-c80b832993d2-common-18.1.3.tgz",
+      "integrity": "sha512-yEdMrkIIj5wjYdlvHdn3aIo/pLv859Wge5Q0GkPXYdC2GufGPJhv8501DKY4bUBQsrKJOLdlWE5w4dtKOkpljQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-f22e7e55-aee8-5b52-a6bc-950efd9f5890-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-f22e7e55-aee8-5b52-a6bc-950efd9f5890-common/-/monaco-vscode-f22e7e55-aee8-5b52-a6bc-950efd9f5890-common-18.1.3.tgz",
+      "integrity": "sha512-W/7/VmZgbpk2DZ1VwyxxNgB/lL+WCzld+P++koA01tlPdFnQJB5DNHghKgte+GsGYkgAyJ/5Cm6tHRHiX/5Q4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-937ecbdf-94c7-5b16-aefa-ad78ae557a93-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common/-/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common-18.1.3.tgz",
+      "integrity": "sha512-UQoytTOkJmVMTqTjpNwVdkW42uzIGdMTmPTakej/9eeGtdwvIYIL25spcr+wAiHQEfXCepOS6L7ydMxoqn5vFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-f338ac19-278c-5fe1-bec8-b588de04a788-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-f338ac19-278c-5fe1-bec8-b588de04a788-common/-/monaco-vscode-f338ac19-278c-5fe1-bec8-b588de04a788-common-18.1.3.tgz",
+      "integrity": "sha512-rrDWdOi00DvHxJdI+xunIrDVBVPlSVj/xfDebpiU9UmHQTqwxblev6NQYveJfFmwYuxYgHNGH3F6JFcoqSHNPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-bc8c28cd-7a80-54a9-af1a-e6b1e7a7f34a-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-f405f7ba-995b-5117-bc17-5bc7f77d92e9-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-f405f7ba-995b-5117-bc17-5bc7f77d92e9-common/-/monaco-vscode-f405f7ba-995b-5117-bc17-5bc7f77d92e9-common-15.0.2.tgz",
-      "integrity": "sha512-wlmIHh0VobtQYcPXZyxZoOJIvAZc5MMHIAgrO39X1O1BUgINcCmJChiFFlFJ6OocKqGksF5TBkKfeoD/j7F4XQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-f405f7ba-995b-5117-bc17-5bc7f77d92e9-common/-/monaco-vscode-f405f7ba-995b-5117-bc17-5bc7f77d92e9-common-18.1.3.tgz",
+      "integrity": "sha512-BZVNxw+UikWwWT0EPZ9JUYBp7Kh3gL2nUWTHDepEHgZZpf+ilyc/an2tAHcKl3Z1qtCCybUqdNRNLZ+VSczvLg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-f48982c4-9e82-55e2-b800-20e6d1e6096f-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-f48982c4-9e82-55e2-b800-20e6d1e6096f-common/-/monaco-vscode-f48982c4-9e82-55e2-b800-20e6d1e6096f-common-18.1.3.tgz",
+      "integrity": "sha512-Hq6/lKT4kPucXw3SqH8ROmSy4ewoip8XZLArFy7F6KlDLnVFAFDL1znKVNxh04Dpey0E7yQ2tUAQdlS8/FocTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-95ea5c7c-15cf-50aa-8e24-38039b06b4a6-common": "18.1.3",
+        "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-f5d4b045-44e8-55a8-b683-308656a412fa-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-f5d4b045-44e8-55a8-b683-308656a412fa-common/-/monaco-vscode-f5d4b045-44e8-55a8-b683-308656a412fa-common-18.1.3.tgz",
+      "integrity": "sha512-2zCpzMb+xb7CFMuZRUePvRxZxKdrScL5eydPtIbLpTPQRVNnApsozqoWAcenkk7gQpDTvtjlegPK0b+JZvJ4Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-4ee27008-17b4-593f-9c09-19e8e3077f51-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "18.1.3",
+        "@codingame/monaco-vscode-a4683c2b-a0d2-5112-96ba-eedc605346d2-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-f6ab89b2-83b0-5a43-8772-cb0eafa650b5-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-f6ab89b2-83b0-5a43-8772-cb0eafa650b5-common/-/monaco-vscode-f6ab89b2-83b0-5a43-8772-cb0eafa650b5-common-15.0.2.tgz",
-      "integrity": "sha512-YB+VoM7nu08w/4JpjZyqKD1EDmmdsTMSsoBWXIzNIH7sbmJLeXEQwcJ0jPfyLXSFu8jeubDZhidoHTa7MIONRg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-f6ab89b2-83b0-5a43-8772-cb0eafa650b5-common/-/monaco-vscode-f6ab89b2-83b0-5a43-8772-cb0eafa650b5-common-18.1.3.tgz",
+      "integrity": "sha512-Vveub5CAmRwVITNVj+imlWvPcNMWeGJ/tjytKFm6BwjoOXxsOZ+hHYolqSTLv6KSlWJIXk+8F9Z+Cq2+vjHZnw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common": "15.0.2",
-        "@codingame/monaco-vscode-7bbc9e7d-eeae-55fc-8bf9-dc2f66e0dc73-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@xterm/addon-clipboard": "0.2.0-beta.81",
-        "@xterm/addon-image": "0.9.0-beta.98",
-        "@xterm/addon-ligatures": "0.10.0-beta.98",
-        "@xterm/addon-progress": "0.2.0-beta.4",
-        "@xterm/addon-search": "0.16.0-beta.98",
-        "@xterm/addon-serialize": "0.14.0-beta.98",
-        "@xterm/addon-unicode11": "0.9.0-beta.98",
-        "@xterm/addon-webgl": "0.19.0-beta.98"
+        "@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common": "18.1.3",
+        "@codingame/monaco-vscode-47472025-cc45-5680-86cd-09ceaba921a1-common": "18.1.3",
+        "@codingame/monaco-vscode-7bbc9e7d-eeae-55fc-8bf9-dc2f66e0dc73-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@xterm/addon-clipboard": "0.2.0-beta.90",
+        "@xterm/addon-image": "0.9.0-beta.107",
+        "@xterm/addon-ligatures": "0.10.0-beta.107",
+        "@xterm/addon-progress": "0.2.0-beta.13",
+        "@xterm/addon-search": "0.16.0-beta.107",
+        "@xterm/addon-serialize": "0.14.0-beta.107",
+        "@xterm/addon-unicode11": "0.9.0-beta.107",
+        "@xterm/addon-webgl": "0.19.0-beta.107"
       }
     },
-    "node_modules/@codingame/monaco-vscode-fc985c90-0334-5b62-88bc-73e2efa0b80b-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-fc985c90-0334-5b62-88bc-73e2efa0b80b-common/-/monaco-vscode-fc985c90-0334-5b62-88bc-73e2efa0b80b-common-15.0.2.tgz",
-      "integrity": "sha512-1p8jf03EnVsLkNFUtAJwwITBoN3kh8DPYihsqvznG7foFlR3XI6gj34oCSc23AlFPNvRZC8O+FuKCZ7o777+hg==",
-      "license": "MIT"
-    },
-    "node_modules/@codingame/monaco-vscode-fdf643f9-94dd-5510-b97a-408abf26ad92-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-fdf643f9-94dd-5510-b97a-408abf26ad92-common/-/monaco-vscode-fdf643f9-94dd-5510-b97a-408abf26ad92-common-15.0.2.tgz",
-      "integrity": "sha512-NQYvXrruzWh6vKYfbrEvLBzthF1ffcPZcLuspc0GW11J9+ZJO1X1JXIymO69ANrkYJGGdLc/6E67LU/dCmku/Q==",
+    "node_modules/@codingame/monaco-vscode-fab30422-b487-5f4e-8d30-8b4d266e3fcd-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-fab30422-b487-5f4e-8d30-8b4d266e3fcd-common/-/monaco-vscode-fab30422-b487-5f4e-8d30-8b4d266e3fcd-common-18.1.3.tgz",
+      "integrity": "sha512-SOGSgyhAVKYBWeLcm/Y6Cf5unzyCKAJbZ+jP0Bku2QiR7u5sLS56BUeJPXHVFCMk1xHRG/0Y8Ext2ikYaI47AA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-1cb11a73-359e-5a2f-9e95-6989cc9858ee-common": "18.1.3",
+        "@codingame/monaco-vscode-3a35f433-1297-5707-ab58-c261b8180e6d-common": "18.1.3",
+        "@codingame/monaco-vscode-3cf6a388-482f-5484-a806-0525ad9ad8af-common": "18.1.3",
+        "@codingame/monaco-vscode-4372ad43-a220-5e78-83e6-95a9cfd64384-common": "18.1.3",
+        "@codingame/monaco-vscode-47472025-cc45-5680-86cd-09ceaba921a1-common": "18.1.3",
+        "@codingame/monaco-vscode-7adbeffb-8051-54a9-8c9b-b62ce9e5836f-common": "18.1.3",
+        "@codingame/monaco-vscode-8d39d04c-3201-5bd6-be79-eed8d17a5ad0-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-c87fff3a-2aa9-52ab-ba4d-17e8d1e5e185-common": "18.1.3",
+        "@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-fc3b1755-9783-51f9-b3e6-45e7ef6fe6e3-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-fc3b1755-9783-51f9-b3e6-45e7ef6fe6e3-common/-/monaco-vscode-fc3b1755-9783-51f9-b3e6-45e7ef6fe6e3-common-18.1.3.tgz",
+      "integrity": "sha512-PecY8zwjSp2Xgh7T0H8t3PJHzV1D68ryi6qP5dEn5Q7zw0IBsXAJ4YVFHJ0tvJCMrVJ6wAw2cuE+tmpDsc6WXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": "18.1.3",
+        "@codingame/monaco-vscode-f48982c4-9e82-55e2-b800-20e6d1e6096f-common": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-fc42f049-7883-579d-bb0b-2aa1010a19a8-common": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-fc42f049-7883-579d-bb0b-2aa1010a19a8-common/-/monaco-vscode-fc42f049-7883-579d-bb0b-2aa1010a19a8-common-18.1.3.tgz",
+      "integrity": "sha512-Onw/Tlwtg+3i/xNM+kfrlwGCSEaZe58H+AJ1nKKXzvIaNy7lXy99qfmtFrkb8WDl8sJtQnGMWJkk6NK5Bv8SXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-ff9fa663-eae3-5274-8573-c2b918871e4b-common": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-ff9fa663-eae3-5274-8573-c2b918871e4b-common/-/monaco-vscode-ff9fa663-eae3-5274-8573-c2b918871e4b-common-15.0.2.tgz",
-      "integrity": "sha512-ot6TbkgL2YSkWbXU8FKrFji9z/Rvwg8STJibZ9mig0+VdhJKNnpJxsHqFcdFSGb5aHAcuUZ8i0RyDw1nakSQZg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-ff9fa663-eae3-5274-8573-c2b918871e4b-common/-/monaco-vscode-ff9fa663-eae3-5274-8573-c2b918871e4b-common-18.1.3.tgz",
+      "integrity": "sha512-BystEB15Jx9LLqVPebei2VrzdnyyyDjedV0bKgd3UGw+imusom5oQ+YT+Z3ZvjpWF4FYbX3mKgsxrepbg6SG9Q==",
       "license": "MIT"
     },
     "node_modules/@codingame/monaco-vscode-files-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-15.0.2.tgz",
-      "integrity": "sha512-gyT52tpPZlie9yM2y4a8Gd37Y12G6eIOy0b5FhcBd2l5S0b1APLavdf+31zDVQxZ6USjmCyZBURl6h19Y11JLg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-files-service-override/-/monaco-vscode-files-service-override-18.1.3.tgz",
+      "integrity": "sha512-EuZx23+f/vXWMOUBCN7HoosiwqA5q9B6+Z66yzAK8vXqvSBOMb6EJw/vugCgD5LSyEyftUOxMMThsak78IFbAw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-0c06bfba-d24d-5c4d-90cd-b40cefb7f811-common": "15.0.2",
-        "@codingame/monaco-vscode-15626ec7-b165-51e1-8caf-7bcc2ae9b95a-common": "15.0.2",
-        "@codingame/monaco-vscode-2e67e044-0db9-5fa6-8bd1-3737a7d586d4-common": "15.0.2",
-        "@codingame/monaco-vscode-2f06fe84-148e-5e6b-a7ca-c7989c5f128a-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "15.0.2",
-        "@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-cea4d01f-6526-5c2f-8b09-b168fead499f-common": "15.0.2"
+        "@codingame/monaco-vscode-0c06bfba-d24d-5c4d-90cd-b40cefb7f811-common": "18.1.3",
+        "@codingame/monaco-vscode-15626ec7-b165-51e1-8caf-7bcc2ae9b95a-common": "18.1.3",
+        "@codingame/monaco-vscode-2f06fe84-148e-5e6b-a7ca-c7989c5f128a-common": "18.1.3",
+        "@codingame/monaco-vscode-8a9062f2-d169-567b-848e-a2530c97ea18-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-a4683c2b-a0d2-5112-96ba-eedc605346d2-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-cea4d01f-6526-5c2f-8b09-b168fead499f-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-groovy-default-extension": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-groovy-default-extension/-/monaco-vscode-groovy-default-extension-15.0.2.tgz",
-      "integrity": "sha512-ltJ/SpZ/iCxaDi4wk02D868hpt7bKYO6/jHxVGFX9CCyPXQmjvx2+5zPbqlpWpP/26xedK6br3agmb3Ms4wAtw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-groovy-default-extension/-/monaco-vscode-groovy-default-extension-18.1.3.tgz",
+      "integrity": "sha512-2zFHlhrNjufl3ZG7TTWhuo5DJ8K9oi27CR5mQyeYpIzFq4puV5HaPCulpjRGA2oRrDkj02JDv2wLnU/XKiJaKA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-host-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-15.0.2.tgz",
-      "integrity": "sha512-Vp3hcSar94Td1AEkrs6Q3aVgKx0+FEIesU132xNms7tJvDdMAlP1kH0c7lqZGjZdk91mml+r2pzQacjLLwQ5zg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-host-service-override/-/monaco-vscode-host-service-override-18.1.3.tgz",
+      "integrity": "sha512-afXrOGHdLJOt/Y9NSAKw6Y58jklvakASV4TrQBDZs0KUANYzWAR5uslPRAD5jiVTmQGGLaAXWwb7a4DWgzJCPw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common": "15.0.2",
-        "@codingame/monaco-vscode-7559b0be-bfa5-5fe6-b731-1973fe9fffa1-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-158b9837-fc78-5d9c-86f5-9134e4358643-common": "18.1.3",
+        "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-java-default-extension": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-java-default-extension/-/monaco-vscode-java-default-extension-15.0.2.tgz",
-      "integrity": "sha512-QLsGk/6lcMODlfBMJM9Z4acQwiSavhEODQghuPtKQuqzd/7tGeL5+tl68b6Wusg8oX3thI8TuKRaXa9SagkH/Q==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-java-default-extension/-/monaco-vscode-java-default-extension-18.1.3.tgz",
+      "integrity": "sha512-BdwKHCCrNjzqpJ1jwz15C8cyVhXFyHPfTdHPzcAUcyvDQqcheCTq7JNfZKA7zhoFmstJ13klxzuZttU0mLmPvw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-javascript-default-extension": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-javascript-default-extension/-/monaco-vscode-javascript-default-extension-15.0.2.tgz",
-      "integrity": "sha512-/W+rv14rdtp/Cz1/FVkkUPP2Y+eBvMB0bCFWTnwzoPbS/5RXq9HoqS3MpohvMiLA/GEb6nGy+vV0AJtwLR89nw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-javascript-default-extension/-/monaco-vscode-javascript-default-extension-18.1.3.tgz",
+      "integrity": "sha512-qDvADuI3fXihxNreR4IJeMnhu3npYDZPfrt58YJbuwzn3C3xxESZ89u1Tx2knU0CvhSSW5VDdYi6fSvVTgX1pg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-json-default-extension": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-json-default-extension/-/monaco-vscode-json-default-extension-15.0.2.tgz",
-      "integrity": "sha512-S8EFZ9W4PBtRFshCmj3zYRrJQP56tcSCMAb0WRuLZljQCBPr02NAeyzSmYQCyku0nFkc3LghtLwAqna84h44mw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-json-default-extension/-/monaco-vscode-json-default-extension-18.1.3.tgz",
+      "integrity": "sha512-QgBNV0yQ6cxI0du0qrq2RS/6alWfm9X3DGODzswqpFyxpS18EsA6e4W4Oa2/hhrizCwxDPDRuDTD6cCiufNlZw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-keybindings-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-keybindings-service-override/-/monaco-vscode-keybindings-service-override-15.0.2.tgz",
-      "integrity": "sha512-gsSLHOGEY/QLwmqE1W8hzWBDmEY/nK11HN6rfvuVJhbkI7i5pqNLtFaNWus1iTw8gB+xjWXlziC+vg8AWjqgNw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-keybindings-service-override/-/monaco-vscode-keybindings-service-override-18.1.3.tgz",
+      "integrity": "sha512-odfG30ZQdrZ9iLdihlVD20h4+5OT5t/D9a1a9FWnma1PsLs7Zg8Xe4642PzdpUmx3kS/4mz/IzFRFNaNoEqOZA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-2a22c7b4-b906-5914-8cd1-3ed912fb738f-common": "15.0.2",
-        "@codingame/monaco-vscode-40cada32-7e9c-528a-81fc-766e4da54147-common": "15.0.2",
-        "@codingame/monaco-vscode-52bb4d5b-ba1a-57fd-9bee-b28824214eac-common": "15.0.2",
-        "@codingame/monaco-vscode-7559b0be-bfa5-5fe6-b731-1973fe9fffa1-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-d609a7d3-bf87-551a-884f-550a8b327ec5-common": "15.0.2",
-        "@codingame/monaco-vscode-files-service-override": "15.0.2"
+        "@codingame/monaco-vscode-2a22c7b4-b906-5914-8cd1-3ed912fb738f-common": "18.1.3",
+        "@codingame/monaco-vscode-40cada32-7e9c-528a-81fc-766e4da54147-common": "18.1.3",
+        "@codingame/monaco-vscode-a3eaa464-944c-5b8f-8886-213068ba4897-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-c87fff3a-2aa9-52ab-ba4d-17e8d1e5e185-common": "18.1.3",
+        "@codingame/monaco-vscode-d609a7d3-bf87-551a-884f-550a8b327ec5-common": "18.1.3",
+        "@codingame/monaco-vscode-files-service-override": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-language-pack-cs": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-cs/-/monaco-vscode-language-pack-cs-15.0.2.tgz",
-      "integrity": "sha512-/cJyjswDFE+gJn0sRXdiLwjfqpS73Z2dFKQrv8xsX7UZDvn7G2Fvj+y9MUano0kLcdYQcNybUrOFpbY6tQbr5g==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-cs/-/monaco-vscode-language-pack-cs-18.1.3.tgz",
+      "integrity": "sha512-gqGX6MkFOhG9s+uGDP9cl5lhqfXNCTFQQzizWEcoqVRJghhnlFkoN6p/xkcILhn7REBOHFfYZGkfeLSdRoGXaQ==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-language-pack-de": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-de/-/monaco-vscode-language-pack-de-15.0.2.tgz",
-      "integrity": "sha512-0kBqcXL6Y1+maU567/4N648AEfBFuS3emIYfh2BHsYO/GK6tVh1CabiocxD0Vwy110FivMt9QaD39UK0ESM+Bg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-de/-/monaco-vscode-language-pack-de-18.1.3.tgz",
+      "integrity": "sha512-ZOJRV7n+SVttK1Vj+lljNkvrz18VCPlAk74KZLON0jeBLKb0c8enAXy+uPPSQ6+LBjAc1wc8vdif7kUSmZKl2g==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-language-pack-es": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-es/-/monaco-vscode-language-pack-es-15.0.2.tgz",
-      "integrity": "sha512-MKBr5Rgwdn6ikLDPbS3OPcVoQyrHk05K5znv8n1Aa8vplwUMGIwhVGQruvyZuDhwb/tHj42pvMcfI6KR1BXG/Q==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-es/-/monaco-vscode-language-pack-es-18.1.3.tgz",
+      "integrity": "sha512-PcawLxQp3WAM35MzC2G0yHZIv1GsZ13XiXFVYJAFfhcrHww4BEwyzqZnFp8V4Qrwl93jZwj/5v0WYwdblNmBdw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-language-pack-fr": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-fr/-/monaco-vscode-language-pack-fr-15.0.2.tgz",
-      "integrity": "sha512-uW1B8sDiiXf8jvYGNcSPCm7LLbb4YkRHwN4eM3c2W7xfRlR313ajqRYe2HCN7zp5ghAZEUS9pJytAMK2nGKO4w==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-fr/-/monaco-vscode-language-pack-fr-18.1.3.tgz",
+      "integrity": "sha512-526ck9/+eRZLI8TklzArvUQJWNcilozX1d88sWVYvbG5G1zwY/u3Yp/7q+6TQGvvX/6HYsKqKd/En5nB/51zaA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-language-pack-it": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-it/-/monaco-vscode-language-pack-it-15.0.2.tgz",
-      "integrity": "sha512-nkkzdhHmlZQDBmO/ff+lfkP7/7VSsEK/myNpELLNGqylFE6Hz0odtlQZaldF2VA6BMj6z3cacBMn5Ru3Qr2cTw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-it/-/monaco-vscode-language-pack-it-18.1.3.tgz",
+      "integrity": "sha512-tz73m/oCOOsB5kIPdRTRgZc+IxARUAAGfIyQpTR0zistuVtzVS4QxH7JOWSUQFuwtdVVm6t+yWUEIjxiPdmJag==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-language-pack-ja": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-ja/-/monaco-vscode-language-pack-ja-15.0.2.tgz",
-      "integrity": "sha512-IvH80s09OBvHNNy9e+ILQoWUnOxqMi+DLDch/y1oObpGQNR3relszHM56TvEPljc6DbDafh02NwiC154vByHmA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-ja/-/monaco-vscode-language-pack-ja-18.1.3.tgz",
+      "integrity": "sha512-Y+C8zZeTJQe71N2fNQJy62BBj6eYp4tijeQCblu7/gnHpNo8Aat2iksO5vA4/KY3E9oZLaEzs8Ql3u0qf8jANA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-language-pack-ko": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-ko/-/monaco-vscode-language-pack-ko-15.0.2.tgz",
-      "integrity": "sha512-38YoVtGQUQogUSOokyVZia5c2J+Dv7YK90kREusZIPpH7bg0zkO85Dpa6HjgNf1LmlCI59mOdqRdXeiE/4zQ/A==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-ko/-/monaco-vscode-language-pack-ko-18.1.3.tgz",
+      "integrity": "sha512-7oEvLf2XklSxgBPaTyb5CTtdbpZjngNT3SuiFZL+X0TvwEnhfTvjR+DxRKZLdRu/d9XnFxbQIM2pTJT5kRMmPQ==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-language-pack-pl": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-pl/-/monaco-vscode-language-pack-pl-15.0.2.tgz",
-      "integrity": "sha512-V+nwSAEzoGyX48y29zOf7g2Shl2VVaZJ6jl4KDb/C427S5+IkyC4q3htyJS0YxMcBAVBkp23/t+A0F7+8pMmxw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-pl/-/monaco-vscode-language-pack-pl-18.1.3.tgz",
+      "integrity": "sha512-y52bRiPTyDHXwo4+1e08FvIK6ySISICDh+V0GzVvxRSNVjBMtgjyMlpNejvjNtgmOpPaHOz5Mnr9CLjZAOrkvw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-language-pack-pt-br": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-pt-br/-/monaco-vscode-language-pack-pt-br-15.0.2.tgz",
-      "integrity": "sha512-OSrd0ORd9eZiRl1gLvxJ5i5t+C7TfLw9seMlhE7xTCEQ6jgbJ9a4cVsu/YDSRIGSXxlqr8bIpkH3ZLRp97MeAw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-pt-br/-/monaco-vscode-language-pack-pt-br-18.1.3.tgz",
+      "integrity": "sha512-UoowVBi4GkChNMk2sDCdFOi0PgtL8kJAVf/+X1iBdqm8MFkfLp9+BZaw4fvekzvE717em3dImMnIxYX94IKJtA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-language-pack-qps-ploc": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-qps-ploc/-/monaco-vscode-language-pack-qps-ploc-15.0.2.tgz",
-      "integrity": "sha512-PVn+/JevTRbO/IsQQwwr45M9y3RprG/rhD3hRXXPRsehjJx8pvuUrSsunmV5Va7m5Zz0LPRXZBlLTpoVWRYkCQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-qps-ploc/-/monaco-vscode-language-pack-qps-ploc-18.1.3.tgz",
+      "integrity": "sha512-W8oIsL+kOSDyaPd7M6AhWiv//NJpWyHlLGg0j+S8fdzNcZYnp2KNDNsco5Cen3+SYiNwk1vgV7XAjlc1h9CnXw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-language-pack-ru": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-ru/-/monaco-vscode-language-pack-ru-15.0.2.tgz",
-      "integrity": "sha512-YuGWXQnKxoSmUwa9449jc0xAWqCTHiu2Er8v3MI3wyccacokPdcNzqMvpmPlL6J5fyE/LEimbKxQZ0KkNOlbGw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-ru/-/monaco-vscode-language-pack-ru-18.1.3.tgz",
+      "integrity": "sha512-jymkqyI/nybCxZIujPiHl3sE6mBTHhPXOMrWScyxod8/gCWEpNUW4Yty8v7GJ7Hv/KbYrBHzM5Xp5pvX4Ok1Ow==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-language-pack-tr": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-tr/-/monaco-vscode-language-pack-tr-15.0.2.tgz",
-      "integrity": "sha512-UK4/qaw0WAYJrJtk/vcWb5pWmSEzfp88UYD5lRdlNGyCteJoL7Fa/6xahHWKxzRleADHhCfxKfJpxZaRX3cZfw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-tr/-/monaco-vscode-language-pack-tr-18.1.3.tgz",
+      "integrity": "sha512-0/+BOEEPTc+8lkQtrYnKI60nPCooYokzdVZPRUIovbrq20Lg0vp10LONGnN2Ef0+uoyn7eO8IfCK2Lz86powsg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-language-pack-zh-hans": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-zh-hans/-/monaco-vscode-language-pack-zh-hans-15.0.2.tgz",
-      "integrity": "sha512-2o7CjPQ77yY/g5uv2Nu3CZsRsexssSrdqvx6A3LHvQg67JtqYI/aeQg8vB7RIi8GttDqg5ReJrTrXJt8KFLwwA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-zh-hans/-/monaco-vscode-language-pack-zh-hans-18.1.3.tgz",
+      "integrity": "sha512-1WM7elRCyP0ohoFdvOJAeA0t2nIWQqhjJch509zj0dyVLiGBJCyel+TdXI7HBVwZDk9AWmOwwq5r08U19xLdmw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-language-pack-zh-hant": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-zh-hant/-/monaco-vscode-language-pack-zh-hant-15.0.2.tgz",
-      "integrity": "sha512-5hY9cR43I6TeVBCybQZb/R44Cm5M1fdmCo4kqndtlPiRkAuMBir1AwCo8quMV7sdQGsYIVhqnXLhHrr5hcAIVQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-language-pack-zh-hant/-/monaco-vscode-language-pack-zh-hant-18.1.3.tgz",
+      "integrity": "sha512-ETxf7aPrGcsmQqDEtoFB3P1MtnULppfRAn1HS+qWPBZRj60MuNQCYLrBuIai9hnNiNBDCwuhMmA78dujTV6plA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-languages-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-languages-service-override/-/monaco-vscode-languages-service-override-15.0.2.tgz",
-      "integrity": "sha512-jrf12nVSIpFdRbkDQBFWLK9fzOxpUCWJZK9i3p6Ta5qU59Ff2XR9ybSMjWJQMCn9ZnGZoH/hRWl4+ZZ2zi4Lng==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-languages-service-override/-/monaco-vscode-languages-service-override-18.1.3.tgz",
+      "integrity": "sha512-Kpaztomrh03dVSz8t+2mSh0q9maOx2zemdyC+WRxNf1eJOooOVaB9WJNUfbr8XKULm2gtr1JvzwZ0CV4mn2+Rw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-files-service-override": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-files-service-override": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-layout-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-15.0.2.tgz",
-      "integrity": "sha512-2CPl9z0MBN8HP71H5lf8uV60Z5Tgo1QdX9iQLQec0WWKBmQXL0Eid60F1pB1RT//ABPspebZV+C9me4NrYo/hg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-layout-service-override/-/monaco-vscode-layout-service-override-18.1.3.tgz",
+      "integrity": "sha512-M1SNWE/Dd9xm5wdwTPXkEugbPBUCL6GFMcXWfns+PrqvhEizVYjQV82A5PaMP3vO9xkaYacADUVcBPSWkNHfxQ==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-d8236b3b-b91a-522d-89f4-94d70a546f6a-common": "15.0.2"
+        "@codingame/monaco-vscode-6bf85d7b-e6e3-54e9-9bc1-7e08d663f0f6-common": "18.1.3",
+        "@codingame/monaco-vscode-85886bdb-61c5-52f1-8eb7-d1d32f6f8cbd-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-lifecycle-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-lifecycle-service-override/-/monaco-vscode-lifecycle-service-override-15.0.2.tgz",
-      "integrity": "sha512-kXk5CW92DOIoYere02eLQ/zYpNMRhcPIbGvzWXX9bc4NA77JxCNMZqiR1w83KzIchXrvOl3ONeN1P7WbTIQbvA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-lifecycle-service-override/-/monaco-vscode-lifecycle-service-override-18.1.3.tgz",
+      "integrity": "sha512-xFHqFPs1D5ZLelumDRvoqj4A7PhAJOuBlDkrlrXblVo6n/NYcJT/NOj5mAzfPMvBiO6hoxz2Oiw0ExfTrwk0Kw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-localization-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-localization-service-override/-/monaco-vscode-localization-service-override-15.0.2.tgz",
-      "integrity": "sha512-kRKbOmHof6o9w0zkUCMOyNA9/hwVJuRqOI74WHKHF7efisJaurn1fqQbFhwNsO0uD0ax0taYjSvU1nI2iCMH8A==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-localization-service-override/-/monaco-vscode-localization-service-override-18.1.3.tgz",
+      "integrity": "sha512-NasQQH/sLMdEXS2r9bMFVvmokY6hpUiotURf0Jxp0Y+jAyF/IH5yFQJI4WqF3UB6K7WHIhRFcUxxx6USiiOQgw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-7ba0af96-90c2-5e11-ad7f-befdbbf246c8-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-93784a59-b4cf-520c-8339-f8104d3a4f3e-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-log-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-log-service-override/-/monaco-vscode-log-service-override-15.0.2.tgz",
-      "integrity": "sha512-2ihDMYGJ0gkR0Uv8Lqjky66IbOzqHh3EfNcY0Jwl3gkKnie5D0OC4FOP6JWMuYjfFMS97a5LTeiiJ7xoAjD42w==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-log-service-override/-/monaco-vscode-log-service-override-18.1.3.tgz",
+      "integrity": "sha512-f+9BuxPzjQirlJJzduihWvIW6DGRam51Srf6wiz5cZVuRTYcP7+Z5BCDZuazeStGqMX5SpmuT5pV/j4rsMSLqg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-abed5a84-8a82-5f84-9412-88a736235bae-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-cea4d01f-6526-5c2f-8b09-b168fead499f-common": "15.0.2",
-        "@codingame/monaco-vscode-environment-service-override": "15.0.2"
+        "@codingame/monaco-vscode-abed5a84-8a82-5f84-9412-88a736235bae-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-cea4d01f-6526-5c2f-8b09-b168fead499f-common": "18.1.3",
+        "@codingame/monaco-vscode-environment-service-override": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-model-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-model-service-override/-/monaco-vscode-model-service-override-15.0.2.tgz",
-      "integrity": "sha512-FnORHgAmY5+zx5pZgaVxnaj12CjA0j1FiSrYiRjWj//AvRcaGBTh8QuRtZZvB6wk6Lh6SgmMN5ALwbzdQuDkSA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-model-service-override/-/monaco-vscode-model-service-override-18.1.3.tgz",
+      "integrity": "sha512-dJrZzPJfuum9piB0OSMMz1lb/Qo2bflFu5CIApVtsZHbnTtMXL2hizu5l5pDDvaBDl57J64F7nhoXz1YqbLLyg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-0c06bfba-d24d-5c4d-90cd-b40cefb7f811-common": "15.0.2",
-        "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "15.0.2",
-        "@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-0c06bfba-d24d-5c4d-90cd-b40cefb7f811-common": "18.1.3",
+        "@codingame/monaco-vscode-4ee27008-17b4-593f-9c09-19e8e3077f51-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-monarch-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-monarch-service-override/-/monaco-vscode-monarch-service-override-15.0.2.tgz",
-      "integrity": "sha512-G7LFMgUrq1sIYR+5lsX8t5UZI7X6vvREvRlewaofr44R1+NlARkGKJ5S431ruOlVUf8YxwuwqjeuNWAFGDbbfA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-monarch-service-override/-/monaco-vscode-monarch-service-override-18.1.3.tgz",
+      "integrity": "sha512-hEgGHZenOBg4gbWdHsBQDCApfbgjjIE+jRbHmmVkQYrdu7oTtMn8hh/xZX6uyldoPBJZ0TGNp3GU6FOd42Ap7w==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
+      }
+    },
+    "node_modules/@codingame/monaco-vscode-outline-service-override": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-outline-service-override/-/monaco-vscode-outline-service-override-18.1.3.tgz",
+      "integrity": "sha512-R/I6qQyIkPcXHGs3MfZMLgZBqYv6qg2Vut4WjZohRCVM/MuZNvgFS7xGEJrjYiAdTLp4fCc8LJLzwOLT0FMQ9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codingame/monaco-vscode-0094ae09-a688-53e7-bacc-93e26f7f49db-common": "18.1.3",
+        "@codingame/monaco-vscode-0cd5242b-7b61-5f66-ac25-ffa40baf8e8f-common": "18.1.3",
+        "@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-b71b5434-ce96-5581-8993-e8da380bd63f-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-preferences-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-preferences-service-override/-/monaco-vscode-preferences-service-override-15.0.2.tgz",
-      "integrity": "sha512-1Vohw10/0YtFsvgwy5rKVx7URG5JQqwFhjZFpcgJru5rcSZ8Gq15wmv1IwMEwUcQp/LQ84JyyYY+Ap6yvNjRNQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-preferences-service-override/-/monaco-vscode-preferences-service-override-18.1.3.tgz",
+      "integrity": "sha512-JDuQinHipeLlYLHbnlthKnSI87zdBIntzCeEH2FgVQhoUiHp/3h7onjD2SHH/eSzOjjiWxFGMojD3fyPAMf4/Q==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-0f5ced28-abde-558b-8652-db8e7d4d64aa-common": "15.0.2",
-        "@codingame/monaco-vscode-10418ae3-ee63-5700-a757-89cbe6564ee4-common": "15.0.2",
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-1bb39316-6fbf-572e-ab6a-818a2496c14f-common": "15.0.2",
-        "@codingame/monaco-vscode-2e69e120-617a-5258-95e0-3b8902f4e014-common": "15.0.2",
-        "@codingame/monaco-vscode-422642f2-7e3a-5c1c-9e1e-1d3ef1817346-common": "15.0.2",
-        "@codingame/monaco-vscode-52bb4d5b-ba1a-57fd-9bee-b28824214eac-common": "15.0.2",
-        "@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common": "15.0.2",
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-b1249c5b-1339-5278-b002-746f08105c6d-common": "15.0.2",
-        "@codingame/monaco-vscode-c3b3387c-7bce-5b8f-9e14-bebeb636f1c8-common": "15.0.2",
-        "@codingame/monaco-vscode-d609a7d3-bf87-551a-884f-550a8b327ec5-common": "15.0.2",
-        "@codingame/monaco-vscode-e72c94ca-257a-5b75-8b68-5a5fa3c18255-common": "15.0.2",
-        "@codingame/monaco-vscode-fc985c90-0334-5b62-88bc-73e2efa0b80b-common": "15.0.2",
-        "@codingame/monaco-vscode-fdf643f9-94dd-5510-b97a-408abf26ad92-common": "15.0.2"
+        "@codingame/monaco-vscode-0094ae09-a688-53e7-bacc-93e26f7f49db-common": "18.1.3",
+        "@codingame/monaco-vscode-158b9837-fc78-5d9c-86f5-9134e4358643-common": "18.1.3",
+        "@codingame/monaco-vscode-422642f2-7e3a-5c1c-9e1e-1d3ef1817346-common": "18.1.3",
+        "@codingame/monaco-vscode-7869cfe8-f42c-5721-9f2b-7d04a6a41f16-common": "18.1.3",
+        "@codingame/monaco-vscode-8bcd87e5-7461-57cf-b4e4-a7b00d2b33df-common": "18.1.3",
+        "@codingame/monaco-vscode-8d39d04c-3201-5bd6-be79-eed8d17a5ad0-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "18.1.3",
+        "@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common": "18.1.3",
+        "@codingame/monaco-vscode-a3eaa464-944c-5b8f-8886-213068ba4897-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-c3b3387c-7bce-5b8f-9e14-bebeb636f1c8-common": "18.1.3",
+        "@codingame/monaco-vscode-c87fff3a-2aa9-52ab-ba4d-17e8d1e5e185-common": "18.1.3",
+        "@codingame/monaco-vscode-ce7c734f-7712-563c-9335-d7acb43306af-common": "18.1.3",
+        "@codingame/monaco-vscode-d609a7d3-bf87-551a-884f-550a8b327ec5-common": "18.1.3",
+        "@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": "18.1.3",
+        "@codingame/monaco-vscode-e72c94ca-257a-5b75-8b68-5a5fa3c18255-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-python-default-extension": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-python-default-extension/-/monaco-vscode-python-default-extension-15.0.2.tgz",
-      "integrity": "sha512-ip8ZjA4CrDxVirbsdXQp4iA5CMAwyYtgkvrmxzIDaGNl4oZJ9gkXdMxofQQJsrqMXUxEEu23ZnkGGs3e4E1VPg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-python-default-extension/-/monaco-vscode-python-default-extension-18.1.3.tgz",
+      "integrity": "sha512-l5bcNdw4ZNrpiJLWz0SPUU/rnhF+caTfE/8GtMGiBYj+9n8UY6Dg+sf9AUogVGTbB5RuUV8+4+fZYHM8/4xS2Q==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-quickaccess-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-15.0.2.tgz",
-      "integrity": "sha512-KK/n7l1bJOSW1RKDL1DvIIWrxd3WRnhVtkEz4mNDMreGYsfbaUF5t6gw4pKP/r+blk9ZO/ZTm6+udZMUZ2gEnQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-quickaccess-service-override/-/monaco-vscode-quickaccess-service-override-18.1.3.tgz",
+      "integrity": "sha512-eDhYCBQA4SpmAjBicfiAAeM0LN/+9RmvA8ziz92rvtOihxr431pk1o8I/rIxyxjdo/Z43rI6weiNzkEZPOTNeQ==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-40cada32-7e9c-528a-81fc-766e4da54147-common": "15.0.2",
-        "@codingame/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common": "15.0.2",
-        "@codingame/monaco-vscode-4ead9d5f-54da-5c5a-b093-32be4a84d711-common": "15.0.2",
-        "@codingame/monaco-vscode-7559b0be-bfa5-5fe6-b731-1973fe9fffa1-common": "15.0.2",
-        "@codingame/monaco-vscode-9a1a5840-af83-5d07-a156-ba32a36c5c4b-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-d609a7d3-bf87-551a-884f-550a8b327ec5-common": "15.0.2",
-        "@codingame/monaco-vscode-ea14e352-8f1c-5569-b79a-8a96a53e8abe-common": "15.0.2",
-        "@codingame/monaco-vscode-fc985c90-0334-5b62-88bc-73e2efa0b80b-common": "15.0.2"
+        "@codingame/monaco-vscode-158b9837-fc78-5d9c-86f5-9134e4358643-common": "18.1.3",
+        "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "18.1.3",
+        "@codingame/monaco-vscode-40cada32-7e9c-528a-81fc-766e4da54147-common": "18.1.3",
+        "@codingame/monaco-vscode-6c0f93b9-169c-58c3-a9cb-7d60698eb52c-common": "18.1.3",
+        "@codingame/monaco-vscode-9a1a5840-af83-5d07-a156-ba32a36c5c4b-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-d609a7d3-bf87-551a-884f-550a8b327ec5-common": "18.1.3",
+        "@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": "18.1.3",
+        "@codingame/monaco-vscode-ea14e352-8f1c-5569-b79a-8a96a53e8abe-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-remote-agent-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-remote-agent-service-override/-/monaco-vscode-remote-agent-service-override-15.0.2.tgz",
-      "integrity": "sha512-YZT9zGncgA4mTFkA8/fGdpbP1cpOEzzTKZwCQg5F52FLOyDqiODj3cArWYaUt/AbVbL0fJB+NKU7DDMgYLHysA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-remote-agent-service-override/-/monaco-vscode-remote-agent-service-override-18.1.3.tgz",
+      "integrity": "sha512-68o4/k/d28EDWNIfTDgGd/3S1WMULvZCrf/TReY7XjgSlDMq/e9SXBBi+EvyAx/s0fj+m+Kdb5WtUY8WsExyQw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-1b4486de-4fe4-59c4-9e6d-34f265ff6625-common": "15.0.2",
-        "@codingame/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common": "15.0.2",
-        "@codingame/monaco-vscode-55ed5668-e8ca-5335-a587-790bcf1200c0-common": "15.0.2",
-        "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "15.0.2",
-        "@codingame/monaco-vscode-7559b0be-bfa5-5fe6-b731-1973fe9fffa1-common": "15.0.2",
-        "@codingame/monaco-vscode-7ba0af96-90c2-5e11-ad7f-befdbbf246c8-common": "15.0.2",
-        "@codingame/monaco-vscode-abed5a84-8a82-5f84-9412-88a736235bae-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-bd6ad8b7-9db3-51a8-9895-0046508c029d-common": "15.0.2",
-        "@codingame/monaco-vscode-environment-service-override": "15.0.2"
+        "@codingame/monaco-vscode-158b9837-fc78-5d9c-86f5-9134e4358643-common": "18.1.3",
+        "@codingame/monaco-vscode-1b4486de-4fe4-59c4-9e6d-34f265ff6625-common": "18.1.3",
+        "@codingame/monaco-vscode-2a94c04a-b85b-5669-b06b-89c1bfa11cb9-common": "18.1.3",
+        "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "18.1.3",
+        "@codingame/monaco-vscode-4a3ac544-9a61-534c-88df-756262793ef7-common": "18.1.3",
+        "@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": "18.1.3",
+        "@codingame/monaco-vscode-93784a59-b4cf-520c-8339-f8104d3a4f3e-common": "18.1.3",
+        "@codingame/monaco-vscode-abed5a84-8a82-5f84-9412-88a736235bae-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-environment-service-override": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-search-result-default-extension": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-search-result-default-extension/-/monaco-vscode-search-result-default-extension-15.0.2.tgz",
-      "integrity": "sha512-UjgRQMN1DpWeWXt6YJDEv+V2cvNowrkTjnptu6xMG22UVCxd8y0DtBiVwpZAjKyoDCczSUM4CKJVq4Rn/uijDA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-search-result-default-extension/-/monaco-vscode-search-result-default-extension-18.1.3.tgz",
+      "integrity": "sha512-22nmd5EggFQxnMQG9XvvxL0Lk85z8P/kLQIJm2Y3YMnIQs2/iA1Yzksr+W6KbOydzYP90IVrggyXPraktT/3/A==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-search-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-search-service-override/-/monaco-vscode-search-service-override-15.0.2.tgz",
-      "integrity": "sha512-rH+9Btqowdg9FcjWc6nfO/5JFD70OMNaf9vylVkj4g46QBCtr927Hq+esNBczyVLUbOtII2NP4nPNw8kKgic7w==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-search-service-override/-/monaco-vscode-search-service-override-18.1.3.tgz",
+      "integrity": "sha512-+bLOZF/G1ucKzDFpWbh8AuEv1R7Lxnx+iUs4BxHolxaMsp3UZWnVLaQFfIWSwrpVBqWyAY+txW8G1tisfLTXpA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-1ae7d696-d960-5ac6-97a3-9fe7c8c3a793-common": "15.0.2",
-        "@codingame/monaco-vscode-42931eb9-e564-530c-bafc-fa23ab43a070-common": "15.0.2",
-        "@codingame/monaco-vscode-45a408c6-90ed-5d8b-801d-f3f69c7a97f2-common": "15.0.2",
-        "@codingame/monaco-vscode-4ead9d5f-54da-5c5a-b093-32be4a84d711-common": "15.0.2",
-        "@codingame/monaco-vscode-523730aa-81e6-55d7-9916-87ad537fe087-common": "15.0.2",
-        "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "15.0.2",
-        "@codingame/monaco-vscode-695440c8-a687-5594-b476-bbc7b36bafe9-common": "15.0.2",
-        "@codingame/monaco-vscode-6f9bc782-77e0-5716-93bd-b05210c768c5-common": "15.0.2",
-        "@codingame/monaco-vscode-7559b0be-bfa5-5fe6-b731-1973fe9fffa1-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "15.0.2",
-        "@codingame/monaco-vscode-9a6d8b6c-ad4c-5ea3-9558-f43d6dc4c0ad-common": "15.0.2",
-        "@codingame/monaco-vscode-9b5a5e82-d649-5455-b4bf-ef90d6afd294-common": "15.0.2",
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-d56fc266-2991-5e70-8f69-134ad70e1700-common": "15.0.2",
-        "@codingame/monaco-vscode-ea14e352-8f1c-5569-b79a-8a96a53e8abe-common": "15.0.2"
+        "@codingame/monaco-vscode-158b9837-fc78-5d9c-86f5-9134e4358643-common": "18.1.3",
+        "@codingame/monaco-vscode-3cf6a388-482f-5484-a806-0525ad9ad8af-common": "18.1.3",
+        "@codingame/monaco-vscode-45a408c6-90ed-5d8b-801d-f3f69c7a97f2-common": "18.1.3",
+        "@codingame/monaco-vscode-47472025-cc45-5680-86cd-09ceaba921a1-common": "18.1.3",
+        "@codingame/monaco-vscode-523730aa-81e6-55d7-9916-87ad537fe087-common": "18.1.3",
+        "@codingame/monaco-vscode-64322fa2-7385-5f46-935b-8f243d98004b-common": "18.1.3",
+        "@codingame/monaco-vscode-85f7fb0f-70f5-5a5e-831b-15c743a8bd11-common": "18.1.3",
+        "@codingame/monaco-vscode-a8d3bd74-e63e-5327-96e8-4f931661e329-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-bc8c28cd-7a80-54a9-af1a-e6b1e7a7f34a-common": "18.1.3",
+        "@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": "18.1.3",
+        "@codingame/monaco-vscode-e28ac690-06d5-5ee9-92d1-02df70296354-common": "18.1.3",
+        "@codingame/monaco-vscode-ea14e352-8f1c-5569-b79a-8a96a53e8abe-common": "18.1.3",
+        "@codingame/monaco-vscode-f338ac19-278c-5fe1-bec8-b588de04a788-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-secret-storage-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-secret-storage-service-override/-/monaco-vscode-secret-storage-service-override-15.0.2.tgz",
-      "integrity": "sha512-zW2GVQqDaLfMGHVSEwm7Z/prNky8uj3mgKMeVV3Mx2L1Nq3Wzmp59j8sa7QIixqpFM8n/HyGOJZjaRksuLMr5A==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-secret-storage-service-override/-/monaco-vscode-secret-storage-service-override-18.1.3.tgz",
+      "integrity": "sha512-UtFQ3McWZ/XjjN/hcdr+5R1fKfA5K0RUTTYhyRI6PxUf1owAtacAmIYw77ofkWxsZxUlMBT9Zv97eDIvU+xYUg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-standalone-json-language-features": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-standalone-json-language-features/-/monaco-vscode-standalone-json-language-features-15.0.2.tgz",
-      "integrity": "sha512-RRBxi7UsTKYW9fmvArcFly4CHZTwtngFhk9YbgO+ghYO21TeUlrkGisnBO5FuKJkHE/63nOSEz3kCUjzmvkUIg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-standalone-json-language-features/-/monaco-vscode-standalone-json-language-features-18.1.3.tgz",
+      "integrity": "sha512-r+wEYnsZU8sKKmNJt/XzsDqnZcXo3g9OnBGmAVoJMVCwQ6x/guJRvyvdru4pvLTF8zLJqoH66IrblnYo3g8mGw==",
       "license": "MIT",
       "dependencies": {
-        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@15.0.2"
-      }
-    },
-    "node_modules/@codingame/monaco-vscode-standalone-languages": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-standalone-languages/-/monaco-vscode-standalone-languages-15.0.2.tgz",
-      "integrity": "sha512-ah83ra+eIW/TlZoYOBmJWEqVzcMVFTtJtZrnsrut8O4Lw7LAQHJdq9Iy0Xno75ss+AIj5j4InLiyn3Y56jOlUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@15.0.2"
+        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-standalone-typescript-language-features": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-standalone-typescript-language-features/-/monaco-vscode-standalone-typescript-language-features-15.0.2.tgz",
-      "integrity": "sha512-9XX7VIBKc3ht2GtoUnezrpfCETWMp4xXizj2MVzfsT+dppEQK93oTumMnCu+OvygW7PFLzzsJrZloNBLwGAvaw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-standalone-typescript-language-features/-/monaco-vscode-standalone-typescript-language-features-18.1.3.tgz",
+      "integrity": "sha512-4WxPoNTBW92cL2rk1NXFRYKcvzeG6HXOEU6t+QfL2SdhVn4cB99Of5VZ161JIdESNOEsj2akCAlA2AUIm4YLiA==",
       "license": "MIT",
       "dependencies": {
-        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@15.0.2"
+        "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-storage-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-storage-service-override/-/monaco-vscode-storage-service-override-15.0.2.tgz",
-      "integrity": "sha512-qmpAARkcn9r47bSOPP1Rw+O8NuIgFSq6jJdYos8XQ8AvPyCUwyB8KmnQlNpzqI1cy8dzX9ppf++VcxRxURRoBg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-storage-service-override/-/monaco-vscode-storage-service-override-18.1.3.tgz",
+      "integrity": "sha512-3p0C6QKoQWBbgN63d1K2BClTNIcD2pUxp4qTmgpd/hWHmRiJ3isQNMlI0c0aECAqZDIPo9IfmjqNCwpqg126/Q==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-2f06fe84-148e-5e6b-a7ca-c7989c5f128a-common": "15.0.2",
-        "@codingame/monaco-vscode-a2719803-af40-5ae9-a29f-8a2231c33056-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-2f06fe84-148e-5e6b-a7ca-c7989c5f128a-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-cecd476b-6f89-54b7-b016-fe6fdaa6675e-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-terminal-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-terminal-service-override/-/monaco-vscode-terminal-service-override-15.0.2.tgz",
-      "integrity": "sha512-4q4xGbttstM9DYyil2GorlsjrT4nF20g9rQMENkkD9huPRKEP1E1g++TeMv/I0sCaWDPVH1e6yQO3prHSiy1Rg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-terminal-service-override/-/monaco-vscode-terminal-service-override-18.1.3.tgz",
+      "integrity": "sha512-eyvPJV52FAZw9kYG00hfZsI6++mJ2x9BQ1Od7kisQK6UDpjd88awsvmtGtJsrqnDMjDd/aJ5HXrU9eR2LpvB2g==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common": "15.0.2",
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-1bb39316-6fbf-572e-ab6a-818a2496c14f-common": "15.0.2",
-        "@codingame/monaco-vscode-38f25ab8-ea30-5ba9-8a08-ae3308c297c0-common": "15.0.2",
-        "@codingame/monaco-vscode-422642f2-7e3a-5c1c-9e1e-1d3ef1817346-common": "15.0.2",
-        "@codingame/monaco-vscode-42931eb9-e564-530c-bafc-fa23ab43a070-common": "15.0.2",
-        "@codingame/monaco-vscode-45a408c6-90ed-5d8b-801d-f3f69c7a97f2-common": "15.0.2",
-        "@codingame/monaco-vscode-55ed5668-e8ca-5335-a587-790bcf1200c0-common": "15.0.2",
-        "@codingame/monaco-vscode-625898ab-0e33-5b7f-a3ae-29c10271dc1c-common": "15.0.2",
-        "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "15.0.2",
-        "@codingame/monaco-vscode-7559b0be-bfa5-5fe6-b731-1973fe9fffa1-common": "15.0.2",
-        "@codingame/monaco-vscode-7bbc9e7d-eeae-55fc-8bf9-dc2f66e0dc73-common": "15.0.2",
-        "@codingame/monaco-vscode-805e9c2f-56b6-5a43-8b5b-d2dc2d3805fc-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-9a6d8b6c-ad4c-5ea3-9558-f43d6dc4c0ad-common": "15.0.2",
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-c4e2825a-b5b1-5f0e-b547-068c32e06d50-common": "15.0.2",
-        "@codingame/monaco-vscode-f405f7ba-995b-5117-bc17-5bc7f77d92e9-common": "15.0.2",
-        "@codingame/monaco-vscode-f6ab89b2-83b0-5a43-8772-cb0eafa650b5-common": "15.0.2",
-        "@xterm/xterm": "5.6.0-beta.98"
+        "@codingame/monaco-vscode-07eaa805-9dea-5ec6-a422-a4f04872424d-common": "18.1.3",
+        "@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common": "18.1.3",
+        "@codingame/monaco-vscode-158b9837-fc78-5d9c-86f5-9134e4358643-common": "18.1.3",
+        "@codingame/monaco-vscode-2a94c04a-b85b-5669-b06b-89c1bfa11cb9-common": "18.1.3",
+        "@codingame/monaco-vscode-422642f2-7e3a-5c1c-9e1e-1d3ef1817346-common": "18.1.3",
+        "@codingame/monaco-vscode-45a408c6-90ed-5d8b-801d-f3f69c7a97f2-common": "18.1.3",
+        "@codingame/monaco-vscode-47472025-cc45-5680-86cd-09ceaba921a1-common": "18.1.3",
+        "@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": "18.1.3",
+        "@codingame/monaco-vscode-625898ab-0e33-5b7f-a3ae-29c10271dc1c-common": "18.1.3",
+        "@codingame/monaco-vscode-7adbeffb-8051-54a9-8c9b-b62ce9e5836f-common": "18.1.3",
+        "@codingame/monaco-vscode-7bbc9e7d-eeae-55fc-8bf9-dc2f66e0dc73-common": "18.1.3",
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-9ed6fe06-a052-57c2-a234-5d9b94d2e7e0-common": "18.1.3",
+        "@codingame/monaco-vscode-a8d3bd74-e63e-5327-96e8-4f931661e329-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-c465110a-57c0-59d7-a6b2-be0a4db7e517-common": "18.1.3",
+        "@codingame/monaco-vscode-d26a96d3-122c-5a3d-a04d-deb5ff0f19c0-common": "18.1.3",
+        "@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": "18.1.3",
+        "@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common": "18.1.3",
+        "@codingame/monaco-vscode-f405f7ba-995b-5117-bc17-5bc7f77d92e9-common": "18.1.3",
+        "@codingame/monaco-vscode-f48982c4-9e82-55e2-b800-20e6d1e6096f-common": "18.1.3",
+        "@codingame/monaco-vscode-f5d4b045-44e8-55a8-b683-308656a412fa-common": "18.1.3",
+        "@codingame/monaco-vscode-f6ab89b2-83b0-5a43-8772-cb0eafa650b5-common": "18.1.3",
+        "@xterm/xterm": "5.6.0-beta.107"
       }
     },
+    "node_modules/@codingame/monaco-vscode-terminal-service-override/node_modules/@xterm/xterm": {
+      "version": "5.6.0-beta.107",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.6.0-beta.107.tgz",
+      "integrity": "sha512-7cuJFZtc7Rv9BEpf9UsvErfXhLKkEmogI0mizgri+nNjEENnpQcFOpx84GFTjax/Zta8MAxOMUP1XU5Guju80A==",
+      "license": "MIT"
+    },
     "node_modules/@codingame/monaco-vscode-testing-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-testing-service-override/-/monaco-vscode-testing-service-override-15.0.2.tgz",
-      "integrity": "sha512-/6/wv4gFcl0gs1nexUhfhyLJCoSgQneSeIHyyKVoOuyc4dXaEyuFIgmvJbIsn2XGx4WxwsmptEx/CW80c6Ynog==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-testing-service-override/-/monaco-vscode-testing-service-override-18.1.3.tgz",
+      "integrity": "sha512-21Pe+m4McpVsKfHF/nMMxbV7K32PFXHG73PYReXGs1gcNctperC+Pla6Mz+ZN+Meg2u7qbwGGb2Wui+KS0w8Ng==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common": "15.0.2",
-        "@codingame/monaco-vscode-10418ae3-ee63-5700-a757-89cbe6564ee4-common": "15.0.2",
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-1bb39316-6fbf-572e-ab6a-818a2496c14f-common": "15.0.2",
-        "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "15.0.2",
-        "@codingame/monaco-vscode-6845754f-e617-5ed9-8aaa-6ca3653a9532-common": "15.0.2",
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-a7c9ae3c-16d2-5d17-86b2-981be7094566-common": "15.0.2",
-        "@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-f6ab89b2-83b0-5a43-8772-cb0eafa650b5-common": "15.0.2",
-        "@codingame/monaco-vscode-fdf643f9-94dd-5510-b97a-408abf26ad92-common": "15.0.2",
-        "@codingame/monaco-vscode-terminal-service-override": "15.0.2"
+        "@codingame/monaco-vscode-0b087f42-a5a3-5eb9-9bfd-1eebc1bba163-common": "18.1.3",
+        "@codingame/monaco-vscode-47472025-cc45-5680-86cd-09ceaba921a1-common": "18.1.3",
+        "@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": "18.1.3",
+        "@codingame/monaco-vscode-6845754f-e617-5ed9-8aaa-6ca3653a9532-common": "18.1.3",
+        "@codingame/monaco-vscode-7adbeffb-8051-54a9-8c9b-b62ce9e5836f-common": "18.1.3",
+        "@codingame/monaco-vscode-8bcd87e5-7461-57cf-b4e4-a7b00d2b33df-common": "18.1.3",
+        "@codingame/monaco-vscode-8d39d04c-3201-5bd6-be79-eed8d17a5ad0-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-937ecbdf-94c7-5b16-aefa-ad78ae557a93-common": "18.1.3",
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "18.1.3",
+        "@codingame/monaco-vscode-a4683c2b-a0d2-5112-96ba-eedc605346d2-common": "18.1.3",
+        "@codingame/monaco-vscode-a8d3bd74-e63e-5327-96e8-4f931661e329-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-b99aef83-0d60-5e8c-a62e-9908b6256f35-common": "18.1.3",
+        "@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common": "18.1.3",
+        "@codingame/monaco-vscode-f6ab89b2-83b0-5a43-8772-cb0eafa650b5-common": "18.1.3",
+        "@codingame/monaco-vscode-terminal-service-override": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-textmate-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-textmate-service-override/-/monaco-vscode-textmate-service-override-15.0.2.tgz",
-      "integrity": "sha512-3owPZ8QbpQGVIYw5xeoJQhEPvrHRyrNQ9Cp04MmbjXyj+PnNd6q9VtD6gK4vd+J5XXX0BtdaBS1EhsG1E4LNMA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-textmate-service-override/-/monaco-vscode-textmate-service-override-18.1.3.tgz",
+      "integrity": "sha512-py+NDboyrcB0d20ovCPcNNWyxuhfP4qpTUllSg7B1Eb5zSy2XHINMIK5xlBIIhfoqvfPdVymIR/M/v0fCbUePA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-33833ac7-3af3-5e9d-8fb9-11838d852c59-common": "15.0.2",
-        "@codingame/monaco-vscode-695440c8-a687-5594-b476-bbc7b36bafe9-common": "15.0.2",
-        "@codingame/monaco-vscode-7ba0af96-90c2-5e11-ad7f-befdbbf246c8-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-files-service-override": "15.0.2",
+        "@codingame/monaco-vscode-1ba786a5-b7d7-5d26-8a85-ae48ee2a74a4-common": "18.1.3",
+        "@codingame/monaco-vscode-33833ac7-3af3-5e9d-8fb9-11838d852c59-common": "18.1.3",
+        "@codingame/monaco-vscode-93784a59-b4cf-520c-8339-f8104d3a4f3e-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-files-service-override": "18.1.3",
         "vscode-oniguruma": "1.7.0",
         "vscode-textmate": "9.2.0"
       }
     },
     "node_modules/@codingame/monaco-vscode-theme-defaults-default-extension": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-theme-defaults-default-extension/-/monaco-vscode-theme-defaults-default-extension-15.0.2.tgz",
-      "integrity": "sha512-o66dXwgoNlj3rx9MT8TX2OtSugeK7bd8/PWlcwZLt6XrqE4T082mnFBPpGPpCOQXgsWJbYFTvbJMMuVM4XWfqA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-theme-defaults-default-extension/-/monaco-vscode-theme-defaults-default-extension-18.1.3.tgz",
+      "integrity": "sha512-Dbv4VpVb2aIJUA6BkT/AaRp9Pu5Ob/8akQOKQck+NecDQX1+Hp4Zz97YEPPUbt5faWt7UXMKTNNY70ql3shTEw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-theme-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-theme-service-override/-/monaco-vscode-theme-service-override-15.0.2.tgz",
-      "integrity": "sha512-vNi4Gk8okoLYJi77qXe5l8L4WGFHsUpgQYa5T+yPtfcupOX1ZEGr2W9DCjAzWPijWdbaL73kttFw/3QTs3z+tA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-theme-service-override/-/monaco-vscode-theme-service-override-18.1.3.tgz",
+      "integrity": "sha512-93sIwc+Pfbh+v1daYKKDv40zKzXz2agYvouvgof2POe3YhaPbIV7kIJq52x0IiP7SIsEYcAngPSZZiQ5SEbQ5A==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common": "15.0.2",
-        "@codingame/monaco-vscode-7ba0af96-90c2-5e11-ad7f-befdbbf246c8-common": "15.0.2",
-        "@codingame/monaco-vscode-9d0168a3-519b-57f3-9bcc-89efc41f951a-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-files-service-override": "15.0.2"
+        "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "18.1.3",
+        "@codingame/monaco-vscode-93784a59-b4cf-520c-8339-f8104d3a4f3e-common": "18.1.3",
+        "@codingame/monaco-vscode-9d0168a3-519b-57f3-9bcc-89efc41f951a-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-files-service-override": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-typescript-basics-default-extension": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-typescript-basics-default-extension/-/monaco-vscode-typescript-basics-default-extension-15.0.2.tgz",
-      "integrity": "sha512-ze2c+XOsPvwghY9Hu6nc9zyR2pFrqVLPjP1cDgHeCb9u3IabD18MNfQ8FTTWVFSgpilUoEhbAb4oWWSxzM27JQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-typescript-basics-default-extension/-/monaco-vscode-typescript-basics-default-extension-18.1.3.tgz",
+      "integrity": "sha512-4hx0dpQGXfUGQgEta+LUHILVn8p/CtF96j0PwSglDqNtQW0G8cmAgI6VV1NwsZ0ZwayfdVfX4XE51g+qlTF02w==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-typescript-language-features-default-extension": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-typescript-language-features-default-extension/-/monaco-vscode-typescript-language-features-default-extension-15.0.2.tgz",
-      "integrity": "sha512-iAeVUjBN32/v9IW/7osm9v/1cjPGgcFHjA8xmmSn/ogN7j947Ycgx12Fw65jTrb/wBu7m11Vq0WMFYRCxQCYUA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-typescript-language-features-default-extension/-/monaco-vscode-typescript-language-features-default-extension-18.1.3.tgz",
+      "integrity": "sha512-ofAU/dYw2jdh+JZDz8A96qyHMwynPxCaq1TNWdQtvMFav91l+neU5eG3Rr2Wpfmpu1eZpo7Mj9jw7lr1fX5TsA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-view-banner-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-banner-service-override/-/monaco-vscode-view-banner-service-override-15.0.2.tgz",
-      "integrity": "sha512-L0ZjRIl+u8G6IHy2JvjEZp7RkGxFgJMnqTyJun1W3vINQe2eiVgM/7m+0Ac1pz6kOJC7cziRupa34LCidH4sJw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-banner-service-override/-/monaco-vscode-view-banner-service-override-18.1.3.tgz",
+      "integrity": "sha512-GB1OCSNF33b88KcJq7R6KjjHH2aHXAlIteKDY+3I287TWqFe1FbEFUehaSYAB2zRRCIwNokYp2dev1DovX0a7g==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-d8236b3b-b91a-522d-89f4-94d70a546f6a-common": "15.0.2"
+        "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "18.1.3",
+        "@codingame/monaco-vscode-85886bdb-61c5-52f1-8eb7-d1d32f6f8cbd-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-view-common-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-common-service-override/-/monaco-vscode-view-common-service-override-15.0.2.tgz",
-      "integrity": "sha512-tbKXC7T30bFDc+EoI9yAVcJ2ruVdoanskZRmcRUM3SJglELj4FRAVO9pmb/jthDWSQgiEdBEQ7v6UdU9l6aQcg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-common-service-override/-/monaco-vscode-view-common-service-override-18.1.3.tgz",
+      "integrity": "sha512-pCP898KRKkbsx11Hy10gccn1fjAd7y2aArabom6+KD88EPqazRZ9MV2RBzAny1sc4tBYOmXJ8JTKNwjn0RqrUg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-0c06bfba-d24d-5c4d-90cd-b40cefb7f811-common": "15.0.2",
-        "@codingame/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common": "15.0.2",
-        "@codingame/monaco-vscode-0f5ced28-abde-558b-8652-db8e7d4d64aa-common": "15.0.2",
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-1b4486de-4fe4-59c4-9e6d-34f265ff6625-common": "15.0.2",
-        "@codingame/monaco-vscode-210e86a9-a91b-5273-b05d-390c776dde1f-common": "15.0.2",
-        "@codingame/monaco-vscode-29bc1406-2925-5b8f-b25e-d04a7772d896-common": "15.0.2",
-        "@codingame/monaco-vscode-38f25ab8-ea30-5ba9-8a08-ae3308c297c0-common": "15.0.2",
-        "@codingame/monaco-vscode-40cada32-7e9c-528a-81fc-766e4da54147-common": "15.0.2",
-        "@codingame/monaco-vscode-44b92f80-48ea-5562-a8d0-18a015f8d845-common": "15.0.2",
-        "@codingame/monaco-vscode-4a316137-39d1-5d77-8b53-112db3547c1e-common": "15.0.2",
-        "@codingame/monaco-vscode-523730aa-81e6-55d7-9916-87ad537fe087-common": "15.0.2",
-        "@codingame/monaco-vscode-55ed5668-e8ca-5335-a587-790bcf1200c0-common": "15.0.2",
-        "@codingame/monaco-vscode-65619f8f-0eab-5d8b-855a-43b6353fe527-common": "15.0.2",
-        "@codingame/monaco-vscode-6980eeab-47bb-5a48-8e15-32caf0785565-common": "15.0.2",
-        "@codingame/monaco-vscode-7559b0be-bfa5-5fe6-b731-1973fe9fffa1-common": "15.0.2",
-        "@codingame/monaco-vscode-7ba0af96-90c2-5e11-ad7f-befdbbf246c8-common": "15.0.2",
-        "@codingame/monaco-vscode-7f39b6f1-3542-5430-8760-0f404d7a7cee-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "15.0.2",
-        "@codingame/monaco-vscode-897bebad-39df-57cb-8a57-36a271d038be-common": "15.0.2",
-        "@codingame/monaco-vscode-89a82baf-8ded-5b2f-b8af-e5fbd72dc5ad-common": "15.0.2",
-        "@codingame/monaco-vscode-8ccb7637-50ea-5359-97bf-00015d7fe567-common": "15.0.2",
-        "@codingame/monaco-vscode-9b5a5e82-d649-5455-b4bf-ef90d6afd294-common": "15.0.2",
-        "@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common": "15.0.2",
-        "@codingame/monaco-vscode-a4c2011e-8775-52bd-abf0-4a3c07a9696b-common": "15.0.2",
-        "@codingame/monaco-vscode-a7c9ae3c-16d2-5d17-86b2-981be7094566-common": "15.0.2",
-        "@codingame/monaco-vscode-ad89fae6-94f0-5ac2-a185-22dea4b68ee0-common": "15.0.2",
-        "@codingame/monaco-vscode-aff8bc9b-c6f8-578f-9c8a-f70d14f9c13c-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-b1e8558d-1726-5299-bc75-e43ee6d1a124-common": "15.0.2",
-        "@codingame/monaco-vscode-bd6ad8b7-9db3-51a8-9895-0046508c029d-common": "15.0.2",
-        "@codingame/monaco-vscode-bulk-edit-service-override": "15.0.2",
-        "@codingame/monaco-vscode-c4e2825a-b5b1-5f0e-b547-068c32e06d50-common": "15.0.2",
-        "@codingame/monaco-vscode-d481a59e-259c-524e-bee1-76483d75d3a1-common": "15.0.2",
-        "@codingame/monaco-vscode-e59ecb8c-db32-5324-8fe4-cf9921fd92b8-common": "15.0.2",
-        "@codingame/monaco-vscode-e72c94ca-257a-5b75-8b68-5a5fa3c18255-common": "15.0.2",
-        "@codingame/monaco-vscode-fdf643f9-94dd-5510-b97a-408abf26ad92-common": "15.0.2",
-        "@codingame/monaco-vscode-ff9fa663-eae3-5274-8573-c2b918871e4b-common": "15.0.2"
+        "@codingame/monaco-vscode-0c06bfba-d24d-5c4d-90cd-b40cefb7f811-common": "18.1.3",
+        "@codingame/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common": "18.1.3",
+        "@codingame/monaco-vscode-158b9837-fc78-5d9c-86f5-9134e4358643-common": "18.1.3",
+        "@codingame/monaco-vscode-1b4486de-4fe4-59c4-9e6d-34f265ff6625-common": "18.1.3",
+        "@codingame/monaco-vscode-210e86a9-a91b-5273-b05d-390c776dde1f-common": "18.1.3",
+        "@codingame/monaco-vscode-2a94c04a-b85b-5669-b06b-89c1bfa11cb9-common": "18.1.3",
+        "@codingame/monaco-vscode-3109a756-1f83-5d09-945b-9f0fcad928f0-common": "18.1.3",
+        "@codingame/monaco-vscode-40cada32-7e9c-528a-81fc-766e4da54147-common": "18.1.3",
+        "@codingame/monaco-vscode-4372ad43-a220-5e78-83e6-95a9cfd64384-common": "18.1.3",
+        "@codingame/monaco-vscode-4a316137-39d1-5d77-8b53-112db3547c1e-common": "18.1.3",
+        "@codingame/monaco-vscode-4ee27008-17b4-593f-9c09-19e8e3077f51-common": "18.1.3",
+        "@codingame/monaco-vscode-501b06ab-3f58-516b-8a1a-c29d375d3da4-common": "18.1.3",
+        "@codingame/monaco-vscode-523730aa-81e6-55d7-9916-87ad537fe087-common": "18.1.3",
+        "@codingame/monaco-vscode-6980eeab-47bb-5a48-8e15-32caf0785565-common": "18.1.3",
+        "@codingame/monaco-vscode-7869cfe8-f42c-5721-9f2b-7d04a6a41f16-common": "18.1.3",
+        "@codingame/monaco-vscode-7f39b6f1-3542-5430-8760-0f404d7a7cee-common": "18.1.3",
+        "@codingame/monaco-vscode-897bebad-39df-57cb-8a57-36a271d038be-common": "18.1.3",
+        "@codingame/monaco-vscode-89a82baf-8ded-5b2f-b8af-e5fbd72dc5ad-common": "18.1.3",
+        "@codingame/monaco-vscode-8ccb7637-50ea-5359-97bf-00015d7fe567-common": "18.1.3",
+        "@codingame/monaco-vscode-924e8f00-6faf-5059-b518-e43427d29ab3-common": "18.1.3",
+        "@codingame/monaco-vscode-93784a59-b4cf-520c-8339-f8104d3a4f3e-common": "18.1.3",
+        "@codingame/monaco-vscode-937ecbdf-94c7-5b16-aefa-ad78ae557a93-common": "18.1.3",
+        "@codingame/monaco-vscode-95ea5c7c-15cf-50aa-8e24-38039b06b4a6-common": "18.1.3",
+        "@codingame/monaco-vscode-97284942-b044-5fbb-b53b-3f46d2468746-common": "18.1.3",
+        "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "18.1.3",
+        "@codingame/monaco-vscode-9c84f943-bcb5-5bcf-92a6-91f66a732f26-common": "18.1.3",
+        "@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common": "18.1.3",
+        "@codingame/monaco-vscode-a4683c2b-a0d2-5112-96ba-eedc605346d2-common": "18.1.3",
+        "@codingame/monaco-vscode-a8d3bd74-e63e-5327-96e8-4f931661e329-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-b1e8558d-1726-5299-bc75-e43ee6d1a124-common": "18.1.3",
+        "@codingame/monaco-vscode-bulk-edit-service-override": "18.1.3",
+        "@codingame/monaco-vscode-c3c61c00-c254-5856-9dc9-d7929c1f9062-common": "18.1.3",
+        "@codingame/monaco-vscode-d26a96d3-122c-5a3d-a04d-deb5ff0f19c0-common": "18.1.3",
+        "@codingame/monaco-vscode-d481a59e-259c-524e-bee1-76483d75d3a1-common": "18.1.3",
+        "@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": "18.1.3",
+        "@codingame/monaco-vscode-e59ecb8c-db32-5324-8fe4-cf9921fd92b8-common": "18.1.3",
+        "@codingame/monaco-vscode-e72c94ca-257a-5b75-8b68-5a5fa3c18255-common": "18.1.3",
+        "@codingame/monaco-vscode-f1bbc6d3-6129-583c-a2ba-c80b832993d2-common": "18.1.3",
+        "@codingame/monaco-vscode-f48982c4-9e82-55e2-b800-20e6d1e6096f-common": "18.1.3",
+        "@codingame/monaco-vscode-f5d4b045-44e8-55a8-b683-308656a412fa-common": "18.1.3",
+        "@codingame/monaco-vscode-ff9fa663-eae3-5274-8573-c2b918871e4b-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-view-status-bar-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-status-bar-service-override/-/monaco-vscode-view-status-bar-service-override-15.0.2.tgz",
-      "integrity": "sha512-/C09z2qfq/erWhu1msN+DbfsJAQrH4rM6MqkE/+zZsdcl6OqRFYvnV0aBBp9x3SXthnYWWZ7iwxX+lVCAq3MBQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-status-bar-service-override/-/monaco-vscode-view-status-bar-service-override-18.1.3.tgz",
+      "integrity": "sha512-qX5SMupu6onTSG8Q6E8xn+PUUTB4+/vmDZy4+GfIyfOYHo2SxkgAX0eFu6Ni1z/6scAgatKAVdHNlvXx2PvV6w==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common": "15.0.2",
-        "@codingame/monaco-vscode-2e69e120-617a-5258-95e0-3b8902f4e014-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-d8236b3b-b91a-522d-89f4-94d70a546f6a-common": "15.0.2"
+        "@codingame/monaco-vscode-0094ae09-a688-53e7-bacc-93e26f7f49db-common": "18.1.3",
+        "@codingame/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common": "18.1.3",
+        "@codingame/monaco-vscode-85886bdb-61c5-52f1-8eb7-d1d32f6f8cbd-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-view-title-bar-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-title-bar-service-override/-/monaco-vscode-view-title-bar-service-override-15.0.2.tgz",
-      "integrity": "sha512-9uB8ADGv071CNDHNbat7WsJPXCeB6yRvgKt0q1f10f4NJFR+IbLidGVcdwLwzeNeELHEZBIe6WrPxWAaiWeqiA==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-view-title-bar-service-override/-/monaco-vscode-view-title-bar-service-override-18.1.3.tgz",
+      "integrity": "sha512-uX1LRnsjJW0uWz8Vl9vpn/R1MRjTuhBv0DlgMoko91E5mJpiI9c3+lHR84g0ZGRw5JDfJF2eiGKiB81Z6f3T4w==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-2e69e120-617a-5258-95e0-3b8902f4e014-common": "15.0.2",
-        "@codingame/monaco-vscode-38f25ab8-ea30-5ba9-8a08-ae3308c297c0-common": "15.0.2",
-        "@codingame/monaco-vscode-40cada32-7e9c-528a-81fc-766e4da54147-common": "15.0.2",
-        "@codingame/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-d8236b3b-b91a-522d-89f4-94d70a546f6a-common": "15.0.2"
+        "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "18.1.3",
+        "@codingame/monaco-vscode-40cada32-7e9c-528a-81fc-766e4da54147-common": "18.1.3",
+        "@codingame/monaco-vscode-69cd7d65-4465-53e8-9718-bc4f6df50f7d-common": "18.1.3",
+        "@codingame/monaco-vscode-85886bdb-61c5-52f1-8eb7-d1d32f6f8cbd-common": "18.1.3",
+        "@codingame/monaco-vscode-96e83782-7f38-572e-8787-02e981f1c54f-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-dcfc2191-2da1-54c7-8fb7-e92c5d11ecef-common": "18.1.3",
+        "@codingame/monaco-vscode-f48982c4-9e82-55e2-b800-20e6d1e6096f-common": "18.1.3",
+        "@codingame/monaco-vscode-fc3b1755-9783-51f9-b3e6-45e7ef6fe6e3-common": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-views-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-views-service-override/-/monaco-vscode-views-service-override-15.0.2.tgz",
-      "integrity": "sha512-jbZ6AV9jnF22Q29DAl8nuJcQeOvDjXJrkT8OEMXs3dYAdZqkg7Y+P3ggW2G+EuMo2ytNrfhLBez8It7jJS+tAQ==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-views-service-override/-/monaco-vscode-views-service-override-18.1.3.tgz",
+      "integrity": "sha512-J/Y6aVXrtRW2vb/P3J4GgFhVV9p6UgETo+6KhfIAkfSLk4UAgxpxhUyWrFS53xzKduTsSDqrtGJrvRI5yFumQQ==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-0cc5da60-f921-59b9-bd8c-a018e93c0a6f-common": "15.0.2",
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-2e69e120-617a-5258-95e0-3b8902f4e014-common": "15.0.2",
-        "@codingame/monaco-vscode-6980eeab-47bb-5a48-8e15-32caf0785565-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "15.0.2",
-        "@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-d8236b3b-b91a-522d-89f4-94d70a546f6a-common": "15.0.2",
-        "@codingame/monaco-vscode-keybindings-service-override": "15.0.2",
-        "@codingame/monaco-vscode-layout-service-override": "15.0.2",
-        "@codingame/monaco-vscode-quickaccess-service-override": "15.0.2",
-        "@codingame/monaco-vscode-view-common-service-override": "15.0.2"
+        "@codingame/monaco-vscode-4ee27008-17b4-593f-9c09-19e8e3077f51-common": "18.1.3",
+        "@codingame/monaco-vscode-6980eeab-47bb-5a48-8e15-32caf0785565-common": "18.1.3",
+        "@codingame/monaco-vscode-6bf85d7b-e6e3-54e9-9bc1-7e08d663f0f6-common": "18.1.3",
+        "@codingame/monaco-vscode-85886bdb-61c5-52f1-8eb7-d1d32f6f8cbd-common": "18.1.3",
+        "@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common": "18.1.3",
+        "@codingame/monaco-vscode-a8d3bd74-e63e-5327-96e8-4f931661e329-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common": "18.1.3",
+        "@codingame/monaco-vscode-keybindings-service-override": "18.1.3",
+        "@codingame/monaco-vscode-layout-service-override": "18.1.3",
+        "@codingame/monaco-vscode-quickaccess-service-override": "18.1.3",
+        "@codingame/monaco-vscode-view-common-service-override": "18.1.3"
       }
     },
     "node_modules/@codingame/monaco-vscode-workbench-service-override": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-workbench-service-override/-/monaco-vscode-workbench-service-override-15.0.2.tgz",
-      "integrity": "sha512-w7SU4pQw1DWhMEZjWL+XIjxr/3v3hJdZRX5QDk8AQXvPZ+m4HxrPRHY8LF/kuPwHuB4oYrKQvU7WKy/OAS/PSw==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-workbench-service-override/-/monaco-vscode-workbench-service-override-18.1.3.tgz",
+      "integrity": "sha512-X3qFsr4GUguLUaj1XHrj7mxNUJWRKZLxyWkO3CqIqvJZnyOh0GgzZcuuYWjfem/Qurq3/MCmTtPXIaO498gFxQ==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-1021b67c-93e5-5c78-a270-cbdb2574d980-common": "15.0.2",
-        "@codingame/monaco-vscode-12c5f9eb-72d3-57ca-babd-5bef7aa9de3b-common": "15.0.2",
-        "@codingame/monaco-vscode-256d5b78-0649-50e9-8354-2807f95f68f4-common": "15.0.2",
-        "@codingame/monaco-vscode-2e69e120-617a-5258-95e0-3b8902f4e014-common": "15.0.2",
-        "@codingame/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common": "15.0.2",
-        "@codingame/monaco-vscode-494be54c-bd37-5b3c-af70-02f086e28768-common": "15.0.2",
-        "@codingame/monaco-vscode-6980eeab-47bb-5a48-8e15-32caf0785565-common": "15.0.2",
-        "@codingame/monaco-vscode-81f603ca-d6ea-5402-90dd-3014dffc63b4-common": "15.0.2",
-        "@codingame/monaco-vscode-86d65fc6-30f9-5dca-9501-e249de688591-common": "15.0.2",
-        "@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-d8236b3b-b91a-522d-89f4-94d70a546f6a-common": "15.0.2",
-        "@codingame/monaco-vscode-fdf643f9-94dd-5510-b97a-408abf26ad92-common": "15.0.2",
-        "@codingame/monaco-vscode-keybindings-service-override": "15.0.2",
-        "@codingame/monaco-vscode-quickaccess-service-override": "15.0.2",
-        "@codingame/monaco-vscode-view-banner-service-override": "15.0.2",
-        "@codingame/monaco-vscode-view-common-service-override": "15.0.2",
-        "@codingame/monaco-vscode-view-status-bar-service-override": "15.0.2",
-        "@codingame/monaco-vscode-view-title-bar-service-override": "15.0.2"
+        "@codingame/monaco-vscode-1021b67c-93e5-5c78-a270-cbdb2574d980-common": "18.1.3",
+        "@codingame/monaco-vscode-256d5b78-0649-50e9-8354-2807f95f68f4-common": "18.1.3",
+        "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "18.1.3",
+        "@codingame/monaco-vscode-494be54c-bd37-5b3c-af70-02f086e28768-common": "18.1.3",
+        "@codingame/monaco-vscode-4ee27008-17b4-593f-9c09-19e8e3077f51-common": "18.1.3",
+        "@codingame/monaco-vscode-6980eeab-47bb-5a48-8e15-32caf0785565-common": "18.1.3",
+        "@codingame/monaco-vscode-85886bdb-61c5-52f1-8eb7-d1d32f6f8cbd-common": "18.1.3",
+        "@codingame/monaco-vscode-9c72783f-914c-50be-b9ef-da16356d81a8-common": "18.1.3",
+        "@codingame/monaco-vscode-9c84f943-bcb5-5bcf-92a6-91f66a732f26-common": "18.1.3",
+        "@codingame/monaco-vscode-9efc1f50-c7de-55d6-8b28-bcc88bd49b5a-common": "18.1.3",
+        "@codingame/monaco-vscode-a8d3bd74-e63e-5327-96e8-4f931661e329-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-f24b7f0a-ceeb-5877-9148-81eb98a4f5d7-common": "18.1.3",
+        "@codingame/monaco-vscode-keybindings-service-override": "18.1.3",
+        "@codingame/monaco-vscode-quickaccess-service-override": "18.1.3",
+        "@codingame/monaco-vscode-view-banner-service-override": "18.1.3",
+        "@codingame/monaco-vscode-view-common-service-override": "18.1.3",
+        "@codingame/monaco-vscode-view-status-bar-service-override": "18.1.3",
+        "@codingame/monaco-vscode-view-title-bar-service-override": "18.1.3"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -2463,17 +2714,17 @@
       }
     },
     "node_modules/@typefox/monaco-editor-react": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@typefox/monaco-editor-react/-/monaco-editor-react-6.6.0.tgz",
-      "integrity": "sha512-8cqr4CCHQgdAbF+cxZNg7QOF4e3Oy2QAM7buTqiwAaKJxbWL5eZJPAO49fHYd3a/DpyUUZxjPURRoV788/zEeA==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@typefox/monaco-editor-react/-/monaco-editor-react-6.9.0.tgz",
+      "integrity": "sha512-licSlxaUEh6Xk1fUrSHs/nt2DC31TAhXjMf9AC2Sx6a9YIyNA3y8REkUi0NTSwmRckXdVxtCSM4/nAdVMvz3yw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-editor-api": "~15.0.2",
-        "monaco-editor-wrapper": "~6.6.0",
+        "@codingame/monaco-vscode-editor-api": "~18.1.0",
+        "monaco-editor-wrapper": "~6.9.0",
         "react": ">=18.0.0 || <20.0.0"
       },
       "engines": {
-        "node": ">=18.19.0",
+        "node": ">=20.10.0",
         "npm": ">=10.2.3"
       }
     },
@@ -2507,6 +2758,13 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vscode/iconv-lite-umd": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@vscode/iconv-lite-umd/-/iconv-lite-umd-0.7.0.tgz",
@@ -2520,30 +2778,30 @@
       "license": "MIT"
     },
     "node_modules/@xterm/addon-clipboard": {
-      "version": "0.2.0-beta.81",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-clipboard/-/addon-clipboard-0.2.0-beta.81.tgz",
-      "integrity": "sha512-vDxRyBO9VHzsl+gUQsDlUM9o2ZxSJKzE2eYQtuILKcf5D0EXYI86aMwKT/1iguX41vcMg42WXQBQ0TLWZ2MyTQ==",
+      "version": "0.2.0-beta.90",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-clipboard/-/addon-clipboard-0.2.0-beta.90.tgz",
+      "integrity": "sha512-2i7qtACRBYRTRba831ufEjQMeAvK4uuVPYPBkSXzKJ/dIAvhws5B6OOmxqZzR97OsmzUC/SrjHSujgwyD0MVVw==",
       "license": "MIT",
       "dependencies": {
         "js-base64": "^3.7.5"
       },
       "peerDependencies": {
-        "@xterm/xterm": "^5.6.0-beta.98"
+        "@xterm/xterm": "^5.6.0-beta.107"
       }
     },
     "node_modules/@xterm/addon-image": {
-      "version": "0.9.0-beta.98",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-image/-/addon-image-0.9.0-beta.98.tgz",
-      "integrity": "sha512-yJaezwUc1Y3QYCmYSpjFW9IzMTLPSqrRCgdPnQ0JbCAVASRVmH6DLRfeikheJCvoXW6VUwMmGkb3fSplTxiV1w==",
+      "version": "0.9.0-beta.107",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-image/-/addon-image-0.9.0-beta.107.tgz",
+      "integrity": "sha512-/vqb2BhVjJeCcOIDSpjWrfXbhNTCse95qkKbpmzFkQJJEh0CyaqjSUBIAM+Qcl9f/x6H//O2wADnn3Wsn5qYsg==",
       "license": "MIT",
       "peerDependencies": {
-        "@xterm/xterm": "^5.6.0-beta.98"
+        "@xterm/xterm": "^5.6.0-beta.107"
       }
     },
     "node_modules/@xterm/addon-ligatures": {
-      "version": "0.10.0-beta.98",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-ligatures/-/addon-ligatures-0.10.0-beta.98.tgz",
-      "integrity": "sha512-1zYeS9OUBR2ThG7dsxsGKOqeSlUo+DNTd5aaV5ZFbKQsQ1w+sQCaL73ZrXp1kuVK7pBiP5NCo4ffcXfzcztztA==",
+      "version": "0.10.0-beta.107",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-ligatures/-/addon-ligatures-0.10.0-beta.107.tgz",
+      "integrity": "sha512-3qQZz6dPS8XlGGwz1p5Bqjoosah6Km1GwGeNv7YxkCVU2kpTOymFH8BMUEOFC5WHdYseDXnz8hIEleexF9Pa2g==",
       "license": "MIT",
       "dependencies": {
         "font-finder": "^1.1.0",
@@ -2553,78 +2811,73 @@
         "node": ">8.0.0"
       },
       "peerDependencies": {
-        "@xterm/xterm": "^5.6.0-beta.98"
+        "@xterm/xterm": "^5.6.0-beta.107"
       }
     },
     "node_modules/@xterm/addon-progress": {
-      "version": "0.2.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-progress/-/addon-progress-0.2.0-beta.4.tgz",
-      "integrity": "sha512-7t1nlaANdEjUBVvuTTs5gw6UQgB+unFLwSGGnYXIvdQroYdkXQXSSATSqpYKVCd/6QFhBerzdB2VwPM5L5lxIw==",
+      "version": "0.2.0-beta.13",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-progress/-/addon-progress-0.2.0-beta.13.tgz",
+      "integrity": "sha512-BLmX+JdA+LLOMbVLQm+gPqieeKaVMiugBFpCtQtBus3kCs/2/F8pU/XNGV31CnXxDdRjptyOGrPVRreF/rDdcg==",
       "license": "MIT",
       "peerDependencies": {
-        "@xterm/xterm": "^5.6.0-beta.98"
+        "@xterm/xterm": "^5.6.0-beta.107"
       }
     },
     "node_modules/@xterm/addon-search": {
-      "version": "0.16.0-beta.98",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-search/-/addon-search-0.16.0-beta.98.tgz",
-      "integrity": "sha512-7gtx7eYvwFLxlb5q2IKxa7jG1KEinVwTlT3ijnSsPawwn7rGi6nR135rGiR8DAjEV0GUO406ICeoYyVbgiFNwQ==",
+      "version": "0.16.0-beta.107",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-search/-/addon-search-0.16.0-beta.107.tgz",
+      "integrity": "sha512-poHjeKjnTKtS6rHyu3r5lhW/0rdLcRMSJLDmT9xo9lfTuyhfcUl8gro44iPtscKY+LEtrhZcortTlElMewy/Bw==",
       "license": "MIT",
       "peerDependencies": {
-        "@xterm/xterm": "^5.6.0-beta.98"
+        "@xterm/xterm": "^5.6.0-beta.107"
       }
     },
     "node_modules/@xterm/addon-serialize": {
-      "version": "0.14.0-beta.98",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-serialize/-/addon-serialize-0.14.0-beta.98.tgz",
-      "integrity": "sha512-Tsr8j3wnun2raYR1DgsNClQP/I5a85u/uW/5EiYH+/iPPua6EWJvPlr5Q6TCU/cdIKW1o27Z3L5/mw0pfMUXrQ==",
+      "version": "0.14.0-beta.107",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-serialize/-/addon-serialize-0.14.0-beta.107.tgz",
+      "integrity": "sha512-MGaoO2zlNuSGofX5Xfbw+MU2wgAApEsDOPeYoEBSQyLf5BR7Z2rGVCxFyF5zNsIhNDov7ptQIVpCfonMVAgUvg==",
       "license": "MIT",
       "peerDependencies": {
-        "@xterm/xterm": "^5.6.0-beta.98"
+        "@xterm/xterm": "^5.6.0-beta.107"
       }
     },
     "node_modules/@xterm/addon-unicode11": {
-      "version": "0.9.0-beta.98",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-unicode11/-/addon-unicode11-0.9.0-beta.98.tgz",
-      "integrity": "sha512-3GjjEYAPWAEGE1CaTFDjQxKcY5NiHHPmeufTsRp3IL5850ZiaMMq9bIL2WSdoFIbVgfbxh5mRy2cJPdu9m0uRQ==",
+      "version": "0.9.0-beta.107",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-unicode11/-/addon-unicode11-0.9.0-beta.107.tgz",
+      "integrity": "sha512-XTfJ1G7u+8zOT6faCfEB49AbVFAX4XWUoiLtyXCfRvbrVuv5wv53T03dLtBtpwjWoFaveLKGl3ZiU7t3dpl0RA==",
       "license": "MIT",
       "peerDependencies": {
-        "@xterm/xterm": "^5.6.0-beta.98"
+        "@xterm/xterm": "^5.6.0-beta.107"
       }
     },
     "node_modules/@xterm/addon-webgl": {
-      "version": "0.19.0-beta.98",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.19.0-beta.98.tgz",
-      "integrity": "sha512-09FbNHgN2ad/8JI+AEyg8C3msyk04ET1FihQIpTeWPfd2LJIAdps7G4St2+qzZbhlFkR6m9Dgrgh/AC2uegh8A==",
+      "version": "0.19.0-beta.107",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.19.0-beta.107.tgz",
+      "integrity": "sha512-wdUkYiV4PnR9+7+1giJoFm5xrguCOKTH4xdQ/6lYuSbgMS0y1ykpcQjDNshwHy0TyUuh4o4z1+rd48qNjqGM6Q==",
       "license": "MIT",
       "peerDependencies": {
-        "@xterm/xterm": "^5.6.0-beta.98"
+        "@xterm/xterm": "^5.6.0-beta.107"
       }
     },
     "node_modules/@xterm/xterm": {
-      "version": "5.6.0-beta.98",
-      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.6.0-beta.98.tgz",
-      "integrity": "sha512-fJexj3XKDAMGsR8KKaiEhGrtJD1eRANbT3094E3KSgvbHRa3524tSFvDCx5+5KRE/hYaECmi0knAUIWJCvSPTg==",
-      "license": "MIT"
+      "version": "5.6.0-beta.115",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.6.0-beta.115.tgz",
+      "integrity": "sha512-EJXAW6dbxPuwQnLfTmPB5R3M5uu8qp24ltHdjCcfwGpudKxQRoDEbq1IeGrVLIuRc/8TbnT1U07dXUX7kyGYEQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
       "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2633,27 +2886,23 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
       },
       "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
+        "node": ">=18"
       }
     },
     "node_modules/brace-expansion": {
@@ -2688,9 +2937,9 @@
       }
     },
     "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
-      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2701,13 +2950,13 @@
       }
     },
     "node_modules/call-bound": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "get-intrinsic": "^1.2.6"
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2821,9 +3070,9 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -2842,19 +3091,22 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "license": "MIT"
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -2883,12 +3135,20 @@
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/depd": {
@@ -2900,16 +3160,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
@@ -2918,6 +3168,15 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -2968,9 +3227,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2995,45 +3254,41 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "license": "MIT",
       "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
       },
       "engines": {
-        "node": ">= 0.10.0"
+        "node": ">= 18"
       },
       "funding": {
         "type": "opencollective",
@@ -3041,18 +3296,17 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
-      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
-        "unpipe": "~1.0.0"
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
       },
       "engines": {
         "node": ">= 0.8"
@@ -3095,12 +3349,12 @@
       }
     },
     "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs.realpath": {
@@ -3134,27 +3388,40 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
-      "integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "dunder-proto": "^1.0.0",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
-        "math-intrinsics": "^1.0.0"
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-system-fonts": {
@@ -3240,13 +3507,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -3318,6 +3594,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -3358,9 +3640,9 @@
       }
     },
     "node_modules/langium": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/langium/-/langium-3.4.0.tgz",
-      "integrity": "sha512-7xufsaF5jYGFMXHOTka8bN48b9FHn2vZGL2R+PGgyi+JY/xgimUFDKYcz/h4gm5m8p3sSRtZDh+sK2U63K0MNg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-3.5.0.tgz",
+      "integrity": "sha512-tnqVzWOkUcoiY0bWlyE8diFrZjmGBCF7MesC1bjUaZM+YGQSfdPC+KkhmHM0DWFG+uLcPxidKaPP1SYGtg3J0Q==",
       "license": "MIT",
       "dependencies": {
         "chevrotain": "~11.0.3",
@@ -3422,60 +3704,42 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
       "license": "MIT",
       "dependencies": {
-        "mime-db": "1.52.0"
+        "mime-db": "^1.54.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -3506,141 +3770,168 @@
     },
     "node_modules/monaco-editor": {
       "name": "@codingame/monaco-vscode-editor-api",
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-editor-api/-/monaco-vscode-editor-api-15.0.2.tgz",
-      "integrity": "sha512-to1b/4bqfMDUTYZzkDZUFxJr7xYWDZ1lRKPKCyqhxt8TRShAIsItEQ6rZ3HrhjKJR4T1prwDyG1N4eCObFX4/g==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-editor-api/-/monaco-vscode-editor-api-18.1.3.tgz",
+      "integrity": "sha512-VSLWmToMS5/CiaP8tRX+JvUqDA2iECX9MZqUkTkaNgK976OPigVjyEdqia+85xwLjYnNLYfbh2YijFAXR3F5eA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-5452e2b7-9081-5f95-839b-4ab3544ce28f-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2"
+        "@codingame/monaco-vscode-5452e2b7-9081-5f95-839b-4ab3544ce28f-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3"
       }
     },
     "node_modules/monaco-editor-wrapper": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor-wrapper/-/monaco-editor-wrapper-6.6.0.tgz",
-      "integrity": "sha512-VkLf/zaiAphMq0VlTmlVWAswD4/zDbYDUDAro7bpWsgM7vLxDjm5boF+nHY+vcy585CVX+ce0t5uWI10Njmu9A==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor-wrapper/-/monaco-editor-wrapper-6.9.0.tgz",
+      "integrity": "sha512-JvmSNNdeyGXeTNDD+iRAt2Cf8wjaWfMKpA8YKFkBQ5KoA47Rwndcbu2dGcKNmT4AT/TwGQw4HvhsdEvvI7jySw==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "~15.0.2",
-        "@codingame/monaco-vscode-editor-api": "~15.0.2",
-        "@codingame/monaco-vscode-editor-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-extension-api": "~15.0.2",
-        "@codingame/monaco-vscode-language-pack-cs": "~15.0.2",
-        "@codingame/monaco-vscode-language-pack-de": "~15.0.2",
-        "@codingame/monaco-vscode-language-pack-es": "~15.0.2",
-        "@codingame/monaco-vscode-language-pack-fr": "~15.0.2",
-        "@codingame/monaco-vscode-language-pack-it": "~15.0.2",
-        "@codingame/monaco-vscode-language-pack-ja": "~15.0.2",
-        "@codingame/monaco-vscode-language-pack-ko": "~15.0.2",
-        "@codingame/monaco-vscode-language-pack-pl": "~15.0.2",
-        "@codingame/monaco-vscode-language-pack-pt-br": "~15.0.2",
-        "@codingame/monaco-vscode-language-pack-qps-ploc": "~15.0.2",
-        "@codingame/monaco-vscode-language-pack-ru": "~15.0.2",
-        "@codingame/monaco-vscode-language-pack-tr": "~15.0.2",
-        "@codingame/monaco-vscode-language-pack-zh-hans": "~15.0.2",
-        "@codingame/monaco-vscode-language-pack-zh-hant": "~15.0.2",
-        "@codingame/monaco-vscode-monarch-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-textmate-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-theme-defaults-default-extension": "~15.0.2",
-        "@codingame/monaco-vscode-theme-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-views-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-workbench-service-override": "~15.0.2",
-        "monaco-languageclient": "~9.5.0",
-        "vscode": "npm:@codingame/monaco-vscode-extension-api@~15.0.2",
+        "@codingame/monaco-vscode-api": "~18.1.0",
+        "@codingame/monaco-vscode-editor-api": "~18.1.0",
+        "@codingame/monaco-vscode-editor-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-extension-api": "~18.1.0",
+        "@codingame/monaco-vscode-language-pack-cs": "~18.1.0",
+        "@codingame/monaco-vscode-language-pack-de": "~18.1.0",
+        "@codingame/monaco-vscode-language-pack-es": "~18.1.0",
+        "@codingame/monaco-vscode-language-pack-fr": "~18.1.0",
+        "@codingame/monaco-vscode-language-pack-it": "~18.1.0",
+        "@codingame/monaco-vscode-language-pack-ja": "~18.1.0",
+        "@codingame/monaco-vscode-language-pack-ko": "~18.1.0",
+        "@codingame/monaco-vscode-language-pack-pl": "~18.1.0",
+        "@codingame/monaco-vscode-language-pack-pt-br": "~18.1.0",
+        "@codingame/monaco-vscode-language-pack-qps-ploc": "~18.1.0",
+        "@codingame/monaco-vscode-language-pack-ru": "~18.1.0",
+        "@codingame/monaco-vscode-language-pack-tr": "~18.1.0",
+        "@codingame/monaco-vscode-language-pack-zh-hans": "~18.1.0",
+        "@codingame/monaco-vscode-language-pack-zh-hant": "~18.1.0",
+        "@codingame/monaco-vscode-monarch-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-textmate-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-theme-defaults-default-extension": "~18.1.0",
+        "@codingame/monaco-vscode-theme-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-views-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-workbench-service-override": "~18.1.0",
+        "monaco-languageclient": "~9.8.0",
+        "vscode": "npm:@codingame/monaco-vscode-extension-api@~18.1.0",
         "vscode-languageclient": "~9.0.1",
         "vscode-languageserver-protocol": "~3.17.5",
         "vscode-ws-jsonrpc": "~3.4.0"
       },
       "engines": {
-        "node": ">=18.19.0",
+        "node": ">=20.10.0",
         "npm": ">=10.2.3"
       }
     },
     "node_modules/monaco-languageclient": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/monaco-languageclient/-/monaco-languageclient-9.5.0.tgz",
-      "integrity": "sha512-kl9DHbKxNh3fe5MDOZZLobIkU8q7BNUIEW1wUcnIW1V+Ti+pqbbgLEEM4sWQaVkMMaJE2ySoPtF3VhDh5rF3Rg==",
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/monaco-languageclient/-/monaco-languageclient-9.8.0.tgz",
+      "integrity": "sha512-xQ82vs0xWdeaxDK0lXJdN81CGC0gzMOVhmr7bN71y+tFezsToAW0+tt+IpQbyw1i3lQQxjdh1ci+Hu5CCx43ew==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-api": "~15.0.2",
-        "@codingame/monaco-vscode-configuration-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-editor-api": "~15.0.2",
-        "@codingame/monaco-vscode-editor-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-extension-api": "~15.0.2",
-        "@codingame/monaco-vscode-extensions-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-languages-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-localization-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-log-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-model-service-override": "~15.0.2",
-        "vscode": "npm:@codingame/monaco-vscode-extension-api@~15.0.2",
+        "@codingame/monaco-vscode-api": "~18.1.0",
+        "@codingame/monaco-vscode-configuration-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-editor-api": "~18.1.0",
+        "@codingame/monaco-vscode-editor-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-extension-api": "~18.1.0",
+        "@codingame/monaco-vscode-extensions-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-languages-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-localization-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-log-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-model-service-override": "~18.1.0",
+        "vscode": "npm:@codingame/monaco-vscode-extension-api@~18.1.0",
         "vscode-languageclient": "~9.0.1"
       },
       "engines": {
-        "node": ">=18.19.0",
+        "node": ">=20.10.0",
         "npm": ">=10.2.3"
       }
     },
     "node_modules/monaco-languageclient-examples": {
-      "version": "2025.3.6",
-      "resolved": "https://registry.npmjs.org/monaco-languageclient-examples/-/monaco-languageclient-examples-2025.3.6.tgz",
-      "integrity": "sha512-TGUeLLmDYBTeJVeZo51G2yMR4hpwsUl9/PpjyZmfaDGlNJGX+81vCbXRMBO9+LphmPgNUyT/KSE3HaCFx3WDAA==",
+      "version": "2025.6.2",
+      "resolved": "https://registry.npmjs.org/monaco-languageclient-examples/-/monaco-languageclient-examples-2025.6.2.tgz",
+      "integrity": "sha512-5Mh9lMHWvMnR5g/zHJFCzrTfDasK1CHw88u4yc56iM4Tc8JTegDwF0ULsGNoYqfZtyRukJjAEOiCu8D9PuZrWA==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-configuration-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-cpp-default-extension": "~15.0.2",
-        "@codingame/monaco-vscode-debug-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-editor-api": "~15.0.2",
-        "@codingame/monaco-vscode-environment-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-explorer-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-files-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-groovy-default-extension": "~15.0.2",
-        "@codingame/monaco-vscode-java-default-extension": "~15.0.2",
-        "@codingame/monaco-vscode-javascript-default-extension": "~15.0.2",
-        "@codingame/monaco-vscode-json-default-extension": "~15.0.2",
-        "@codingame/monaco-vscode-keybindings-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-lifecycle-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-localization-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-preferences-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-python-default-extension": "~15.0.2",
-        "@codingame/monaco-vscode-remote-agent-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-search-result-default-extension": "~15.0.2",
-        "@codingame/monaco-vscode-search-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-secret-storage-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-standalone-json-language-features": "~15.0.2",
-        "@codingame/monaco-vscode-standalone-languages": "~15.0.2",
-        "@codingame/monaco-vscode-standalone-typescript-language-features": "~15.0.2",
-        "@codingame/monaco-vscode-storage-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-testing-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-textmate-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-theme-defaults-default-extension": "~15.0.2",
-        "@codingame/monaco-vscode-theme-service-override": "~15.0.2",
-        "@codingame/monaco-vscode-typescript-basics-default-extension": "~15.0.2",
-        "@codingame/monaco-vscode-typescript-language-features-default-extension": "~15.0.2",
-        "@codingame/monaco-vscode-views-service-override": "~15.0.2",
-        "@typefox/monaco-editor-react": "~6.6.0",
+        "@codingame/monaco-vscode-configuration-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-cpp-default-extension": "~18.1.0",
+        "@codingame/monaco-vscode-debug-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-editor-api": "~18.1.0",
+        "@codingame/monaco-vscode-environment-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-explorer-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-files-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-groovy-default-extension": "~18.1.0",
+        "@codingame/monaco-vscode-java-default-extension": "~18.1.0",
+        "@codingame/monaco-vscode-javascript-default-extension": "~18.1.0",
+        "@codingame/monaco-vscode-json-default-extension": "~18.1.0",
+        "@codingame/monaco-vscode-keybindings-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-lifecycle-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-localization-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-outline-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-preferences-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-python-default-extension": "~18.1.0",
+        "@codingame/monaco-vscode-remote-agent-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-search-result-default-extension": "~18.1.0",
+        "@codingame/monaco-vscode-search-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-secret-storage-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-standalone-json-language-features": "~18.1.0",
+        "@codingame/monaco-vscode-standalone-typescript-language-features": "~18.1.0",
+        "@codingame/monaco-vscode-storage-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-testing-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-textmate-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-theme-defaults-default-extension": "~18.1.0",
+        "@codingame/monaco-vscode-theme-service-override": "~18.1.0",
+        "@codingame/monaco-vscode-typescript-basics-default-extension": "~18.1.0",
+        "@codingame/monaco-vscode-typescript-language-features-default-extension": "~18.1.0",
+        "@codingame/monaco-vscode-views-service-override": "~18.1.0",
+        "@typefox/monaco-editor-react": "~6.9.0",
         "cors": "^2.8.5",
-        "express": "~4.21.2",
+        "express": "~5.1.0",
         "jszip": "~3.10.1",
-        "langium": "~3.4.0",
-        "monaco-editor-wrapper": "~6.6.0",
-        "monaco-languageclient": "~9.5.0",
-        "pyright": "~1.1.396",
-        "react": "~19.0.0",
-        "react-dom": "~19.0.0",
+        "langium": "~3.5.0",
+        "monaco-editor-wrapper": "~6.9.0",
+        "monaco-languageclient": "~9.8.0",
+        "pyright": "~1.1.402",
+        "react": "~19.1.0",
+        "react-dom": "~19.1.0",
         "request-light": "~0.8.0",
-        "vscode": "npm:@codingame/monaco-vscode-extension-api@~15.0.2",
-        "vscode-json-languageservice": "~5.4.2",
+        "vscode": "npm:@codingame/monaco-vscode-extension-api@~18.1.0",
+        "vscode-json-languageservice": "~5.6.0",
         "vscode-languageclient": "~9.0.1",
         "vscode-languageserver": "~9.0.1",
         "vscode-uri": "~3.1.0",
         "vscode-ws-jsonrpc": "~3.4.0",
-        "ws": "~8.18.0",
+        "ws": "~8.18.2",
         "wtd-core": "~4.0.1"
       },
       "engines": {
-        "node": ">=18.19.0",
+        "node": ">=20.10.0",
         "npm": ">=10.2.3"
       }
+    },
+    "node_modules/monaco-languageclient-examples/node_modules/react": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/monaco-languageclient-examples/node_modules/react-dom": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
+      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.1"
+      }
+    },
+    "node_modules/monaco-languageclient-examples/node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
     },
     "node_modules/monaco-languageclient-examples/node_modules/vscode-uri": {
       "version": "3.1.0",
@@ -3649,9 +3940,9 @@
       "license": "MIT"
     },
     "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3673,9 +3964,9 @@
       }
     },
     "node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3745,9 +4036,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3772,7 +4063,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -3823,10 +4113,13 @@
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "license": "MIT"
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3891,9 +4184,9 @@
       }
     },
     "node_modules/pyright": {
-      "version": "1.1.396",
-      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.396.tgz",
-      "integrity": "sha512-+/8GN9ZRlqS/EFUjSW3yb2FN9XF7KjGpnLVYLtfTPDiiH+tfua898acKenUTGYbdfvSf7J0GD/g1b5RItnyYPw==",
+      "version": "1.1.403",
+      "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.403.tgz",
+      "integrity": "sha512-OyslngwxftKgNfbiyR8WDadUoLHDoinwUfbd50P1VBfLWkR5cro9R52qMQMpVI/LiSVpWbzunToR2NX7SanwmA==",
       "license": "MIT",
       "bin": {
         "pyright": "index.js",
@@ -3907,12 +4200,12 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -3931,14 +4224,14 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
+        "iconv-lite": "0.6.3",
         "unpipe": "1.0.0"
       },
       "engines": {
@@ -4023,6 +4316,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4068,57 +4377,40 @@
       }
     },
     "node_modules/send": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
       "license": "MIT",
       "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
       }
-    },
-    "node_modules/send/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/serve-static": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.19.0"
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
       }
     },
     "node_modules/setimmediate": {
@@ -4300,9 +4592,9 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -4389,13 +4681,14 @@
       "license": "0BSD"
     },
     "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "license": "MIT",
       "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -4437,15 +4730,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -4457,29 +4741,35 @@
     },
     "node_modules/vscode": {
       "name": "@codingame/monaco-vscode-extension-api",
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extension-api/-/monaco-vscode-extension-api-15.0.2.tgz",
-      "integrity": "sha512-qdt2VEKR6aI5Z7KAw5ex/dXD72k6lmKi4V+Po++De0YdSPPzqo4+KaNLiHqcM2FWXbgox4J+qE8ul9CZ131SMg==",
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/@codingame/monaco-vscode-extension-api/-/monaco-vscode-extension-api-18.1.3.tgz",
+      "integrity": "sha512-jv1sRVVIE4MXBcUGgPiDOZQMYOYL277CuJUdzt8GwvirgiEVvWJyl2aql572SgdkKRkAr42Jq5KFlgns0NSMeg==",
       "license": "MIT",
       "dependencies": {
-        "@codingame/monaco-vscode-411e0589-fa79-504b-b32c-80a88847b23a-common": "15.0.2",
-        "@codingame/monaco-vscode-api": "15.0.2",
-        "@codingame/monaco-vscode-bd6ad8b7-9db3-51a8-9895-0046508c029d-common": "15.0.2",
-        "@codingame/monaco-vscode-extensions-service-override": "15.0.2"
+        "@codingame/monaco-vscode-34a0ffd3-b9f5-5699-b43b-38af5732f38a-common": "18.1.3",
+        "@codingame/monaco-vscode-4a3ac544-9a61-534c-88df-756262793ef7-common": "18.1.3",
+        "@codingame/monaco-vscode-api": "18.1.3",
+        "@codingame/monaco-vscode-extensions-service-override": "18.1.3"
       }
     },
     "node_modules/vscode-json-languageservice": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-5.4.2.tgz",
-      "integrity": "sha512-2qujUseKRbLEwLXvEOFAxaz3y1ssdNCXXi95LRdG8AFchJHSnmI2qCg9ixoYxbJtSehIrXOmkhV87Y9lIivOgQ==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-5.6.1.tgz",
+      "integrity": "sha512-IQIURBF2VMKBdWcMunbHSI3G2WmJ9H7613E1hRxIXX7YsAPSdBxnEiIUrTnsSW/3fk+QW1kfsvSigqgAFYIYtg==",
       "license": "MIT",
       "dependencies": {
         "@vscode/l10n": "^0.0.18",
         "jsonc-parser": "^3.3.1",
         "vscode-languageserver-textdocument": "^1.0.12",
         "vscode-languageserver-types": "^3.17.5",
-        "vscode-uri": "^3.0.8"
+        "vscode-uri": "^3.1.0"
       }
+    },
+    "node_modules/vscode-json-languageservice/node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
@@ -4505,9 +4795,9 @@
       }
     },
     "node_modules/vscode-languageclient/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4603,13 +4893,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
### Problem
`vscode-ws-jsonrpc` was importing internal modules of `vscode-jsonrpc` such as:
  import { AbstractMessageReader } from 'vscode-jsonrpc/lib/common/messageReader.js';

With the introduction of an "exports" field in `vscode-jsonrpc` (Which was another problem in and of itself, here's the [issue](https://github.com/microsoft/vscode-languageserver-node/issues/1662)), consumers
can no longer reach into those internal paths, causing errors like:
 `Error: Package subpath './lib/common/messageReader.js' is not defined by "exports"`
Also, the existing TypeScript config did not consistently opt into
modern module resolution modes needed to work with exported subpaths.

### Solution
- Replaced all deep/internal `vscode-jsonrpc/lib/...` imports with public exports
  (e.g., `import { AbstractMessageReader } from 'vscode-jsonrpc'`).
- Adjusted `tsconfig.src.json` to enable `module: NodeNext`, `moduleResolution: NodeNext`,
  and enabled `declaration` output so the build can resolve the exported surface and
  emit type definitions correctly.
- Ensures compatibility with strict package export policies and avoids relying on
  implementation details.