### PR TITLE
Fix a typo

### DIFF
--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -13,7 +13,7 @@ All changes are noted in the [CHANGELOG](https://github.com/TypeFox/monaco-langu
 
 ## Getting Started
 
-This is npm package is part of the <https://github.com/TypeFox/monaco-languageclient> mono repo. Please follow the main repositories [instructions]](<https://github.com/TypeFox/monaco-languageclient#getting-started>) to get started with local development.
+This is npm package is part of the <https://github.com/TypeFox/monaco-languageclient> mono repo. Please follow the main repositories [instructions](<https://github.com/TypeFox/monaco-languageclient#getting-started>) to get started with local development.
 
 ## Usage
 

--- a/packages/vscode-ws-jsonrpc/README.md
+++ b/packages/vscode-ws-jsonrpc/README.md
@@ -8,7 +8,7 @@ All changes are noted in the [CHANGELOG](https://github.com/TypeFox/monaco-langu
 
 ## Getting Started
 
-This is npm package is part of the <https://github.com/TypeFox/monaco-languageclient> mono repo. Please follow the main repositories [instructions]](<https://github.com/TypeFox/monaco-languageclient#getting-started>) to get started with local development.
+This is npm package is part of the <https://github.com/TypeFox/monaco-languageclient> mono repo. Please follow the main repositories [instructions](<https://github.com/TypeFox/monaco-languageclient#getting-started>) to get started with local development.
 
 ## Usage
 


### PR DESCRIPTION
Previously the link shows up incorrectly in https://www.npmjs.com/package/vscode-ws-jsonrpc

<img width="934" height="191" alt="image" src="https://github.com/user-attachments/assets/7b27aea6-f8e7-41ed-9216-aac30548ecd4" />

