### PR TITLE
Updated migration guide, relaxed requirement to specify htmlContainer

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -20,8 +20,7 @@ import { MonacoVscodeApiWrapper, type MonacoVscodeApiConfig } from 'monaco-langu
 const vscodeApiConfig: MonacoVscodeApiConfig = {
     $type: 'extended',
     viewsConfig: {
-        $type: 'EditorService',
-        htmlContainer: document.getElementById('my-editor-dom-element')!
+        $type: 'EditorService'
     }
 };
 
@@ -43,8 +42,7 @@ import { configureDefaultWorkerFactory } from 'monaco-languageclient/workerFacto
 const vscodeApiConfig: MonacoVscodeApiConfig = {
     $type: 'extended',
     viewsConfig: {
-        $type: 'EditorService',
-        htmlContainer: document.getElementById('my-editor-dom-element')!
+        $type: 'EditorService'
     }
     logLevel: LogLevel.Info,
 
@@ -76,8 +74,7 @@ import { createDefaultLocaleConfiguration } from 'monaco-languageclient/vscodeAp
 const vscodeApiConfig: MonacoVscodeApiConfig = {
     $type: 'extended',
     viewsConfig: {
-        $type: 'EditorService',
-        htmlContainer: document.getElementById('my-editor-dom-element')!
+        $type: 'EditorService'
     }
 
     // Override specific services
@@ -145,8 +142,7 @@ import { MonacoVscodeApiWrapper, type MonacoVscodeApiConfig } from 'monaco-langu
 const vscodeApiConfig: MonacoVscodeApiConfig = {
     $type: 'classic',
     viewsConfig: {
-        $type: 'EditorService',
-        htmlContainer: document.getElementById('my-editor-dom-element')!
+        $type: 'EditorService'
     }
 };
 
@@ -155,7 +151,8 @@ await apiWrapper.start();
 
 const editorAppConfig: EditorAppConfig = {};
 const editorApp = new EditorApp(editorAppConfig);
-editorApp.start(apiWrapper.getHtmlContainer());
+const htmlContainer = document.getElementById('monaco-editor-root')!;
+await editorApp.start(htmlContainer);
 ```
 
 ## Common Configuration Options
@@ -308,7 +305,7 @@ await Promise.all([
 
 The configuration is validated at runtime. Common validation errors:
 
-- **Missing htmlContainer**: Must provide a DOM element for Extended Mode
+- **Missing htmlContainer**: Must provide a DOM element for `ViewsService` and `WorkbenchService`.
 - **Missing document selector**: Language clients need to know which files to handle
 
 ## Next Steps

--- a/docs/guides/examples.md
+++ b/docs/guides/examples.md
@@ -33,9 +33,7 @@ async function createJsonEditor() {
     const vscodeApiConfig = {
         $type: 'extended',
         viewsConfig: {
-            $type: 'EditorService',
-            // the div to which monaco-editor is added
-            htmlContainer: document.getElementById('monaco-editor-root')!
+            $type: 'EditorService'
         },
         logLevel: LogLevel.Debug,
         userConfiguration: {
@@ -85,7 +83,8 @@ async function createJsonEditor() {
     });
 
     // Start the editor
-    await editorApp.start(apiWrapper.getHtmlContainer());
+    const htmlContainer = document.getElementById('monaco-editor-root')!;
+    await editorApp.start(htmlContainer);
 
     console.log('JSON editor with language client is ready!');
 }
@@ -105,12 +104,10 @@ import { MonacoVscodeApiWrapper, type MonacoVscodeApiConfig } from 'monaco-langu
 import { defineDefaultWorkerLoaders, useWorkerFactory } from 'monaco-languageclient/workerFactory';
 
 export const runClient = async () => {
-    const htmlContainer = document.getElementById('monaco-editor-root')!;
     const vscodeApiConfig: MonacoVscodeApiConfig = {
         $type: 'classic',
         viewsConfig: {
-            $type: 'EditorService',
-            htmlContainer
+            $type: 'EditorService'
         },
         logLevel: LogLevel.Debug,
         userConfiguration: {
@@ -147,7 +144,8 @@ export const runClient = async () => {
         }
     };
     const editorApp = new EditorApp(editorAppConfig);
-    await editorApp.start(apiWrapper.getHtmlContainer());
+    const htmlContainer = document.getElementById('monaco-editor-root')!;
+    await editorApp.start(htmlContainer);
 
     const languageClientConfig: LanguageClientConfig = {
         languageId,
@@ -220,7 +218,9 @@ import '@codingame/monacovscode-java-default-extension';
 async function createMultiLanguageEditor() {
     const apiWrapper = new MonacoVscodeApiWrapper({
         $type: 'extended',
-        htmlContainer: document.getElementById('editor')!,
+        viewsConfig: {
+            $type: 'EditorService'
+        },
         monacoWorkerFactory: configureDefaultWorkerFactory
     });
     await apiWrapper.start();
@@ -247,7 +247,8 @@ async function createMultiLanguageEditor() {
         }
     });
 
-    await editorApp.init(wrapper);
+    const htmlContainer = document.getElementById('monaco-editor-root')!;
+    await editorApp.start(htmlContainer);
 }
 ```
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -72,8 +72,7 @@ async function createJsonEditor() {
     const vscodeApiConfig: MonacoVscodeApiConfig = {
         $type: 'extended',
         viewsConfig: {
-            $type: 'EditorService',
-            htmlContainer: document.getElementById('monaco-editor-root')!
+            $type: 'EditorService'
         },
         logLevel: LogLevel.Debug,
         userConfiguration: {
@@ -124,7 +123,8 @@ async function createJsonEditor() {
 
     // Create and start the editor app
     const editorApp = new EditorApp(editorAppConfig);
-    await editorApp.start(apiWrapper.getHtmlContainer());
+    const htmlContainer = document.getElementById('monaco-editor-root')!;
+    await editorApp.start(htmlContainer);
 
     console.log('JSON editor with language client is ready!');
 }

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -25,8 +25,7 @@ const vscodeApiConfig: MonacoVscodeApiConfig = {
     // both $type and viewsConfig are mandatory
     $type: 'extended',
     viewsConfig: {
-        $type: 'ViewsService',
-        htmlContainer: document.getElementById('monaco-editor-root')!
+        $type: 'ViewsService'
     },
     // further configuration
 };
@@ -44,8 +43,7 @@ const vscodeApiConfig: MonacoVscodeApiConfig = {
     $type: 'classic',
     viewsConfig: {
         // in classic mode only one type can be configured
-        $type: 'EditorService',
-        htmlContainer: document.getElementById('monaco-editor-root')!
+        $type: 'EditorService'
     },
     // further configuration
 };
@@ -65,7 +63,8 @@ await apiWrapper.start();
 
 // create editor with empty content
 const editorApp = new EditorApp({});
-await editorApp.start(apiWrapper.getHtmlContainer());
+const htmlContainer = document.getElementById('monaco-editor-root')!;
+await editorApp.start(htmlContainer);
 ```
 
 Generally you should start with Extended Mode unless you have specific constraints that require Classic Mode.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -51,8 +51,7 @@ import { LanguageClientWrapper, type LanguageClientConfig } from 'monaco-languag
 const vscodeApiConfig: MonacoVscodeApiConfig = {
     $type: 'extended',
     viewsConfig: {
-        $type: 'EditorService',
-        htmlContainer: document.getElementById('monaco-editor-root')!
+        $type: 'EditorService'
     }.
     // ...
 };
@@ -71,7 +70,8 @@ const lcWrapper = new LanguageClientWrapper(languageClientConfig);
 await lcWrapper.start();
 
 const editorApp = new EditorApp(editorAppConfig);
-await editorApp.start(apiWrapper.getHtmlContainer());
+const htmlContainer = document.getElementById('monaco-editor-root')!;
+await editorApp.start(htmlContainer);
 ```
 
 </td></tr>
@@ -91,7 +91,7 @@ The content and scope configuration objects `MonacoVscodeApiConfig`, `LanguageCl
 $type: 'extended',
 const wrapperConfig: WrapperConfig = {
     $type: 'extended',
-    htmlContainer,
+    htmlContainer: document.getElementById('monaco-editor-root')!
     vscodeApiConfig: {
         serviceOverrides: {
         },
@@ -106,9 +106,7 @@ const wrapperConfig: WrapperConfig = {
 const vscodeApiConfig: MonacoVscodeApiConfig = {
     $type: 'extended',
     viewsConfig: {
-        $type: 'EditorService',
-        // the div to which monaco-editor is added
-        htmlContainer: document.getElementById('monaco-editor-root')!
+        $type: 'EditorService'
     }
     // ...
 };
@@ -285,3 +283,44 @@ The callbacks names have been aligned and a couple have been added. None are man
 - `onError`: Called when an error occurred.
 - `onDisposeEditor`: **New** Called when `monaco-editor` has been disposed.
 - `onDisposeLanguageClient`: **New** Called when a language client has been disposed.
+
+## Service Initialization only
+
+If you used `initServices` to directly initializes services you have to change your approach. It is now possible to just rely on `MonacoVscodeApiWrapper` to perform the service initialization.
+
+<table>
+<tr><th>v9/v6</th><th>v10</th></tr>
+<tr><td>
+
+```ts
+import getKeybindingsServiceOverride from '@codingame/monaco-vscode-keybindings-service-override';
+import { initServices } from "monaco-languageclient/vscode/services";
+
+initServices({
+    serviceOverrides: {
+        ...getKeybindingsServiceOverride()
+    }
+};
+```
+
+</td><td>
+
+```ts
+import { MonacoVscodeApiWrapper, type MonacoVscodeApiConfig } from 'monaco-languageclient/vscodeApiWrapper';
+import getKeybindingsServiceOverride from '@codingame/monaco-vscode-keybindings-service-override';
+
+const vscodeApiConfig: MonacoVscodeApiConfig = {
+    $type: 'classic',
+    viewsConfig: {
+        $type: 'EditorService'
+    },
+    serviceOverrides: {
+        ...getKeybindingsServiceOverride()
+    }
+};
+const apiWrapper = new MonacoVscodeApiWrapper(vscodeApiConfig);
+await apiWrapper.start();
+```
+
+</td></tr>
+</table>

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -286,7 +286,7 @@ The callbacks names have been aligned and a couple have been added. None are man
 
 ## Service Initialization only
 
-If you used `initServices` to directly initializes services you have to change your approach. It is now possible to just rely on `MonacoVscodeApiWrapper` to perform the service initialization.
+If you used `initServices` to directly initialize services, you have to change your approach. It is now possible to just rely on `MonacoVscodeApiWrapper` to perform the service initialization.
 
 <table>
 <tr><th>v9/v6</th><th>v10</th></tr>

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -52,9 +52,7 @@ async function createEditorAndLanguageClient() {
     const vscodeApiConfig: MonacoVscodeApiConfig = {
         $type: 'extended',
         viewsConfig: {
-            $type: 'EditorService',
-            // the div to which monaco-editor is added
-            htmlContainer: document.getElementById('monaco-editor-root')!
+            $type: 'EditorService'
         },
         userConfiguration: {
             json: JSON.stringify({
@@ -105,7 +103,8 @@ async function createEditorAndLanguageClient() {
 
     // Create and start the editor app
     const editorApp = new EditorApp(editorAppConfig);
-    await editorApp.start(apiWrapper.getHtmlContainer());
+    const htmlContainer = document.getElementById('monaco-editor-root')!;
+    await editorApp.start(htmlContainer);
 }
 
 createEditorAndLanguageClient().catch(console.error);

--- a/packages/client/src/vscode/config.ts
+++ b/packages/client/src/vscode/config.ts
@@ -15,7 +15,7 @@ export type OverallConfigType = 'extended' | 'classic';
 
 export type ViewsConfigTypes = 'EditorService' | 'ViewsService' | 'WorkbenchService';
 
-export type HtmlContainerConfig = HTMLElement | 'ReactPlaceholder';
+// export type HtmlContainerConfig = HTMLElement;
 
 export interface MonacoEnvironmentEnhanced extends monaco.Environment {
     vscodeApiInitialising?: boolean;
@@ -31,7 +31,7 @@ export interface UserConfiguration {
 
 export interface ViewsConfig {
     $type: ViewsConfigTypes;
-    htmlContainer: HtmlContainerConfig;
+    htmlContainer?: HTMLElement;
     openEditorFunc?: OpenEditor;
     htmlAugmentationInstructions?: (htmlContainer: HTMLElement | null | undefined) => void;
     viewsInitFunc?: () => Promise<void>;

--- a/packages/client/test/editorApp/editorApp-classic.test.ts
+++ b/packages/client/test/editorApp/editorApp-classic.test.ts
@@ -14,7 +14,7 @@ import { createDefaultMonacoVscodeApiConfig, createEditorAppConfig, createMonaco
 describe('Test Test EditorApp (classic)', () => {
 
     const htmlContainer = createMonacoEditorDiv();
-    const apiConfig = createDefaultMonacoVscodeApiConfig('classic', htmlContainer);
+    const apiConfig = createDefaultMonacoVscodeApiConfig('classic', htmlContainer, 'EditorService');
 
     beforeAll(async () => {
         const apiWrapper = new MonacoVscodeApiWrapper(apiConfig);

--- a/packages/client/test/editorApp/editorApp.test.ts
+++ b/packages/client/test/editorApp/editorApp.test.ts
@@ -14,7 +14,7 @@ import { createDefaultMonacoVscodeApiConfig, createEditorAppConfig, createMonaco
 describe('Test EditorApp', () => {
 
     const htmlContainer = createMonacoEditorDiv();
-    const apiConfig = createDefaultMonacoVscodeApiConfig('extended', htmlContainer);
+    const apiConfig = createDefaultMonacoVscodeApiConfig('extended', htmlContainer, 'EditorService');
 
     beforeAll(async () => {
         const apiWrapper = new MonacoVscodeApiWrapper(apiConfig);

--- a/packages/client/test/editorApp/editorApp.wrongservices.test.ts
+++ b/packages/client/test/editorApp/editorApp.wrongservices.test.ts
@@ -11,15 +11,15 @@ import { createDefaultMonacoVscodeApiConfig, createEditorAppConfig, createMonaco
 describe('Test EditorApp', () => {
 
     test('Start EditorApp with no services', async () => {
-        const apiConfig = createDefaultMonacoVscodeApiConfig('extended', createMonacoEditorDiv());
-        apiConfig.viewsConfig.$type = 'ViewsService';
+        const htmlContainer = createMonacoEditorDiv();
+        const apiConfig = createDefaultMonacoVscodeApiConfig('extended', htmlContainer, 'ViewsService');
         const apiWrapper = new MonacoVscodeApiWrapper(apiConfig);
         await apiWrapper.start();
 
         const editorAppConfig = createEditorAppConfig({});
         const editorApp = new EditorApp(editorAppConfig);
         await expect(async () => {
-            await editorApp.start(apiWrapper.getHtmlContainer());
+            await editorApp.start(htmlContainer);
         }).rejects.toThrowError('No EditorService configured. monaco-editor will not be started.');
     });
 

--- a/packages/client/test/support/helper.ts
+++ b/packages/client/test/support/helper.ts
@@ -5,7 +5,7 @@
 
 import type { CodeResources, EditorAppConfig } from 'monaco-languageclient/editorApp';
 import type { LanguageClientConfig } from 'monaco-languageclient/lcwrapper';
-import type { MonacoVscodeApiConfig, OverallConfigType } from 'monaco-languageclient/vscodeApiWrapper';
+import type { MonacoVscodeApiConfig, OverallConfigType, ViewsConfigTypes } from 'monaco-languageclient/vscodeApiWrapper';
 import { configureDefaultWorkerFactory } from 'monaco-languageclient/workerFactory';
 import { MessageTransports } from 'vscode-languageclient/browser.js';
 
@@ -71,7 +71,7 @@ export const createEditorAppConfig = (codeResources: CodeResources): EditorAppCo
     };
 };
 
-export const createDefaultMonacoVscodeApiConfig = (overallConfigType: OverallConfigType, htmlContainer: HTMLElement): MonacoVscodeApiConfig => {
+export const createDefaultMonacoVscodeApiConfig = (overallConfigType: OverallConfigType, htmlContainer: HTMLElement, viewsConfigType: ViewsConfigTypes): MonacoVscodeApiConfig => {
     return {
         $type: overallConfigType,
         advanced: {
@@ -84,7 +84,7 @@ export const createDefaultMonacoVscodeApiConfig = (overallConfigType: OverallCon
             })
         },
         viewsConfig: {
-            $type: 'EditorService',
+            $type: viewsConfigType,
             htmlContainer
         },
         monacoWorkerFactory: configureDefaultWorkerFactory

--- a/packages/client/test/vscode/manager.test.ts
+++ b/packages/client/test/vscode/manager.test.ts
@@ -14,7 +14,7 @@ describe('MonacoVscodeApiWrapper Tests', () => {
     const htmlContainer = createMonacoEditorDiv();
 
     beforeAll(() => {
-        const apiConfig = createDefaultMonacoVscodeApiConfig('extended', htmlContainer);
+        const apiConfig = createDefaultMonacoVscodeApiConfig('extended', htmlContainer, 'EditorService');
         apiConfig.extensions = [{
             config: {
                 name: 'unit-test-extension',

--- a/packages/client/test/vscode/manager.wrongHtmlContainer.test.ts
+++ b/packages/client/test/vscode/manager.wrongHtmlContainer.test.ts
@@ -1,0 +1,43 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) 2025 TypeFox and others.
+ * Licensed under the MIT License. See LICENSE in the package root for license information.
+ * ------------------------------------------------------------------------------------------ */
+import { MonacoVscodeApiWrapper } from 'monaco-languageclient/vscodeApiWrapper';
+import { describe, expect, test } from 'vitest';
+import { createDefaultMonacoVscodeApiConfig, createMonacoEditorDiv } from '../support/helper.js';
+
+describe('MonacoVscodeApiWrapper Tests: Different config', () => {
+
+    const htmlContainer = createMonacoEditorDiv();
+
+    test('Start MonacoVscodeApiWrapper with ViewsService but no htmlContainer', async () => {
+        const apiConfig = createDefaultMonacoVscodeApiConfig('extended', htmlContainer, 'ViewsService');
+        apiConfig.viewsConfig.htmlContainer = undefined;
+
+        let apiWrapper: MonacoVscodeApiWrapper;
+        expect(() => {
+            apiWrapper = new MonacoVscodeApiWrapper(apiConfig!);
+        }).toThrowError('View Service Type "ViewsService" requires a HTMLElement.');
+        expect(apiWrapper!).toBeUndefined();
+    });
+
+    test('Start MonacoVscodeApiWrapper with WorkbenchService but no htmlContainer', async () => {
+        const apiConfig = createDefaultMonacoVscodeApiConfig('extended', htmlContainer, 'WorkbenchService');
+        apiConfig.viewsConfig.htmlContainer = undefined;
+
+        let apiWrapper: MonacoVscodeApiWrapper;
+        await expect(async () => {
+            apiWrapper = new MonacoVscodeApiWrapper(apiConfig!);
+        }).rejects.toThrowError('View Service Type "WorkbenchService" requires a HTMLElement.');
+        expect(apiWrapper!).toBeUndefined();
+    });
+
+    test('Start MonacoVscodeApiWrapper with EditorService but no htmlContainer', async () => {
+        const apiConfig = createDefaultMonacoVscodeApiConfig('extended', htmlContainer, 'EditorService');
+        apiConfig.viewsConfig.htmlContainer = undefined;
+
+        const apiWrapper = new MonacoVscodeApiWrapper(apiConfig!);
+        expect(apiWrapper).toBeDefined();
+    });
+
+});

--- a/packages/client/test/worker/workerLoaders.test.ts
+++ b/packages/client/test/worker/workerLoaders.test.ts
@@ -22,7 +22,7 @@ describe('Test WorkerLoaders', () => {
     const htmlContainer = createMonacoEditorDiv();
 
     beforeAll(async () => {
-        const apiConfig = createDefaultMonacoVscodeApiConfig('extended', htmlContainer);
+        const apiConfig = createDefaultMonacoVscodeApiConfig('extended', htmlContainer, 'EditorService');
         apiConfig.monacoWorkerFactory = configureClassicWorkerFactory;
         const apiWrapper = new MonacoVscodeApiWrapper(apiConfig);
         await apiWrapper.start();

--- a/packages/examples/src/appPlayground/config.ts
+++ b/packages/examples/src/appPlayground/config.ts
@@ -28,7 +28,7 @@ import '@codingame/monaco-vscode-typescript-language-features-default-extension'
 import '../../resources/vsix/open-collaboration-tools.vsix';
 
 import { createDefaultLocaleConfiguration } from 'monaco-languageclient/vscodeApiLocales';
-import { defaultHtmlAugmentationInstructions, defaultViewsInit, type HtmlContainerConfig, type MonacoVscodeApiConfig } from 'monaco-languageclient/vscodeApiWrapper';
+import { defaultHtmlAugmentationInstructions, defaultViewsInit, type MonacoVscodeApiConfig } from 'monaco-languageclient/vscodeApiWrapper';
 import { configureDefaultWorkerFactory } from 'monaco-languageclient/workerFactory';
 import helloTsCode from '../../resources/appPlayground/hello.ts?raw';
 import testerTsCode from '../../resources/appPlayground/tester.ts?raw';
@@ -41,7 +41,7 @@ export type ConfigResult = {
     testerTsUri: vscode.Uri;
 };
 
-export const configure = async (htmlContainer: HtmlContainerConfig): Promise<ConfigResult> => {
+export const configure = async (htmlContainer?: HTMLElement): Promise<ConfigResult> => {
     const workspaceFileUri = vscode.Uri.file('/workspace.code-workspace');
 
     const vscodeApiConfig: MonacoVscodeApiConfig = {

--- a/packages/examples/src/appPlayground/reactMain.tsx
+++ b/packages/examples/src/appPlayground/reactMain.tsx
@@ -11,7 +11,7 @@ import { configurePostStart } from './common.js';
 
 export const runApplicationPlaygroundReact = async () => {
 
-    const configResult = await configure('ReactPlaceholder');
+    const configResult = await configure();
     const root = ReactDOM.createRoot(document.getElementById('react-root')!);
     const App = () => {
         return (

--- a/packages/examples/src/browser/main.ts
+++ b/packages/examples/src/browser/main.ts
@@ -28,11 +28,12 @@ export const runBrowserEditor = async () => {
 }`;
     const codeUri = '/workspace/model.json';
 
+    const htmlContainer = document.getElementById('monaco-editor-root')!;
     const vscodeApiConfig: MonacoVscodeApiConfig = {
         $type: 'extended',
         viewsConfig: {
             $type: 'EditorService',
-            htmlContainer: document.getElementById('monaco-editor-root')!
+            htmlContainer
         },
         logLevel: LogLevel.Debug,
         serviceOverrides: {
@@ -159,7 +160,7 @@ export const runBrowserEditor = async () => {
         diagnosticCollection.clear();
     };
 
-    await editorApp.start(apiWrapper.getHtmlContainer());
+    await editorApp.start(htmlContainer);
 
     editorApp.getTextModels().modified?.onDidChangeContent(() => {
         validate();

--- a/packages/examples/src/common/client/extendedClient.ts
+++ b/packages/examples/src/common/client/extendedClient.ts
@@ -96,7 +96,7 @@ export const runExtendedClient = async (lsConfig: ExampleLsConfig, helloCode: st
 
     try {
         document.querySelector('#button-start')?.addEventListener('click', async () => {
-            await editorApp.start(apiWrapper.getHtmlContainer());
+            await editorApp.start(htmlContainer);
             await lcWrapper.start();
 
             // open files, so the LS can pick it up

--- a/packages/examples/src/debugger/common/definitions.ts
+++ b/packages/examples/src/debugger/common/definitions.ts
@@ -4,7 +4,6 @@
  * ------------------------------------------------------------------------------------------ */
 
 import { RegisteredMemoryFile } from '@codingame/monaco-vscode-files-service-override';
-import type { HtmlContainerConfig } from 'monaco-languageclient/vscodeApiWrapper';
 import { Uri } from 'vscode';
 
 export type FileDefinition = {
@@ -27,7 +26,7 @@ export type ConfigParams = {
     homeDir: string;
     workspaceRoot: string;
     workspaceFile: Uri;
-    htmlContainer: HtmlContainerConfig;
+    htmlContainer: HTMLElement;
     protocol: 'ws' | 'wss';
     hostname: string;
     port: number;

--- a/packages/examples/src/json/client/classic.ts
+++ b/packages/examples/src/json/client/classic.ts
@@ -53,7 +53,7 @@ export const runClient = async () => {
         }
     };
     const editorApp = new EditorApp(editorAppConfig);
-    await editorApp.start(apiWrapper.getHtmlContainer());
+    await editorApp.start(htmlContainer);
 
     const languageClientConfig: LanguageClientConfig = {
         languageId,

--- a/packages/examples/src/langium/statemachine/config/statemachineConfig.ts
+++ b/packages/examples/src/langium/statemachine/config/statemachineConfig.ts
@@ -9,7 +9,7 @@ import getLocalizationServiceOverride from '@codingame/monaco-vscode-localizatio
 import { LogLevel } from '@codingame/monaco-vscode-api';
 import { MessageTransports } from 'vscode-languageclient';
 import { createDefaultLocaleConfiguration } from 'monaco-languageclient/vscodeApiLocales';
-import type { HtmlContainerConfig, MonacoVscodeApiConfig } from 'monaco-languageclient/vscodeApiWrapper';
+import type { MonacoVscodeApiConfig } from 'monaco-languageclient/vscodeApiWrapper';
 import type { LanguageClientConfig } from 'monaco-languageclient/lcwrapper';
 import { configureDefaultWorkerFactory } from 'monaco-languageclient/workerFactory';
 import type { CodeContent, EditorAppConfig } from 'monaco-languageclient/editorApp';
@@ -25,7 +25,7 @@ export const createLangiumGlobalConfig = (params: {
     worker: Worker,
     messagePort?: MessagePort,
     messageTransports?: MessageTransports,
-    htmlContainer: HtmlContainerConfig
+    htmlContainer?: HTMLElement
 }): ExampleAppConfig => {
     const extensionFilesOrContents = new Map<string, string | URL>();
     extensionFilesOrContents.set(`/${params.languageServerId}-statemachine-configuration.json`, statemachineLanguageConfig);

--- a/packages/examples/src/langium/statemachine/main-react.tsx
+++ b/packages/examples/src/langium/statemachine/main-react.tsx
@@ -27,8 +27,7 @@ export const runStatemachineReact = async (noControls: boolean) => {
             uri: '/workspace/example.statemachine'
         },
         worker,
-        messageTransports: { reader, writer },
-        htmlContainer: 'ReactPlaceholder'
+        messageTransports: { reader, writer }
     });
     const root = ReactDOM.createRoot(document.getElementById('react-root')!);
     const App = () => {

--- a/packages/examples/src/langium/statemachine/main.ts
+++ b/packages/examples/src/langium/statemachine/main.ts
@@ -46,6 +46,7 @@ const startEditor = async () => {
         console.log('Received message from worker:', message);
     });
 
+    const htmlContainer = document.getElementById('monaco-editor-root')!;
     // the configuration does not contain any text content
     const appConfig = createLangiumGlobalConfig({
         languageServerId: 'first',
@@ -56,7 +57,7 @@ const startEditor = async () => {
         worker: stateMachineWorkerPort,
         messagePort: channel.port1,
         messageTransports: { reader, writer },
-        htmlContainer: document.getElementById('monaco-editor-root')!
+        htmlContainer
     });
     editorApp = new EditorApp(appConfig.editorAppConfig);
 
@@ -69,7 +70,7 @@ const startEditor = async () => {
     await lcWrapper.start();
 
     // run editorApp
-    await editorApp.start(apiWrapper.getHtmlContainer());
+    await editorApp.start(htmlContainer);
 
     editorApp.updateCodeResources({
         modified: {

--- a/packages/examples/src/multi/twoLanguageClients.ts
+++ b/packages/examples/src/multi/twoLanguageClients.ts
@@ -33,11 +33,12 @@ print("Hello Moon!")
     let currentText = textJson;
     let currenFileExt = 'json';
 
+    const htmlContainer = document.getElementById('monaco-editor-root')!;
     const vscodeApiConfig: MonacoVscodeApiConfig = {
         $type: 'extended',
         viewsConfig: {
             $type: 'EditorService',
-            htmlContainer: document.getElementById('monaco-editor-root')!
+            htmlContainer
         },
         logLevel: LogLevel.Debug,
         serviceOverrides: {
@@ -82,7 +83,7 @@ print("Hello Moon!")
             disableElement('button-start', true);
             disableElement('button-flip', false);
 
-            await editorApp.start(apiWrapper.getHtmlContainer());
+            await editorApp.start(htmlContainer);
             if (editorAppConfig.codeResources?.modified !== undefined) {
                 editorAppConfig.codeResources.modified.text = currentText;
                 editorAppConfig.codeResources.modified.uri = `/workspace/example.${currenFileExt}`;

--- a/packages/examples/src/python/client/config.ts
+++ b/packages/examples/src/python/client/config.ts
@@ -25,7 +25,7 @@ import { createUrl } from 'monaco-languageclient/common';
 import type { EditorAppConfig } from 'monaco-languageclient/editorApp';
 import type { LanguageClientConfig } from 'monaco-languageclient/lcwrapper';
 import { createDefaultLocaleConfiguration } from 'monaco-languageclient/vscodeApiLocales';
-import { defaultHtmlAugmentationInstructions, defaultViewsInit, type HtmlContainerConfig, type MonacoVscodeApiConfig } from 'monaco-languageclient/vscodeApiWrapper';
+import { defaultHtmlAugmentationInstructions, defaultViewsInit, type MonacoVscodeApiConfig } from 'monaco-languageclient/vscodeApiWrapper';
 import { configureDefaultWorkerFactory } from 'monaco-languageclient/workerFactory';
 import * as vscode from 'vscode';
 import type { BaseLanguageClient } from 'vscode-languageclient/browser.js';
@@ -37,7 +37,7 @@ import { createDefaultWorkspaceContent } from '../../common/client/utils.js';
 import { provideDebuggerExtensionConfig } from '../../debugger/client/debugger.js';
 import { createDebugLaunchConfigFile, type ConfigParams, type FileDefinition } from '../../debugger/common/definitions.js';
 
-export const createDefaultConfigParams = (homeDir: string, htmlContainer: HtmlContainerConfig): ConfigParams => {
+export const createDefaultConfigParams = (homeDir: string, htmlContainer: HTMLElement): ConfigParams => {
     const files = new Map<string, FileDefinition>();
     const workspaceRoot = `${homeDir}/workspace`;
     const configParams: ConfigParams = {

--- a/packages/wrapper-react/README.md
+++ b/packages/wrapper-react/README.md
@@ -42,9 +42,7 @@ export const createEditorAndLanguageClient = async () => {
     const vscodeApiConfig: MonacoVscodeApiConfig = {
         $type: 'extended',
         viewsConfig: {
-            $type: 'EditorService',
-            // the div to which monaco-editor is added
-            htmlContainer: document.getElementById('monaco-editor-root')!
+            $type: 'EditorService'
         },
         userConfiguration: {
             json: JSON.stringify({

--- a/packages/wrapper-react/test/index.test.tsx
+++ b/packages/wrapper-react/test/index.test.tsx
@@ -20,8 +20,7 @@ describe('Test MonacoEditorReactComp', () => {
     const vscodeApiConfig: MonacoVscodeApiConfig = {
         $type: 'extended',
         viewsConfig: {
-            $type: 'EditorService',
-            htmlContainer: 'ReactPlaceholder'
+            $type: 'EditorService'
         },
         logLevel: LogLevel.Debug
     };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,6 +40,7 @@ export const vitestConfig = {
             // '**/client/test/common/utils.test.ts',
             // '**/client/test/fs/endpoints/emptyEndpoint.test.ts',
             // '**/client/test/vscode/manager.test.ts',
+            // '**/client/test/vscode/manager.wrongHtmlContainer.test.ts',
             // '**/client/test/wrapper/lcmanager.test.ts',
             // '**/client/test/wrapper/lcwrapper.test.ts',
             // '**/client/test/worker/workerFactory.test.ts',


### PR DESCRIPTION
I just wanted to improve the v9 to v10 migration guide.
Then I noticed that making `htmlContainer` mandatory is too limiting. It is no optional and only required with `ViewsService` and `WorkbenchService`. New units test are available to check the behaviour.