### PR TITLE
fix example in client README

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -65,7 +65,7 @@ async function createEditorAndLanguageClient() {
 
     // Language client configuration
     const languageClientConfig: LanguageClientConfig = {
-        languageId,
+        languageId: languageId,
         connection: {
             options: {
                 $type: 'WebSocketUrl',


### PR DESCRIPTION
Hey there,

I updated to monaco-languageclient and noticed this error in the example.

Otherwise the migration went smooth, thanks a lot!