### PR TITLE
Update depencdencies: vite 8.1.2 works again properly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "shx": "~0.4.0",
         "tsx": "~4.22.4",
         "typescript": "~6.0.3",
-        "vite": "8.1.0",
+        "vite": "~8.1.2",
         "vitest": "~4.1.9"
       },
       "engines": {
@@ -7810,16 +7810,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
-      "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.2.tgz",
+      "integrity": "sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.15",
-        "rolldown": "~1.1.2",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
         "tinyglobby": "^0.2.17"
       },
       "bin": {
@@ -8115,12 +8115,12 @@
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.18.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.1.tgz",
-      "integrity": "sha512-RTiiVHdpxpYcJVI5sq6S5TLjQ4WDR/rBrIWru+kPXe6sGQ9PFQ3GamrTKLvPqbR4ylr1SoodhmcqbFII0WXVuw==",
+      "version": "3.18.2",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.18.2.tgz",
+      "integrity": "sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==",
       "license": "MIT",
       "dependencies": {
-        "vscode-jsonrpc": "9.0.0",
+        "vscode-jsonrpc": "9.0.1",
         "vscode-languageserver-types": "3.18.0"
       }
     },
@@ -8295,7 +8295,7 @@
         "@codingame/monaco-vscode-workbench-service-override": "^34.1.3",
         "vscode": "npm:@codingame/monaco-vscode-extension-api@^34.1.3",
         "vscode-languageclient": "~10.0.1",
-        "vscode-languageserver-protocol": "~3.18.1",
+        "vscode-languageserver-protocol": "~3.18.2",
         "vscode-ws-jsonrpc": "~4.0.0-next.0"
       },
       "devDependencies": {
@@ -8363,7 +8363,7 @@
         "vscode-json-languageservice": "~5.7.2",
         "vscode-languageclient": "~10.0.1",
         "vscode-languageserver": "~10.0.1",
-        "vscode-languageserver-protocol": "~3.18.1",
+        "vscode-languageserver-protocol": "~3.18.2",
         "vscode-languageserver-textdocument": "~1.0.12",
         "vscode-uri": "~3.1.0",
         "vscode-ws-jsonrpc": "~4.0.0-next.0",

--- a/package.json
+++ b/package.json
@@ -71,14 +71,15 @@
     "shx": "~0.4.0",
     "tsx": "~4.22.4",
     "typescript": "~6.0.3",
-    "vite": "8.1.0",
+    "vite": "~8.1.2",
     "vitest": "~4.1.9"
   },
   "overrides": {
     "dompurify": "~3.4.11",
     "esbuild": "~0.28.1",
     "minimatch": "~10.2.5",
-    "vscode-jsonrpc": "~9.0.1"
+    "vscode-jsonrpc": "~9.0.1",
+    "vscode-languageserver-protocol": "~3.18.2"
   },
   "engines": {
     "node": ">=22",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -112,7 +112,7 @@
     "@codingame/monaco-vscode-workbench-service-override": "^34.1.3",
     "vscode": "npm:@codingame/monaco-vscode-extension-api@^34.1.3",
     "vscode-languageclient": "~10.0.1",
-    "vscode-languageserver-protocol": "~3.18.1",
+    "vscode-languageserver-protocol": "~3.18.2",
     "vscode-ws-jsonrpc": "~4.0.0-next.0"
   },
   "devDependencies": {

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -128,7 +128,7 @@
     "vscode-json-languageservice": "~5.7.2",
     "vscode-languageclient": "~10.0.1",
     "vscode-languageserver": "~10.0.1",
-    "vscode-languageserver-protocol": "~3.18.1",
+    "vscode-languageserver-protocol": "~3.18.2",
     "vscode-languageserver-textdocument": "~1.0.12",
     "vscode-uri": "~3.1.0",
     "vscode-ws-jsonrpc": "~4.0.0-next.0",

--- a/verify/angular/package.json
+++ b/verify/angular/package.json
@@ -36,7 +36,7 @@
     "@types/node": "~24.10.15",
     "shx": "~0.4.0",
     "typescript": "~6.0.3",
-    "vite": "8.1.0"
+    "vite": "~8.1.2"
   },
   "overrides": {
     "@babel/core": "~7.29.7",
@@ -44,7 +44,7 @@
     "esbuild": "~0.28.1",
     "monaco-languageclient": "../../packages/client",
     "path-to-regexp": "~8.4.2",
-    "vite": "8.1.0",
+    "vite": "~8.1.2",
     "vscode-ws-jsonrpc": "../../packages/vscode-ws-jsonrpc"
   },
   "allowScripts": {

--- a/verify/next/package.json
+++ b/verify/next/package.json
@@ -42,7 +42,7 @@
     "@types/react-dom": "~19.2.3",
     "@typescript/native-preview": "beta",
     "shx": "~0.4.0",
-    "vite": "8.1.0"
+    "vite": "~8.1.2"
   },
   "overrides": {
     "@typefox/monaco-editor-react": "../../packages/wrapper-react",

--- a/verify/webpack/package.json
+++ b/verify/webpack/package.json
@@ -25,7 +25,7 @@
     "source-map-loader": "~5.0.0",
     "style-loader": "~4.0.0",
     "ts-loader": "~9.6.1",
-    "vite": "8.1.0",
+    "vite": "~8.1.2",
     "webpack-cli": "~7.1.0"
   },
   "overrides": {


### PR DESCRIPTION
Plus, enforce newest version of vscode-languageserver-protocol as otherwise it is inconsistent